### PR TITLE
Add per-track textEvents, versusPhrases, and animations to RawChartData

### DIFF
--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -1,0 +1,725 @@
+/**
+ * Tests for per-track data fields: textEvents, versusPhrases, animations.
+ * Covers both MIDI and .chart format parsing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { writeMidi, MidiData } from 'midi-file'
+import { parseNotesFromMidi } from '../chart/midi-parser'
+import { parseNotesFromChart } from '../chart/chart-parser'
+import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMidi(ticksPerBeat: number, tracks: MidiData['tracks']): Uint8Array {
+	const data: MidiData = {
+		header: { format: 1, numTracks: tracks.length, ticksPerBeat },
+		tracks,
+	}
+	return new Uint8Array(writeMidi(data))
+}
+
+function tempoTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: '' },
+		{ deltaTime: 0, type: 'setTempo', microsecondsPerBeat: 500000 },
+		{ deltaTime: 0, type: 'timeSignature', numerator: 4, denominator: 4, metronome: 24, thirtyseconds: 8 },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+function eventsTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+type TimedEvent = { absTick: number; event: MidiData['tracks'][number][number] }
+
+/**
+ * Build an instrument track with notes and optional text events, versus phrases, and animations.
+ */
+function instrumentTrack(name: string, opts: {
+	notes?: { tick: number; noteNumber: number; length: number; velocity?: number }[]
+	textEvents?: { tick: number; text: string }[]
+}): MidiData['tracks'][number] {
+	const track: MidiData['tracks'][number] = [
+		{ deltaTime: 0, type: 'trackName', text: name },
+	]
+
+	const timedEvents: TimedEvent[] = []
+
+	for (const n of opts.notes ?? []) {
+		timedEvents.push({
+			absTick: n.tick,
+			event: { deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: n.noteNumber, velocity: n.velocity ?? 100 },
+		})
+		timedEvents.push({
+			absTick: n.tick + n.length,
+			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: n.noteNumber, velocity: 0 },
+		})
+	}
+
+	for (const t of opts.textEvents ?? []) {
+		timedEvents.push({
+			absTick: t.tick,
+			event: { deltaTime: 0, type: 'text', text: t.text },
+		})
+	}
+
+	timedEvents.sort((a, b) => a.absTick - b.absTick)
+	let prevTick = 0
+	for (const te of timedEvents) {
+		te.event.deltaTime = te.absTick - prevTick
+		prevTick = te.absTick
+		track.push(te.event)
+	}
+
+	track.push({ deltaTime: 0, type: 'endOfTrack' })
+	return track
+}
+
+function buildChart(sections: Record<string, string[]>): Uint8Array {
+	const lines: string[] = []
+	for (const [name, content] of Object.entries(sections)) {
+		lines.push(`[${name}]`)
+		lines.push('{')
+		for (const line of content) {
+			lines.push(`  ${line}`)
+		}
+		lines.push('}')
+	}
+	return new TextEncoder().encode(lines.join('\r\n'))
+}
+
+/** Helper to get trackData for a specific instrument+difficulty. */
+function getTrack(result: { trackData: { instrument: string; difficulty: string }[] }, instrument: string, difficulty = 'expert') {
+	return result.trackData.find(t => t.instrument === instrument && t.difficulty === difficulty)
+}
+
+// ---------------------------------------------------------------------------
+// MIDI: Text Events
+// ---------------------------------------------------------------------------
+
+describe('MIDI: per-track text events', () => {
+	it('captures general text events on instrument tracks', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }], // expert green
+				textEvents: [
+					{ tick: 0, text: '[idle]' },
+					{ tick: 480, text: '[play]' },
+					{ tick: 960, text: 'map HandMap_Default' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track).toBeDefined()
+		expect(track.textEvents).toEqual([
+			{ tick: 0, text: '[idle]' },
+			{ tick: 480, text: '[play]' },
+			{ tick: 960, text: 'map HandMap_Default' },
+		])
+	})
+
+	it('excludes ENHANCED_OPENS and ENABLE_CHART_DYNAMICS from textEvents', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [
+					{ tick: 0, text: 'ENHANCED_OPENS' },
+					{ tick: 0, text: '[ENHANCED_OPENS]' },
+					{ tick: 0, text: 'ENABLE_CHART_DYNAMICS' },
+					{ tick: 0, text: '[ENABLE_CHART_DYNAMICS]' },
+					{ tick: 480, text: '[play]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 480, text: '[play]' },
+		])
+	})
+
+	it('excludes disco flip mix events from textEvents on drum tracks', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART DRUMS', {
+				notes: [{ tick: 480, noteNumber: 97, length: 120 }], // expert red
+				textEvents: [
+					{ tick: 0, text: '[mix 0 drums0]' },
+					{ tick: 480, text: '[mix 1 drums2d]' },
+					{ tick: 960, text: '[idle]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums')!
+		expect(track.textEvents).toEqual([
+			{ tick: 960, text: '[idle]' },
+		])
+	})
+
+	it('shares text events across all difficulties', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 }, // expert green
+					{ tick: 480, noteNumber: 84, length: 120 }, // hard green
+				],
+				textEvents: [{ tick: 0, text: '[play]' }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const expert = getTrack(result, 'guitar', 'expert')!
+		const hard = getTrack(result, 'guitar', 'hard')!
+		expect(expert.textEvents).toEqual([{ tick: 0, text: '[play]' }])
+		expect(hard.textEvents).toEqual([{ tick: 0, text: '[play]' }])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: Versus Phrases
+// ---------------------------------------------------------------------------
+
+describe('MIDI: versus phrases', () => {
+	it('extracts player 1 and player 2 versus phrases from notes 105/106', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },     // expert green
+					{ tick: 480, noteNumber: 105, length: 960 },    // player 1 versus phrase
+					{ tick: 1920, noteNumber: 106, length: 480 },   // player 2 versus phrase
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.versusPhrases).toEqual([
+			{ tick: 480, length: 960, isPlayer2: false },
+			{ tick: 1920, length: 480, isPlayer2: true },
+		])
+	})
+
+	it('handles overlapping player 1 and player 2 phrases', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },
+					{ tick: 480, noteNumber: 105, length: 960 },
+					{ tick: 480, noteNumber: 106, length: 960 },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.versusPhrases).toHaveLength(2)
+		expect(track.versusPhrases[0]).toEqual({ tick: 480, length: 960, isPlayer2: false })
+		expect(track.versusPhrases[1]).toEqual({ tick: 480, length: 960, isPlayer2: true })
+	})
+
+	it('shares versus phrases across all difficulties', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },  // expert
+					{ tick: 480, noteNumber: 84, length: 120 },  // hard
+					{ tick: 480, noteNumber: 105, length: 960 }, // versus p1
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const expert = getTrack(result, 'guitar', 'expert')!
+		const hard = getTrack(result, 'guitar', 'hard')!
+		expect(expert.versusPhrases).toEqual([{ tick: 480, length: 960, isPlayer2: false }])
+		expect(hard.versusPhrases).toEqual([{ tick: 480, length: 960, isPlayer2: false }])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: Animations
+// ---------------------------------------------------------------------------
+
+describe('MIDI: animation notes', () => {
+	it('extracts guitar left hand positions (notes 40-59)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },  // expert green
+					{ tick: 480, noteNumber: 40, length: 240 },  // left hand position 1
+					{ tick: 960, noteNumber: 52, length: 120 },  // left hand position 13
+					{ tick: 1440, noteNumber: 59, length: 120 }, // left hand position 20
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 240, noteNumber: 40 },
+			{ tick: 960, length: 120, noteNumber: 52 },
+			{ tick: 1440, length: 120, noteNumber: 59 },
+		])
+	})
+
+	it('extracts drum pad animations (notes 24-51)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 97, length: 120 },  // expert red
+					{ tick: 480, noteNumber: 24, length: 120 },  // kick right foot
+					{ tick: 960, noteNumber: 27, length: 120 },  // snare right hand hard
+					{ tick: 1440, noteNumber: 51, length: 120 }, // floor tom right hand
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 120, noteNumber: 24 },
+			{ tick: 960, length: 120, noteNumber: 27 },
+			{ tick: 1440, length: 120, noteNumber: 51 },
+		])
+	})
+
+	it('does not mix guitar animation range with drum animation range', () => {
+		// Guitar tracks should capture 40-59, NOT 24-39
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },
+					{ tick: 480, noteNumber: 30, length: 120 }, // drum range, should be ignored on guitar
+					{ tick: 480, noteNumber: 45, length: 120 }, // guitar range
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 120, noteNumber: 45 },
+		])
+	})
+
+	it('does not capture guitar animation range on drum tracks', () => {
+		// Drum tracks should capture 24-51, notes 52-59 should be ignored
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 97, length: 120 },
+					{ tick: 480, noteNumber: 55, length: 120 }, // guitar range only
+					{ tick: 480, noteNumber: 45, length: 120 }, // within drum range (tom 1 left hand)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 120, noteNumber: 45 },
+		])
+	})
+
+	it('extracts bass left hand positions same as guitar', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART BASS', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },
+					{ tick: 480, noteNumber: 42, length: 240 },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'bass')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 240, noteNumber: 42 },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Text Events
+// ---------------------------------------------------------------------------
+
+describe('.chart: per-track text events', () => {
+	it('captures E events that are not solo/soloend/disco flip', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: [
+				'0 = N 0 0',
+				'0 = E [idle]',
+				'192 = E [play]',
+				'384 = E map HandMap_Default',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 0, text: '[idle]' },
+			{ tick: 192, text: '[play]' },
+			{ tick: 384, text: 'map HandMap_Default' },
+		])
+	})
+
+	it('excludes solo and soloend from textEvents', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: [
+				'0 = N 0 0',
+				'0 = E solo',
+				'192 = E [play]',
+				'384 = E soloend',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 192, text: '[play]' },
+		])
+	})
+
+	it('excludes disco flip mix events from textEvents', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertDrums: [
+				'0 = N 0 0',
+				'0 = E [mix 0 drums0]',
+				'192 = E [mix 1 drums2d]',
+				'384 = E [idle]',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'drums')!
+		expect(track.textEvents).toEqual([
+			{ tick: 384, text: '[idle]' },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Versus Phrases
+// ---------------------------------------------------------------------------
+
+describe('.chart: versus phrases', () => {
+	it('extracts S 0 and S 1 as versus phrases', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: [
+				'0 = N 0 0',
+				'0 = S 0 384',
+				'768 = S 1 192',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.versusPhrases).toEqual([
+			{ tick: 0, length: 384, isPlayer2: false },
+			{ tick: 768, length: 192, isPlayer2: true },
+		])
+	})
+
+	it('does not mix versus phrases with star power (S 2)', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: [
+				'0 = N 0 0',
+				'0 = S 0 384',
+				'0 = S 2 384',
+				'768 = S 1 192',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.versusPhrases).toEqual([
+			{ tick: 0, length: 384, isPlayer2: false },
+			{ tick: 768, length: 192, isPlayer2: true },
+		])
+		expect(track.starPowerSections).toHaveLength(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Animations (always empty)
+// ---------------------------------------------------------------------------
+
+describe('.chart: animations', () => {
+	it('returns empty animations array (.chart has no note-based animations)', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: ['0 = N 0 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.animations).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: additional text event filters
+// ---------------------------------------------------------------------------
+
+describe('MIDI: text event edge cases', () => {
+	it('filters tick-0 text events that duplicate the track name', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [
+					{ tick: 0, text: 'PART GUITAR' },
+					{ tick: 480, text: '[play]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 480, text: '[play]' },
+		])
+	})
+
+	it('keeps track-name text at non-zero tick', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART DRUMS', {
+				notes: [{ tick: 480, noteNumber: 97, length: 120 }],
+				textEvents: [
+					{ tick: 480, text: 'PART DRUMS' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums')!
+		expect(track.textEvents).toEqual([
+			{ tick: 480, text: 'PART DRUMS' },
+		])
+	})
+
+	it('does not filter disco flip on non-drum instrument tracks', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [
+					{ tick: 0, text: '[mix 0 drums0]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 0, text: '[mix 0 drums0]' },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: additional text event filters
+// ---------------------------------------------------------------------------
+
+describe('.chart: text event edge cases', () => {
+	it('excludes ENABLE_CHART_DYNAMICS from textEvents', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertDrums: [
+				'0 = N 0 0',
+				'0 = E ENABLE_CHART_DYNAMICS',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'drums')!
+		expect(track.textEvents).toEqual([])
+	})
+
+	it('excludes [ENABLE_CHART_DYNAMICS] (with brackets) from textEvents', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertDrums: [
+				'0 = N 0 0',
+				'0 = E [ENABLE_CHART_DYNAMICS]',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'drums')!
+		expect(track.textEvents).toEqual([])
+	})
+
+	it('excludes ENHANCED_OPENS and [ENHANCED_OPENS] from textEvents', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertSingle: [
+				'0 = N 0 0',
+				'0 = E ENHANCED_OPENS',
+				'0 = E [ENHANCED_OPENS]',
+				'192 = E [play]',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([
+			{ tick: 192, text: '[play]' },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: noteOn/noteOff edge cases
+// ---------------------------------------------------------------------------
+
+describe('MIDI: note pair extraction edge cases', () => {
+	it('handles velocity-0 noteOn as noteOff for versus phrases', () => {
+		// Build MIDI manually with velocity-0 noteOn to end the phrase
+		const track: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'PART GUITAR' },
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 96, velocity: 100 },    // expert green
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 105, velocity: 100 },   // versus p1 start
+			{ deltaTime: 120, type: 'noteOff', channel: 0, noteNumber: 96, velocity: 0 },
+			{ deltaTime: 360, type: 'noteOn', channel: 0, noteNumber: 105, velocity: 0 },   // versus p1 end (velocity-0 noteOn)
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const gtr = getTrack(result, 'guitar')!
+		expect(gtr.versusPhrases).toEqual([
+			{ tick: 0, length: 480, isPlayer2: false },
+		])
+	})
+
+	it('skips duplicate noteOn for animations', () => {
+		// Two noteOns for the same note without an intervening noteOff — second should be ignored
+		const track: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'PART GUITAR' },
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 96, velocity: 100 },  // expert green
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 40, velocity: 100 },  // anim start
+			{ deltaTime: 240, type: 'noteOn', channel: 0, noteNumber: 40, velocity: 100 }, // duplicate noteOn (ignored)
+			{ deltaTime: 240, type: 'noteOff', channel: 0, noteNumber: 40, velocity: 0 },  // anim end
+			{ deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 96, velocity: 0 },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const gtr = getTrack(result, 'guitar')!
+		// Should produce exactly one animation from tick 0 to tick 480 (length 480)
+		expect(gtr.animations).toEqual([
+			{ tick: 0, length: 480, noteNumber: 40 },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: keys animation range
+// ---------------------------------------------------------------------------
+
+describe('MIDI: keys animations', () => {
+	it('extracts left hand positions (40-59) on keys track', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART KEYS', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 }, // expert green
+					{ tick: 480, noteNumber: 48, length: 240 }, // left hand position 9
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'keys')!
+		expect(track.animations).toEqual([
+			{ tick: 480, length: 240, noteNumber: 48 },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+describe('per-track data edge cases', () => {
+	it('returns empty arrays when no text events, versus phrases, or animations present', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.textEvents).toEqual([])
+		expect(track.versusPhrases).toEqual([])
+		expect(track.animations).toEqual([])
+	})
+})

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -189,17 +189,21 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 			.toPairs()
 			.map(([trackName, lines]) => {
 				const { instrument, difficulty } = trackNameMap[trackName as TrackName]
-				const trackEvents = _.chain(lines)
-					.map(line => /^(\d+) = ([A-Z]+) ([\w\s[\]]+?)( \d+)?$/.exec(line))
-					.compact()
-					.map(([, tickString, typeCode, value, lengthString]) => {
-						const type = getEventType(typeCode, value, instrument, difficulty)
-						return type !== null ? { tick: Number(tickString), type, length: Number(lengthString) || 0 } : null
-					})
+				// Single parsing pass that produces note-shaped events (`{ tick, type, length }`)
+				// plus data-carrying events (text, versus). Note-shaped events flow through
+				// the same distribution loop as before; the data-carrying ones are routed
+				// to their dedicated arrays inside the same loop.
+				const parsedEvents = _.chain(lines)
+					.map(line => parseTrackLine(line, instrument, difficulty))
 					.compact()
 					.orderBy('tick') // Most parsers reject charts that aren't already sorted, but it's easier to just sort it here
-					.thru(events => mergeSoloEvents(events))
 					.value()
+
+				// Merge solo/soloend pairs in place (note-shaped events only)
+				const trackEvents = mergeSoloEvents(
+					parsedEvents.filter((e): e is ParsedNoteEvent => e.kind === 'note'),
+				)
+
 				const result: RawChartData['trackData'][number] = {
 					instrument,
 					difficulty,
@@ -209,6 +213,9 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 					flexLanes: [],
 					drumFreestyleSections: [],
 					trackEvents: [],
+					textEvents: [],
+					versusPhrases: [],
+					animations: [], // .chart format does not have note-based animations
 				}
 
 				for (const event of trackEvents) {
@@ -232,6 +239,14 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 						})
 					} else {
 						result.trackEvents.push(event)
+					}
+				}
+
+				for (const event of parsedEvents) {
+					if (event.kind === 'text') {
+						result.textEvents.push({ tick: event.tick, text: event.text })
+					} else if (event.kind === 'versus') {
+						result.versusPhrases.push({ tick: event.tick, length: event.length, isPlayer2: event.isPlayer2 })
 					}
 				}
 
@@ -291,146 +306,201 @@ function getFileSections(chartText: string) {
 	return sections
 }
 
-function getEventType(typeCode: string, value: string, instrument: Instrument, difficulty: Difficulty): EventType | null {
-	switch (typeCode) {
-		case 'E': {
-			switch (value) {
-				case 'solo':
-					return eventTypes.soloSectionStart
-				case 'soloend':
-					return eventTypes.soloSectionEnd
-				default: {
-					const match = value.match(/^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/)
-					if (match) {
-						const diff = discoFlipDifficultyMap[Number(match[1])]
-						const flag = match[3] as 'd' | 'dnoflip' | 'easy' | 'easynokick' | ''
-						if ((flag === '' || flag === 'd' || flag === 'dnoflip') && difficulty === diff) {
-							return (
-								flag === '' ? eventTypes.discoFlipOff
-								: flag === 'd' ? eventTypes.discoFlipOn
-								: eventTypes.discoNoFlipOn
-							)
-						}
-					}
-					return null
-				}
+/** Regex matching disco flip mix events (any difficulty). Used to filter them
+ * out from textEvents since they're consumed as disco flip modifiers. */
+const chartDiscoFlipRegex = /^\s*\[?mix[ _][0-3][ _]drums[0-5](d|dnoflip|easy|easynokick|)\]?\s*$/
+
+/**
+ * Events parsed from a single .chart track line. Note-shaped events flow into
+ * `trackEvents` and friends via the distribution loop; text and versus events
+ * have extra data and go into their dedicated arrays.
+ */
+type ParsedNoteEvent = { kind: 'note'; tick: number; type: EventType; length: number }
+type ParsedTextEvent = { kind: 'text'; tick: number; text: string }
+type ParsedVersusEvent = { kind: 'versus'; tick: number; length: number; isPlayer2: boolean }
+type ParsedTrackLine = ParsedNoteEvent | ParsedTextEvent | ParsedVersusEvent
+
+/**
+ * Parse a single line of a .chart instrument track section. Produces a typed
+ * event (note / text / versus) or null if the line is unrecognized or consumed
+ * by other parsing logic (ENABLE_CHART_DYNAMICS, ENHANCED_OPENS).
+ *
+ * Lines take one of these forms:
+ *   TICK = E "TEXT"          → text event (or recognized E type: solo, mix...)
+ *   TICK = S VALUE LENGTH    → starPower, flex lane, freestyle, or versus phrase
+ *   TICK = N VALUE LENGTH    → note (with instrument-specific mapping)
+ */
+function parseTrackLine(line: string, instrument: Instrument, difficulty: Difficulty): ParsedTrackLine | null {
+	// E events have quoted arbitrary text, so handle them separately from N/S.
+	const eMatch = /^(\d+) = E "([^"\r\n]*)"$/.exec(line) ?? /^(\d+) = E ([^\r\n]+?)$/.exec(line)
+	if (eMatch) {
+		const tick = Number(eMatch[1])
+		const value = eMatch[2]
+		const recognizedType = getEEventType(value, difficulty)
+		if (recognizedType !== null) return { kind: 'note', tick, type: recognizedType, length: 0 }
+		// Disco flip events for other difficulties: consumed (not stored as text)
+		if (chartDiscoFlipRegex.test(value)) return null
+		// Skip directives consumed by chart processing (not stored as text events)
+		const stripped = value.replace(/^\[/, '').replace(/\]$/, '').trim()
+		if (stripped === 'ENABLE_CHART_DYNAMICS' || stripped === 'ENHANCED_OPENS') return null
+		return { kind: 'text', tick, text: value }
+	}
+	// N/S events have numeric value + optional length
+	const nsMatch = /^(\d+) = ([NS]) (\w+)( \d+)?$/.exec(line)
+	if (nsMatch) {
+		const tick = Number(nsMatch[1])
+		const typeCode = nsMatch[2]
+		const value = nsMatch[3]
+		const length = Number(nsMatch[4]) || 0
+		if (typeCode === 'S') {
+			// S 0 (player 1) / S 1 (player 2) are versus phrases, not note-shaped
+			if (value === '0' || value === '1') {
+				return { kind: 'versus', tick, length, isPlayer2: value === '1' }
 			}
+			const type = getSEventType(value)
+			return type !== null ? { kind: 'note', tick, type, length } : null
 		}
-		case 'S': {
+		// N: instrument-dependent note mapping
+		const type = getNEventType(value, instrument)
+		return type !== null ? { kind: 'note', tick, type, length } : null
+	}
+	return null
+}
+
+function getEEventType(value: string, difficulty: Difficulty): EventType | null {
+	switch (value) {
+		case 'solo':
+			return eventTypes.soloSectionStart
+		case 'soloend':
+			return eventTypes.soloSectionEnd
+	}
+	const match = value.match(/^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/)
+	if (match) {
+		const diff = discoFlipDifficultyMap[Number(match[1])]
+		const flag = match[3] as 'd' | 'dnoflip' | 'easy' | 'easynokick' | ''
+		if ((flag === '' || flag === 'd' || flag === 'dnoflip') && difficulty === diff) {
+			return (
+				flag === '' ? eventTypes.discoFlipOff
+				: flag === 'd' ? eventTypes.discoFlipOn
+				: eventTypes.discoNoFlipOn
+			)
+		}
+	}
+	return null
+}
+
+function getSEventType(value: string): EventType | null {
+	switch (value) {
+		case '2':
+			return eventTypes.starPower
+		case '64':
+			return eventTypes.freestyleSection
+		case '65':
+			return eventTypes.flexLaneSingle
+		case '66':
+			return eventTypes.flexLaneDouble
+		default:
+			return null
+	}
+}
+
+function getNEventType(value: string, instrument: Instrument): EventType | null {
+	switch (instrument) {
+		case 'drums': {
 			switch (value) {
+				case '0':
+					return eventTypes.kick
+				case '1':
+					return eventTypes.redDrum
 				case '2':
-					return eventTypes.starPower
-				case '64':
-					return eventTypes.freestyleSection
-				case '65':
-					return eventTypes.flexLaneSingle
+					return eventTypes.yellowDrum
+				case '3':
+					return eventTypes.blueDrum
+				case '4':
+					return eventTypes.fiveOrangeFourGreenDrum
+				case '5':
+					return eventTypes.fiveGreenDrum
+				case '32':
+					return eventTypes.kick2x
+				case '34':
+					return eventTypes.redAccent
+				case '35':
+					return eventTypes.yellowAccent
+				case '36':
+					return eventTypes.blueAccent
+				case '37':
+					return eventTypes.fiveOrangeFourGreenAccent
+				case '38':
+					return eventTypes.fiveGreenAccent
+				case '40':
+					return eventTypes.redGhost
+				case '41':
+					return eventTypes.yellowGhost
+				case '42':
+					return eventTypes.blueGhost
+				case '43':
+					return eventTypes.fiveOrangeFourGreenGhost
+				case '44':
+					return eventTypes.fiveGreenGhost
 				case '66':
-					return eventTypes.flexLaneDouble
+					return eventTypes.yellowCymbalMarker
+				case '67':
+					return eventTypes.blueCymbalMarker
+				case '68':
+					return eventTypes.greenCymbalMarker
 				default:
 					return null
 			}
 		}
-		case 'N': {
-			switch (instrument) {
-				case 'drums': {
-					switch (value) {
-						case '0':
-							return eventTypes.kick
-						case '1':
-							return eventTypes.redDrum
-						case '2':
-							return eventTypes.yellowDrum
-						case '3':
-							return eventTypes.blueDrum
-						case '4':
-							return eventTypes.fiveOrangeFourGreenDrum
-						case '5':
-							return eventTypes.fiveGreenDrum
-						case '32':
-							return eventTypes.kick2x
-						case '34':
-							return eventTypes.redAccent
-						case '35':
-							return eventTypes.yellowAccent
-						case '36':
-							return eventTypes.blueAccent
-						case '37':
-							return eventTypes.fiveOrangeFourGreenAccent
-						case '38':
-							return eventTypes.fiveGreenAccent
-						case '40':
-							return eventTypes.redGhost
-						case '41':
-							return eventTypes.yellowGhost
-						case '42':
-							return eventTypes.blueGhost
-						case '43':
-							return eventTypes.fiveOrangeFourGreenGhost
-						case '44':
-							return eventTypes.fiveGreenGhost
-						case '66':
-							return eventTypes.yellowCymbalMarker
-						case '67':
-							return eventTypes.blueCymbalMarker
-						case '68':
-							return eventTypes.greenCymbalMarker
-						default:
-							return null
-					}
-				}
-				case 'guitarghl':
-				case 'guitarcoopghl':
-				case 'rhythmghl':
-				case 'bassghl': {
-					switch (value) {
-						case '0':
-							return eventTypes.white1
-						case '1':
-							return eventTypes.white2
-						case '2':
-							return eventTypes.white3
-						case '3':
-							return eventTypes.black1
-						case '4':
-							return eventTypes.black2
-						case '5':
-							return eventTypes.forceUnnatural
-						case '6':
-							return eventTypes.forceTap
-						case '7':
-							return eventTypes.open
-						case '8':
-							return eventTypes.black3
-						default:
-							return null
-					}
-				}
-				default: {
-					switch (value) {
-						case '0':
-							return eventTypes.green
-						case '1':
-							return eventTypes.red
-						case '2':
-							return eventTypes.yellow
-						case '3':
-							return eventTypes.blue
-						case '4':
-							return eventTypes.orange
-						case '5':
-							return eventTypes.forceUnnatural
-						case '6':
-							return eventTypes.forceTap
-						case '7':
-							return eventTypes.open
-						default:
-							return null
-					}
-				}
+		case 'guitarghl':
+		case 'guitarcoopghl':
+		case 'rhythmghl':
+		case 'bassghl': {
+			switch (value) {
+				case '0':
+					return eventTypes.white1
+				case '1':
+					return eventTypes.white2
+				case '2':
+					return eventTypes.white3
+				case '3':
+					return eventTypes.black1
+				case '4':
+					return eventTypes.black2
+				case '5':
+					return eventTypes.forceUnnatural
+				case '6':
+					return eventTypes.forceTap
+				case '7':
+					return eventTypes.open
+				case '8':
+					return eventTypes.black3
+				default:
+					return null
 			}
 		}
-		default:
-			return null
+		default: {
+			switch (value) {
+				case '0':
+					return eventTypes.green
+				case '1':
+					return eventTypes.red
+				case '2':
+					return eventTypes.yellow
+				case '3':
+					return eventTypes.blue
+				case '4':
+					return eventTypes.orange
+				case '5':
+					return eventTypes.forceUnnatural
+				case '6':
+					return eventTypes.forceTap
+				case '7':
+					return eventTypes.open
+				default:
+					return null
+			}
+		}
 	}
 }
 

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -215,8 +215,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 			.map(t => {
 				const instrument = instrumentNameMap[t.trackName as InstrumentTrackName]
 				const instrumentType = getInstrumentType(instrument)
-				const trackDifficulties = _.chain(t.trackEvents)
-					.thru(trackEvents => getTrackEventEnds(trackEvents, instrumentType))
+				// Single scan pass extracts note-shaped events AND the
+				// data-carrying ones (text, versus, animations).
+				const { eventEnds, textEvents, versusPhrases, animations } = scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				const trackDifficulties = _.chain(eventEnds)
 					.thru(eventEnds => distributeInstrumentEvents(eventEnds)) // Removes 'all' difficulty
 					.thru(eventEnds => getTrackEvents(eventEnds)) // Connects note ends together
 					.thru(events => splitMidiModifierSustains(events, instrumentType))
@@ -234,6 +236,9 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 						flexLanes: [],
 						drumFreestyleSections: [],
 						trackEvents: [],
+						textEvents,
+						versusPhrases,
+						animations,
 					}
 
 					for (const event of trackDifficulties[difficulty]) {
@@ -304,16 +309,46 @@ function getTracks(midiData: MidiData) {
 	return tracks
 }
 
-/** Gets the starting and ending notes for all midi events defined for the .mid chart spec. */
-function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) {
+interface TrackScanResult {
+	eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] }
+	textEvents: { tick: number; text: string }[]
+	versusPhrases: { tick: number; length: number; isPlayer2: boolean }[]
+	animations: { tick: number; length: number; noteNumber: number }[]
+}
+
+/**
+ * Scans a MIDI instrument track and produces:
+ *   - note-shaped events grouped by difficulty (further processed by
+ *     `distributeInstrumentEvents` / `getTrackEvents`)
+ *   - data-carrying events that ride alongside the notes: `textEvents`,
+ *     `versusPhrases` (notes 105/106), `animations` (notes 24-51 drums,
+ *     40-59 fret)
+ *
+ * Versus phrases and animations live in the same MIDI event stream as the
+ * playable notes, so they're emitted from this single iteration.
+ */
+function scanInstrumentTrack(
+	events: MidiEvent[],
+	instrumentType: InstrumentType,
+	trackName: string,
+): TrackScanResult {
 	let enhancedOpens = false
-	const trackEventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] } = {
+	const eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] } = {
 		all: [],
 		expert: [],
 		hard: [],
 		medium: [],
 		easy: [],
 	}
+	const textEvents: { tick: number; text: string }[] = []
+	// Versus phrase + animation collectors need note-on/note-off pairing.
+	const versusStarts = new Map<number, number>() // noteNumber → startTick
+	const versusPhrases: { tick: number; length: number; isPlayer2: boolean }[] = []
+	const animStarts = new Map<number, number>() // noteNumber → startTick
+	const animations: { tick: number; length: number; noteNumber: number }[] = []
+	const animationFilter = instrumentType === instrumentTypes.drums
+		? (n: number) => n >= 24 && n <= 51
+		: (n: number) => n >= 40 && n <= 59
 
 	for (const event of events) {
 		// SysEx event (tap modifier or open)
@@ -326,7 +361,7 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 					: null
 
 				if (type !== null) {
-					trackEventEnds[event.data[4] === 0xff ? 'all' : discoFlipDifficultyMap[event.data[4]]].push({
+					eventEnds[event.data[4] === 0xff ? 'all' : discoFlipDifficultyMap[event.data[4]]].push({
 						tick: event.deltaTime,
 						type,
 						channel: 1,
@@ -336,6 +371,43 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 				}
 			}
 		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
+			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+
+			// Collect versus phrase markers (notes 105/106). These don't overlap
+			// with any note-shaped events, so we don't fall through.
+			if (event.noteNumber === 105 || event.noteNumber === 106) {
+				if (!isOff) {
+					if (!versusStarts.has(event.noteNumber)) {
+						versusStarts.set(event.noteNumber, event.deltaTime)
+					}
+				} else {
+					const startTick = versusStarts.get(event.noteNumber)
+					if (startTick !== undefined) {
+						versusPhrases.push({ tick: startTick, length: event.deltaTime - startTick, isPlayer2: event.noteNumber === 106 })
+						versusStarts.delete(event.noteNumber)
+					}
+				}
+				continue
+			}
+
+			// Collect animation events (notes 24-51 drums, 40-59 fret). These
+			// overlap with easy-difficulty playable notes (60-66), so the event
+			// must also fall through to the difficulty-based dispatch below.
+			if (animationFilter(event.noteNumber)) {
+				if (!isOff) {
+					if (!animStarts.has(event.noteNumber)) {
+						animStarts.set(event.noteNumber, event.deltaTime)
+					}
+				} else {
+					const startTick = animStarts.get(event.noteNumber)
+					if (startTick !== undefined) {
+						animations.push({ tick: startTick, length: event.deltaTime - startTick, noteNumber: event.noteNumber })
+						animStarts.delete(event.noteNumber)
+					}
+				}
+				// fall through — animation note ranges overlap easy-difficulty notes
+			}
+
 			const difficulty =
 				event.noteNumber <= 66 ? 'easy'
 				: event.noteNumber <= 78 ? 'medium'
@@ -346,7 +418,7 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 				// Instrument-wide event (solo marker, star power, etc...) (applies to all difficulties)
 				const type = getInstrumentEventType(event.noteNumber)
 				if (type !== null) {
-					trackEventEnds[difficulty].push({
+					eventEnds[difficulty].push({
 						tick: event.deltaTime,
 						type,
 						velocity: event.velocity,
@@ -360,7 +432,7 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(event.noteNumber, difficulty)
 					: get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)) ?? null
 				if (type !== null) {
-					trackEventEnds[difficulty].push({
+					eventEnds[difficulty].push({
 						tick: event.deltaTime,
 						type,
 						velocity: event.velocity,
@@ -370,6 +442,7 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 				}
 			}
 		} else if (event.type === 'text') {
+			let consumedAsNote = false
 			if (instrumentType === instrumentTypes.drums) {
 				const discoFlipMatch = event.text.match(/^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/)
 				if (discoFlipMatch) {
@@ -382,23 +455,34 @@ function getTrackEventEnds(events: MidiEvent[], instrumentType: InstrumentType) 
 						: null
 					if (eventType) {
 						// Treat this like the other events that have a start and end, so it can be processed the same way later
-						trackEventEnds[difficulty].push({ tick: event.deltaTime, type: eventType, velocity: 127, channel: 1, isStart: true })
-						trackEventEnds[difficulty].push({ tick: event.deltaTime, type: eventType, velocity: 127, channel: 1, isStart: false })
+						eventEnds[difficulty].push({ tick: event.deltaTime, type: eventType, velocity: 127, channel: 1, isStart: true })
+						eventEnds[difficulty].push({ tick: event.deltaTime, type: eventType, velocity: 127, channel: 1, isStart: false })
+						consumedAsNote = true
 					}
 				}
 			}
 
 			if (event.text === 'ENHANCED_OPENS' || event.text === '[ENHANCED_OPENS]') {
 				enhancedOpens = true
+				consumedAsNote = true
 			} else if (event.text === 'ENABLE_CHART_DYNAMICS' || event.text === '[ENABLE_CHART_DYNAMICS]') {
 				// Treat this like the other events that have a start and end, so it can be processed the same way later
-				trackEventEnds['all'].push({ tick: event.deltaTime, type: eventTypes.enableChartDynamics, channel: 1, isStart: true, velocity: 127 })
-				trackEventEnds['all'].push({ tick: event.deltaTime, type: eventTypes.enableChartDynamics, channel: 1, isStart: false, velocity: 127 })
+				eventEnds['all'].push({ tick: event.deltaTime, type: eventTypes.enableChartDynamics, channel: 1, isStart: true, velocity: 127 })
+				eventEnds['all'].push({ tick: event.deltaTime, type: eventTypes.enableChartDynamics, channel: 1, isStart: false, velocity: 127 })
+				consumedAsNote = true
+			}
+
+			if (!consumedAsNote) {
+				// Skip tick-0 text events that duplicate the track name
+				if (event.deltaTime === 0 && event.text === trackName) continue
+				textEvents.push({ tick: event.deltaTime, text: event.text })
 			}
 		}
 	}
 
-	return trackEventEnds
+	versusPhrases.sort((a, b) => a.tick - b.tick)
+	animations.sort((a, b) => a.tick - b.tick)
+	return { eventEnds, textEvents, versusPhrases, animations }
 }
 
 /** These apply to the entire instrument, not specific difficulties. */

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -116,6 +116,31 @@ export interface RawChartData {
 			length: number
 			type: EventType
 		}[]
+		/** Per-track text events (FF 01 text on MIDI instrument tracks, E events in .chart).
+		 * Does not include events already consumed by other fields (disco flip, ENHANCED_OPENS, etc.). */
+		textEvents: {
+			tick: number
+			text: string
+		}[]
+		/** Player 1/2 versus phrase markers (MIDI notes 105/106, S 0/1 in .chart). */
+		versusPhrases: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** true = player 2 (note 106 / S 1), false = player 1 (note 105 / S 0) */
+			isPlayer2: boolean
+		}[]
+		/**
+		 * Note-based animation events (guitar left hand positions: MIDI 40-59,
+		 * drum pad animations: MIDI 24-51). Not present in .chart format.
+		 */
+		animations: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** The MIDI note number identifying the animation */
+			noteNumber: number
+		}[]
 	}[]
 }
 

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -86,6 +86,9 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 					.thru(events => sortAndFixInvalidFlexLaneOverlaps(events))
 					.value(),
 				drumFreestyleSections: setEventMsTimes(track.drumFreestyleSections, timedTempos, rawChartData.chartTicksPerBeat),
+				textEvents: setEventMsTimes(track.textEvents, timedTempos, rawChartData.chartTicksPerBeat),
+				versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, rawChartData.chartTicksPerBeat),
+				animations: setEventMsTimes(track.animations, timedTempos, rawChartData.chartTicksPerBeat),
 				noteEventGroups: _.chain(track.trackEvents)
 					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.groupBy(note => note.tick)


### PR DESCRIPTION
## Summary
- Add per-track textEvents, versusPhrases, and animations to RawChartData

## Stack
PR 4/9. Depends on #78. Please merge in order:
1. Lyrics & vocal phrases (#76)
2. Harmonies (#77)
3. Complete vocal parsing (#78)
4. **This PR** — per-track textEvents, versusPhrases, animations
5. globalEvents, gameMode, text-like MIDI events
6. New instruments (Pro Guitar/Bass/Keys, Elite Drums, GHL Keys)
7. Semantic labels, typed animations, HandMap/StrumMap/CharacterState, glissando
8. VENUE track parsing
9. Unrecognized song.ini values