### PR TITLE
Fix section name regex for midi charts

### DIFF
--- a/.changeset/popular-needles-warn.md
+++ b/.changeset/popular-needles-warn.md
@@ -1,0 +1,5 @@
+---
+"scan-chart": patch
+---
+
+Fix section names for .mid charts to not include trailing closing bracket

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -143,10 +143,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		sections: _.chain(tracks)
 			.find(t => t.trackName === 'EVENTS')
 			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?(?:section|prc)[ _](.*)\]?$/.test(e.text))
+			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.test(e.text))
 			.map(e => ({
 				tick: e.deltaTime,
-				name: e.text.match(/^\[?(?:section|prc)[ _](.*)\]?$/)![1],
+				name: e.text.match(/^\[?(?:section|prc)[ _]([^\]]*)\]?$/)![1],
 			}))
 			.value(),
 		endEvents: _.chain(tracks)


### PR DESCRIPTION
The previous regex would return section names like `chorus_1]` (with the trailing bracket).

The issue is with the regex pattern. The problem is that the regex is using `(.*)` (greedy) instead of `(.*?)` (non-greedy), and it's not properly handling the case where there's a closing bracket.

**Current regex:** `/^\[?(?:section|prc)[ _](.*)\]?$/`

**Problem:** When matching `[section chorus_1]`, the `(.*)` greedily captures everything up to the end of the string, including the `]`, because the final `\]?` is optional and doesn't force the capture group to stop before it.

**What's happening:**
- Input: `[section chorus_1]`
- The `(.*)` captures: `chorus_1]` (including the closing bracket)
- The final `\]?` matches nothing because the `]` was already consumed by the greedy `(.*)`

**The fix would be to use non-greedy matching:**
```regex
/^\[?(?:section|prc)[ _](.*?)\]?$/
```

**Or better yet, to be more explicit about what should not be captured, the closing bracket:**
```regex
/^\[?(?:section|prc)[ _]([^\]]*)\]?$/
```

This would capture only characters that are not `]`, ensuring the closing bracket is never included in the capture group.

**Example:**
- Input: `[section chorus_1]`
- With `(.*?)`: Captures `chorus_1]` (still wrong)
- With `([^\]]*)`: Captures `chorus_1` (correct)


# Validated in my app: 

Before:
<img width="702" height="622" alt="CleanShot 2025-10-03 at 16 19 01@2x" src="https://github.com/user-attachments/assets/b702f0df-6cd3-45df-b076-bc79d5e941c0" />

After: 
<img width="760" height="438" alt="CleanShot 2025-10-03 at 16 19 25@2x" src="https://github.com/user-attachments/assets/06e77410-9c19-4d52-8c06-f289fb5b3904" />
