### PR TITLE
Add unrecognizedEvents and text-like MIDI event support

### DIFF
--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest'
 import { writeMidi, MidiData } from 'midi-file'
 import { parseNotesFromMidi } from '../chart/midi-parser'
 import { parseNotesFromChart } from '../chart/chart-parser'
+import { parseChartFile } from '../chart/notes-parser'
 import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
 
 // ---------------------------------------------------------------------------
@@ -721,5 +722,283 @@ describe('per-track data edge cases', () => {
 		expect(track.textEvents).toEqual([])
 		expect(track.versusPhrases).toEqual([])
 		expect(track.animations).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: Global Events
+// ---------------------------------------------------------------------------
+
+describe('MIDI: global events', () => {
+	it('captures crowd and music events from EVENTS track', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[music_start]' },
+			{ deltaTime: 960, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('excludes sections from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_intense]' },
+			{ deltaTime: 480, type: 'text', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: '[crowd_intense]' },
+		])
+	})
+
+	it('excludes end events and coda from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'text', text: '[coda]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_clap]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 960, text: '[crowd_clap]' },
+		])
+	})
+
+	it('includes misplaced lyric/phrase events in unrecognizedEvents (alongside parseIssues)', () => {
+		// Lyrics and phrase markers belong on PART VOCALS, not EVENTS. Game engines
+		// drop them, but we round-trip them out so users can see and fix them.
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: 'lyric Hello' },
+			{ tick: 960, text: 'phrase_start' },
+			{ tick: 1440, text: 'phrase_end' },
+			{ tick: 1920, text: '[music_end]' },
+		])
+	})
+
+	it('reads from lyrics, marker, and cuePoint event types (not just text)', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'lyrics', text: '[music_start]' },
+			{ deltaTime: 480, type: 'marker', text: '[crowd_clap]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 960, text: '[crowd_clap]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('reads sections from lyrics/marker event types', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'lyrics', text: '[section intro]' },
+			{ deltaTime: 480, type: 'marker', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: 'intro' },
+			{ tick: 480, name: 'verse' },
+		])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('reads end events from lyrics event type', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 960, type: 'lyrics', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.endEvents).toEqual([{ tick: 960 }])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('returns empty array when no EVENTS track', () => {
+		const midi = buildMidi(480, [tempoTrack()])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Global Events
+// ---------------------------------------------------------------------------
+
+describe('.chart: global events', () => {
+	it('captures non-section/end/lyric/phrase events from [Events]', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "crowd_normal"',
+				'192 = E "music_start"',
+				'384 = E "section intro"',
+				'768 = E "music_end"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: 'crowd_normal' },
+			{ tick: 192, text: 'music_start' },
+			{ tick: 768, text: 'music_end' },
+		])
+	})
+
+	it('excludes end events, coda, lyrics, and phrase markers', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "end"',
+				'0 = E "coda"',
+				'192 = E "lyric Hello"',
+				'384 = E "phrase_start"',
+				'576 = E "phrase_end"',
+				'768 = E "crowd_clap"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 768, text: 'crowd_clap' },
+		])
+	})
+
+	it('returns empty array when no Events section', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			ExpertSingle: ['0 = N 0 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: parseIssues for stray vocal events on the EVENTS track
+// ---------------------------------------------------------------------------
+
+describe('MIDI: invalid lyric/phrase events on EVENTS track', () => {
+	it('emits invalidLyric for lyric text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: '[lyric world]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidLyric')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[lyric world]', 'lyric Hello'])
+	})
+
+	it('emits invalidPhraseStart for phrase_start text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseStart')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_start]', 'phrase_start'])
+	})
+
+	it('emits invalidPhraseEnd for phrase_end text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseEnd')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_end]', 'phrase_end'])
+	})
+
+	it('emits a mix of invalidLyric/PhraseStart/PhraseEnd when all coexist', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric Hel-]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric lo]' },
+			{ deltaTime: 240, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
+	})
+
+	it('does NOT emit issues for properly-formed EVENTS-track text', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues).toEqual([])
+	})
+
+	it('reads invalid events from lyrics/marker/cuePoint event types too', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'lyrics', text: '[lyric foo]' },
+			{ deltaTime: 480, type: 'marker', text: '[phrase_start]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
 	})
 })

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -98,12 +98,10 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		throw 'Invalid .chart file: resolution not found.'
 	}
 
