### PR TITLE
Don't flag drum tracks that have no star power sections

### DIFF
--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -302,6 +302,7 @@ function findChartIssues(
 		// noStarPower
 		{
 			if (
+				track.instrument !== 'drums' &&
 				track.starPowerSections.length === 0 &&
 				track.noteEventGroups.length > 50 &&
 				_.last(track.noteEventGroups)![0].msTime - _.first(track.noteEventGroups)![0].msTime > 60000


### PR DESCRIPTION
Per the conversation on discord. Star power doesn't really make sense for drums. You have to play the song incorrectly to be able to trigger it (which is news to me). It also is a major disagreement the drum charting servers have with Chorus. 

Hatt and a few others agree with the change, nobody voiced an opinion against the change. Most negative opinion was whether it mattered.



Note, I haven't tested this yet, but it should probably be tested by scanning issues on my local songs folder before and after the change to ensure it catches the right things.

Since you know this code really well though, if you think this is straight forward, fine to merge.

The goal is to still flag incorrect star power sections if the charter chooses to use star power.