-	const codaEvents = _.chain(fileSections['Events'])
-		.map(line => /^(\d+) = E "\s*\[?coda\]?\s*"$/.exec(line))
-		.compact()
-		.map(([, stringTick]) => ({ tick: Number(stringTick) }))
-		.value()
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].tick : null
+	// Classify each line of the [Events] section into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents.
+	const eventsScan = scanEventsSection(fileSections['Events'] ?? [])
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: resolution,
@@ -169,21 +167,9 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				}
 			})
 			.value(),
-		sections: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?(?:section|prc)[ _](.*?)\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick, stringName]) => ({
-				tick: Number(stringTick),
-				name: stringName,
-			}))
-			.value(),
-		endEvents: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?end\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick]) => ({
-				tick: Number(stringTick),
-			}))
-			.value(),
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [],
 		trackData: _.chain(fileSections)
 			.pick(_.keys(trackNameMap))
@@ -529,5 +515,55 @@ function mergeSoloEvents(events: { tick: number; type: EventType; length: number
 	_.remove(events, event => event.type === eventTypes.soloSectionStart || event.type === eventTypes.soloSectionEnd)
 
 	return events
+}
+
+interface ChartEventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining E-events not recognized as sections/end/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocal
+	 *  parsing path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+}
+
+/**
+ * Parse each line of the .chart [Events] section once via the generic
+ * `TICK = E "TEXT"` regex, then classify the text into one of
+ * {section, end, coda, lyric, phrase, unrecognized}.
+ */
+function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
+	const result: ChartEventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+	}
+	for (const line of eventLines) {
+		const match = /^(\d+) = E "([^\r\n]*?)"$/.exec(line)
+		if (!match) continue
+		const tick = Number(match[1])
+		const text = match[2]
+
+		const sectionMatch = /^\[?(?:section|prc)[ _](.*?)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers are extracted by the vocal parsing path — skip here
+		if (/^\s*lyric[ \t]/.test(text)) continue
+		if (/^(?:phrase_start|phrase_end)$/.test(text)) continue
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -192,6 +192,9 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	brokenNote: 'This note is so close to the previous note that this was likely a charting mistake.',
 	badSustainGap: 'This note is not far enough ahead of the previous sustain.',
 	babySustain: 'The sustain on this note is too short.',
+	invalidLyric: 'This lyric is on the EVENTS track instead of PART VOCALS and will not be displayed.',
+	invalidPhraseStart: 'This phrase_start is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
+	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 } as const
 
 function findChartIssues(

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -145,11 +145,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		}
 	}
 
-	const codaEvents =
-		tracks
-			.find(t => t.trackName === 'EVENTS')
-			?.trackEvents.filter(e => e.type === 'text' && (e.text.trim() === 'coda' || e.text.trim() === '[coda]')) ?? []
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].deltaTime : null
+	// Classify each text-like event on the EVENTS track into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents (the remainder).
+	const eventsScan = scanEventsTrack(tracks)
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: midiFile.header.ticksPerBeat,
@@ -193,24 +192,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				}
 			})
 			.value(),
-		sections: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-				name: e.text.match(/^\[?(?:section|prc)[ _]([^\]]*)\]?$/)![1],
-			}))
-			.value(),
-		endEvents: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?end\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-			}))
-			.value(),
-		parseIssues: [],
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
+		parseIssues: eventsScan.parseIssues,
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -839,5 +824,84 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	)
 
 	return events
+}
+
+/**
+ * YARG/MoonSong reads text-like events from multiple MIDI meta event types:
+ * text (FF 01), lyrics (FF 05), marker (FF 06), cuePoint (FF 07).
+ * trackName (FF 03) and instrumentName (FF 04) are excluded.
+ */
+function isTextLikeEvent(event: MidiEvent): event is MidiTextEvent {
+	return event.type === 'text' || event.type === 'lyrics' || event.type === 'marker' || event.type === 'cuePoint'
+}
+
+interface EventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining text-like events not recognized as sections/endEvents/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocals path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+	/** Issues raised while classifying EVENTS track text events (e.g. stray lyric/phrase
+	 *  events that belong on PART VOCALS, not EVENTS). */
+	parseIssues: RawChartData['parseIssues']
+}
+
+/**
+ * Single-pass scan of the EVENTS track that classifies each text-like event
+ * into one of {section, endEvent, coda, lyric, phrase, unrecognized}. Lyrics
+ * and phrase_start/phrase_end are consumed by the vocal parsing path — we
+ * don't re-emit them here. Everything else that matches a recognized pattern
+ * goes into its typed array; all remaining text-like events fall through to
+ * `unrecognizedEvents`.
+ *
+ * Reads from all text-like event types (text, lyrics, marker, cuePoint),
+ * matching YARG.Core's MoonText behavior.
+ */
+function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[]): EventsScanResult {
+	const result: EventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+		parseIssues: [],
+	}
+	const eventsTrack = tracks.find(t => t.trackName === 'EVENTS')
+	if (!eventsTrack) return result
+
+	for (const event of eventsTrack.trackEvents) {
+		if (!isTextLikeEvent(event)) continue
+		const text = event.text
+		const tick = event.deltaTime
+
+		const sectionMatch = /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
+		// the EVENTS track. Game engines silently drop them when they show up
+		// here. Record a parse issue so consumers can surface the misplacement,
+		// then fall through to unrecognizedEvents so the value round-trips back
+		// out — users can move it to PART VOCALS manually.
+		if (/^\[?\s*lyric[ \t]/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
+		} else if (/^\[?phrase_start\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
+		} else if (/^\[?phrase_end\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
+		}
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -74,6 +74,16 @@ export interface RawChartData {
 		tick: number
 	}[]
 	/**
+	 * Remaining text-like events from the EVENTS track that weren't recognized
+	 * and routed to a typed field (sections, endEvents, vocalTracks). These
+	 * include crowd events, music_start/end, drums mix events, coda markers,
+	 * and any custom/unknown text events.
+	 */
+	unrecognizedEvents: {
+		tick: number
+		text: string
+	}[]
+	/**
 	 * Issues detected at parse time (before `findChartIssues` runs). `chart-scanner`
 	 * concatenates these into the final `chartIssues` array, attaching the standard
 	 * description from `chartIssueDescriptions`. Use this for issues that the parser

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -64,6 +64,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		parseIssues: rawChartData.parseIssues,
 		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -261,6 +261,9 @@ export type ChartIssueType =
 	| 'brokenNote' // This note is so close to the previous note that this was likely a charting mistake
 	| 'badSustainGap' // This note is not far enough ahead of the previous sustain
 	| 'babySustain' // The sustain on this note is too short
+	| 'invalidLyric' // A lyric event was found on the EVENTS track in a .mid chart and will not be displayed
+	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
+	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"


### PR DESCRIPTION
Depends on #89 (parseIssues scaffolding).

- `unrecognizedEvents` on `RawChartData`: text events from EVENTS track not already
  extracted into sections/endEvents/vocalTracks/coda (crowd events, music_start/end,
  practice mode, time signatures as text, etc.)
- Read MIDI sections, end events, coda, and unrecognized events from all
  text-like event types (text, lyrics, marker, cuePoint), matching YARG.Core's
  MoonText behavior
- Coda events are surfaced both in `codaEvents` AND `unrecognizedEvents` for
  consumer visibility (mirrors YARG/MoonSong behavior where coda appears in
  globalEvents)
- New parse issues for stray vocal events on the EVENTS track. Game engines
  silently drop these; we record them so consumers can surface the misplacement:
  - `invalidLyric` — lyric text on EVENTS instead of PART VOCALS
  - `invalidPhraseStart` — phrase_start on EVENTS (vocal phrases use MIDI 105/106 on PART VOCALS)
  - `invalidPhraseEnd` — phrase_end on EVENTS

Validated: 0 hash regressions across 78,046 charts.