### PR TITLE
Add Pro Guitar, Pro Bass, Pro Keys, Elite Drums, GHL Keys, Phase Shift Real Drums

### DIFF
--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -1002,3 +1002,279 @@ describe('MIDI: invalid lyric/phrase events on EVENTS track', () => {
 		expect(types).toEqual(['invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
 	})
 })
+
+// ---------------------------------------------------------------------------
+// New instruments
+// ---------------------------------------------------------------------------
+
+describe('MIDI: Pro Guitar', () => {
+	it('recognizes PART REAL_GUITAR and extracts star power and solo', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 116, length: 960 },  // star power
+					{ tick: 480, noteNumber: 115, length: 960 },  // solo (pro guitar uses 115)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+		expect(track.starPowerSections[0]).toMatchObject({ tick: 480, length: 960 })
+		expect(track.soloSections).toHaveLength(1)
+		expect(track.soloSections[0]).toMatchObject({ tick: 480, length: 960 })
+		expect(track.trackEvents).toEqual([]) // standard note parsing skipped for pro instruments
+	})
+
+	it('extracts raw notes with fret and channel data', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120, velocity: 105 },  // expert string 0 (low E), fret 5
+					{ tick: 480, noteNumber: 97, length: 120, velocity: 100 },  // expert string 1 (A), open
+					{ tick: 960, noteNumber: 96, length: 240, velocity: 107 },  // expert string 0, fret 7
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track.rawNotes).toHaveLength(3)
+		expect(track.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 96, velocity: 105 })
+		expect(track.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 97, velocity: 100 })
+		expect(track.rawNotes[2]).toMatchObject({ tick: 960, noteNumber: 96, velocity: 107 })
+	})
+
+	it('assigns raw notes to correct difficulties', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },  // expert (96-101)
+					{ tick: 480, noteNumber: 72, length: 120 },  // hard (72-77)
+					{ tick: 480, noteNumber: 48, length: 120 },  // medium (48-53)
+					{ tick: 480, noteNumber: 24, length: 120 },  // easy (24-29)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(getTrack(result, 'proguitar', 'expert')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'hard')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'medium')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'easy')!.rawNotes).toHaveLength(1)
+	})
+
+	it('extracts text events from Pro Guitar track', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+				textEvents: [{ tick: 0, text: 'begin_pg song_trainer_pg_1' }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track.textEvents).toEqual([{ tick: 0, text: 'begin_pg song_trainer_pg_1' }])
+	})
+
+	it('recognizes PART REAL_GUITAR_22 as proguitar22', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR_22', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar22', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+	})
+})
+
+describe('MIDI: Pro Bass', () => {
+	it('recognizes PART REAL_BASS and PART REAL_BASS_22', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_BASS', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_BASS_22', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(getTrack(result, 'probass', 'expert')).toBeDefined()
+		expect(getTrack(result, 'probass22', 'expert')).toBeDefined()
+	})
+})
+
+describe('MIDI: Pro Keys', () => {
+	it('maps each PART REAL_KEYS_* track to a single difficulty', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_H', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_M', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_E', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const prokeys = result.trackData.filter(t => t.instrument === 'prokeys')
+		expect(prokeys).toHaveLength(4)
+		expect(prokeys.map(t => t.difficulty).sort()).toEqual(['easy', 'expert', 'hard', 'medium'])
+	})
+
+	it('extracts star power on Pro Keys', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'prokeys', 'expert')!
+		expect(track.starPowerSections).toHaveLength(1)
+		// Should NOT create entries for other difficulties from this track
+		expect(getTrack(result, 'prokeys', 'hard')).toBeUndefined()
+	})
+
+	it('extracts raw key notes (MIDI 48-72)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [
+					{ tick: 480, noteNumber: 48, length: 240 },  // C1 (lowest key)
+					{ tick: 480, noteNumber: 60, length: 240 },  // C2 (middle)
+					{ tick: 960, noteNumber: 72, length: 120 },  // C3 (highest key)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'prokeys', 'expert')!
+		expect(track.rawNotes).toHaveLength(3)
+		expect(track.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 48 })
+		expect(track.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 60 })
+		expect(track.rawNotes[2]).toMatchObject({ tick: 960, noteNumber: 72 })
+	})
+})
+
+describe('MIDI: Elite Drums', () => {
+	it('recognizes PART ELITE_DRUMS and extracts star power', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART ELITE_DRUMS', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'elitedrums', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+	})
+
+	it('extracts raw pad notes with velocity and assigns to correct difficulty', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART ELITE_DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 74, length: 0, velocity: 100 },  // expert kick (base=74, offset 0)
+					{ tick: 480, noteNumber: 75, length: 0, velocity: 127 },  // expert snare, accent (velocity 127)
+					{ tick: 960, noteNumber: 50, length: 0, velocity: 100 },  // hard kick (base=50)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const expert = getTrack(result, 'elitedrums', 'expert')!
+		expect(expert.rawNotes).toHaveLength(2)
+		expect(expert.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 74, velocity: 100 })
+		expect(expert.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 75, velocity: 127 })
+		const hard = getTrack(result, 'elitedrums', 'hard')!
+		expect(hard.rawNotes).toHaveLength(1)
+		expect(hard.rawNotes[0]).toMatchObject({ tick: 960, noteNumber: 50 })
+	})
+})
+
+describe('MIDI: Phase Shift Real Drums', () => {
+	it('maps PART REAL_DRUMS_PS to drums instrument', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_DRUMS_PS', {
+				notes: [{ tick: 480, noteNumber: 97, length: 120 }], // expert red drum
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0) // notes should be parsed as standard drums
+	})
+})
+
+describe('MIDI: GHL Keys', () => {
+	it('recognizes PART KEYS GHL as keysghl with sixFret note parsing', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART KEYS GHL', {
+				notes: [
+					{ tick: 480, noteNumber: 94, length: 120 },  // expert open (sixFretDiffStart.expert = 94)
+					{ tick: 960, noteNumber: 95, length: 120 },  // expert white1
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'keysghl', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0)
+	})
+
+})
+
+describe('.chart: GHL Keys', () => {
+	it('parses ExpertGHLKeys section', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertGHLKeys: ['0 = N 0 0', '192 = N 1 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'keysghl')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0)
+	})
+})

--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest'
 import { writeMidi, MidiData } from 'midi-file'
 import { parseNotesFromMidi } from '../chart/midi-parser'
 import { parseNotesFromChart } from '../chart/chart-parser'
+import { parseChartFile } from '../chart/notes-parser'
 import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
 
 // ---------------------------------------------------------------------------
@@ -721,5 +722,283 @@ describe('per-track data edge cases', () => {
 		expect(track.textEvents).toEqual([])
 		expect(track.versusPhrases).toEqual([])
 		expect(track.animations).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: Global Events
+// ---------------------------------------------------------------------------
+
+describe('MIDI: global events', () => {
+	it('captures crowd and music events from EVENTS track', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[music_start]' },
+			{ deltaTime: 960, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('excludes sections from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_intense]' },
+			{ deltaTime: 480, type: 'text', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: '[crowd_intense]' },
+		])
+	})
+
+	it('excludes end events and coda from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'text', text: '[coda]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_clap]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 960, text: '[crowd_clap]' },
+		])
+	})
+
+	it('includes misplaced lyric/phrase events in unrecognizedEvents (alongside parseIssues)', () => {
+		// Lyrics and phrase markers belong on PART VOCALS, not EVENTS. Game engines
+		// drop them, but we round-trip them out so users can see and fix them.
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: 'lyric Hello' },
+			{ tick: 960, text: 'phrase_start' },
+			{ tick: 1440, text: 'phrase_end' },
+			{ tick: 1920, text: '[music_end]' },
+		])
+	})
+
+	it('reads from lyrics, marker, and cuePoint event types (not just text)', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'lyrics', text: '[music_start]' },
+			{ deltaTime: 480, type: 'marker', text: '[crowd_clap]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 960, text: '[crowd_clap]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('reads sections from lyrics/marker event types', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'lyrics', text: '[section intro]' },
+			{ deltaTime: 480, type: 'marker', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: 'intro' },
+			{ tick: 480, name: 'verse' },
+		])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('reads end events from lyrics event type', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 960, type: 'lyrics', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.endEvents).toEqual([{ tick: 960 }])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('returns empty array when no EVENTS track', () => {
+		const midi = buildMidi(480, [tempoTrack()])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Global Events
+// ---------------------------------------------------------------------------
+
+describe('.chart: global events', () => {
+	it('captures non-section/end/lyric/phrase events from [Events]', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "crowd_normal"',
+				'192 = E "music_start"',
+				'384 = E "section intro"',
+				'768 = E "music_end"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: 'crowd_normal' },
+			{ tick: 192, text: 'music_start' },
+			{ tick: 768, text: 'music_end' },
+		])
+	})
+
+	it('excludes end events, coda, lyrics, and phrase markers', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "end"',
+				'0 = E "coda"',
+				'192 = E "lyric Hello"',
+				'384 = E "phrase_start"',
+				'576 = E "phrase_end"',
+				'768 = E "crowd_clap"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 768, text: 'crowd_clap' },
+		])
+	})
+
+	it('returns empty array when no Events section', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			ExpertSingle: ['0 = N 0 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: parseIssues for stray vocal events on the EVENTS track
+// ---------------------------------------------------------------------------
+
+describe('MIDI: invalid lyric/phrase events on EVENTS track', () => {
+	it('emits invalidLyric for lyric text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: '[lyric world]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidLyric')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[lyric world]', 'lyric Hello'])
+	})
+
+	it('emits invalidPhraseStart for phrase_start text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseStart')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_start]', 'phrase_start'])
+	})
+
+	it('emits invalidPhraseEnd for phrase_end text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseEnd')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_end]', 'phrase_end'])
+	})
+
+	it('emits a mix of invalidLyric/PhraseStart/PhraseEnd when all coexist', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric Hel-]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric lo]' },
+			{ deltaTime: 240, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
+	})
+
+	it('does NOT emit issues for properly-formed EVENTS-track text', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues).toEqual([])
+	})
+
+	it('reads invalid events from lyrics/marker/cuePoint event types too', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'lyrics', text: '[lyric foo]' },
+			{ deltaTime: 480, type: 'marker', text: '[phrase_start]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
 	})
 })

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -57,6 +57,11 @@ const trackNameMap = {
 	HardGHLBass: { instrument: 'bassghl', difficulty: 'hard' },
 	MediumGHLBass: { instrument: 'bassghl', difficulty: 'medium' },
 	EasyGHLBass: { instrument: 'bassghl', difficulty: 'easy' },
+
+	ExpertGHLKeys: { instrument: 'keysghl', difficulty: 'expert' },
+	HardGHLKeys: { instrument: 'keysghl', difficulty: 'hard' },
+	MediumGHLKeys: { instrument: 'keysghl', difficulty: 'medium' },
+	EasyGHLKeys: { instrument: 'keysghl', difficulty: 'easy' },
 } as const
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -203,6 +208,8 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 					textEvents: [],
 					versusPhrases: [],
 					animations: [], // .chart format does not have note-based animations
+					proKeysRangeShifts: [], // Pro instruments are MIDI-only
+					rawNotes: [], // Pro instruments are MIDI-only
 				}
 
 				for (const event of trackEvents) {

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -98,12 +98,10 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		throw 'Invalid .chart file: resolution not found.'
 	}
 
-	const codaEvents = _.chain(fileSections['Events'])
-		.map(line => /^(\d+) = E "\s*\[?coda\]?\s*"$/.exec(line))
-		.compact()
-		.map(([, stringTick]) => ({ tick: Number(stringTick) }))
-		.value()
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].tick : null
+	// Classify each line of the [Events] section into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents.
+	const eventsScan = scanEventsSection(fileSections['Events'] ?? [])
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: resolution,
@@ -169,21 +167,9 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				}
 			})
 			.value(),
-		sections: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?(?:section|prc)[ _](.*?)\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick, stringName]) => ({
-				tick: Number(stringTick),
-				name: stringName,
-			}))
-			.value(),
-		endEvents: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?end\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick]) => ({
-				tick: Number(stringTick),
-			}))
-			.value(),
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [],
 		trackData: _.chain(fileSections)
 			.pick(_.keys(trackNameMap))
@@ -529,5 +515,55 @@ function mergeSoloEvents(events: { tick: number; type: EventType; length: number
 	_.remove(events, event => event.type === eventTypes.soloSectionStart || event.type === eventTypes.soloSectionEnd)
 
 	return events
+}
+
+interface ChartEventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining E-events not recognized as sections/end/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocal
+	 *  parsing path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+}
+
+/**
+ * Parse each line of the .chart [Events] section once via the generic
+ * `TICK = E "TEXT"` regex, then classify the text into one of
+ * {section, end, coda, lyric, phrase, unrecognized}.
+ */
+function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
+	const result: ChartEventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+	}
+	for (const line of eventLines) {
+		const match = /^(\d+) = E "([^\r\n]*?)"$/.exec(line)
+		if (!match) continue
+		const tick = Number(match[1])
+		const text = match[2]
+
+		const sectionMatch = /^\[?(?:section|prc)[ _](.*?)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers are extracted by the vocal parsing path — skip here
+		if (/^\s*lyric[ \t]/.test(text)) continue
+		if (/^(?:phrase_start|phrase_end)$/.test(text)) continue
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -195,6 +195,8 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	invalidLyric: 'This lyric is on the EVENTS track instead of PART VOCALS and will not be displayed.',
 	invalidPhraseStart: 'This phrase_start is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
+	duplicateDrumsTrack:
+		'This chart has both PART DRUMS and PART REAL_DRUMS_PS. PART DRUMS takes precedence; the PART REAL_DRUMS_PS track was dropped.',
 } as const
 
 function findChartIssues(

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -192,6 +192,9 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	brokenNote: 'This note is so close to the previous note that this was likely a charting mistake.',
 	badSustainGap: 'This note is not far enough ahead of the previous sustain.',
 	babySustain: 'The sustain on this note is too short.',
+	invalidLyric: 'This lyric is on the EVENTS track instead of PART VOCALS and will not be displayed.',
+	invalidPhraseStart: 'This phrase_start is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
+	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 } as const
 
 function findChartIssues(

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -20,6 +20,17 @@ const trackNames = [
 	'PART GUITAR COOP GHL',
 	'PART RHYTHM GHL',
 	'PART BASS GHL',
+	'PART KEYS GHL',
+	'PART REAL_GUITAR',
+	'PART REAL_GUITAR_22',
+	'PART REAL_BASS',
+	'PART REAL_BASS_22',
+	'PART REAL_KEYS_X',
+	'PART REAL_KEYS_H',
+	'PART REAL_KEYS_M',
+	'PART REAL_KEYS_E',
+	'PART ELITE_DRUMS',
+	'PART REAL_DRUMS_PS',
 	'PART VOCALS',
 	'HARM1',
 	'HARM2',
@@ -52,8 +63,28 @@ const instrumentNameMap: { [key in InstrumentTrackName]: Instrument } = {
 	'PART GUITAR COOP GHL': 'guitarcoopghl',
 	'PART RHYTHM GHL': 'rhythmghl',
 	'PART BASS GHL': 'bassghl',
+	'PART KEYS GHL': 'keysghl',
+	'PART REAL_GUITAR': 'proguitar',
+	'PART REAL_GUITAR_22': 'proguitar22',
+	'PART REAL_BASS': 'probass',
+	'PART REAL_BASS_22': 'probass22',
+	'PART REAL_KEYS_X': 'prokeys',
+	'PART REAL_KEYS_H': 'prokeys',
+	'PART REAL_KEYS_M': 'prokeys',
+	'PART REAL_KEYS_E': 'prokeys',
+	'PART ELITE_DRUMS': 'elitedrums',
+	'PART REAL_DRUMS_PS': 'drums',
 } as const
 /* eslint-enable @typescript-eslint/naming-convention */
+
+/** Pro Keys uses one MIDI track per difficulty instead of one track for all difficulties. */
+const proKeysDifficultyMap: { [key: string]: Difficulty } = {
+	'PART REAL_KEYS_X': 'expert',
+	'PART REAL_KEYS_H': 'hard',
+	'PART REAL_KEYS_M': 'medium',
+	'PART REAL_KEYS_E': 'easy',
+}
+
 
 const sysExDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 const discoFlipDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
@@ -106,7 +137,21 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 	// Sets event.deltaTime to the number of ticks since the start of the track
 	convertToAbsoluteTime(midiFile)
 
-	const tracks = getTracks(midiFile)
+	const allTracks = getTracks(midiFile)
+	const parseIssues: RawChartData['parseIssues'] = []
+
+	// YARG/Moonscraper behavior: PART DRUMS is canonical; PART REAL_DRUMS_PS is a
+	// fallback used only when PART DRUMS is absent. When both exist, drop the
+	// fallback entirely (matches YARG's TrackOverrides dictionary, where
+	// DRUMS_REAL_TRACK has overwrite=false so it's discarded once drums is loaded).
+	const hasCanonicalDrums = allTracks.some(t => t.trackName === 'PART DRUMS')
+	const hasFallbackDrums = allTracks.some(t => t.trackName === 'PART REAL_DRUMS_PS')
+	const tracks = hasCanonicalDrums && hasFallbackDrums
+		? allTracks.filter(t => t.trackName !== 'PART REAL_DRUMS_PS')
+		: allTracks
+	if (hasCanonicalDrums && hasFallbackDrums) {
+		parseIssues.push({ instrument: 'drums', difficulty: null, noteIssue: 'duplicateDrumsTrack' })
+	}
 
 	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3
 	const vocalTracks: { [part: string]: VocalTrackData } = {}
@@ -195,24 +240,35 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
-		parseIssues: eventsScan.parseIssues,
+		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
 				const instrument = instrumentNameMap[t.trackName as InstrumentTrackName]
 				const instrumentType = getInstrumentType(instrument)
 				// Single scan pass extracts note-shaped events AND the
-				// data-carrying ones (text, versus, animations).
-				const { eventEnds, textEvents, versusPhrases, animations } = scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				// data-carrying ones (text, versus, animations, pro-instrument rawNotes,
+				// Pro Keys range shifts).
+				const { eventEnds, textEvents, versusPhrases, animations, rawNotesByDifficulty, proKeysRangeShifts } =
+					scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				// Pro instruments (pro guitar/bass, pro keys, elite drums) don't use
+				// the difficulty-range noteOn dispatch, so their 'all'-difficulty
+				// modifiers need to be copied to every difficulty unconditionally.
+				const forceDistribute = storesRawNotes(instrumentType)
 				const trackDifficulties = _.chain(eventEnds)
-					.thru(eventEnds => distributeInstrumentEvents(eventEnds)) // Removes 'all' difficulty
+					.thru(eventEnds => distributeInstrumentEvents(eventEnds, forceDistribute)) // Removes 'all' difficulty
 					.thru(eventEnds => getTrackEvents(eventEnds)) // Connects note ends together
 					.thru(events => splitMidiModifierSustains(events, instrumentType))
 					.thru(events => fixLegacyGhStarPower(events, instrumentType, iniChartModifiers))
 					.thru(events => fixFlexLaneLds(events))
 					.value()
 
-				return difficulties.map(difficulty => {
+				// Pro Keys uses one MIDI track per difficulty; other instruments
+				// have all 4 difficulties on one track.
+				const fixedDifficulty = proKeysDifficultyMap[t.trackName as string]
+				const diffsToProcess = fixedDifficulty ? [fixedDifficulty] as Difficulty[] : difficulties
+
+				return diffsToProcess.map(difficulty => {
 					const result: RawChartData['trackData'][number] = {
 						instrument,
 						difficulty,
@@ -225,6 +281,8 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 						textEvents,
 						versusPhrases,
 						animations,
+						proKeysRangeShifts,
+						rawNotes: rawNotesByDifficulty[difficulty],
 					}
 
 					for (const event of trackDifficulties[difficulty]) {
@@ -255,7 +313,13 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				})
 			})
 			.flatMap()
-			.filter(track => track.trackEvents.length > 0)
+			.filter(track =>
+				track.trackEvents.length > 0
+				|| track.rawNotes.length > 0
+				|| track.starPowerSections.length > 0
+				|| track.soloSections.length > 0,
+			)
+			.thru(tracks => copyDownProKeysPhrases(tracks))
 			.value(),
 	}
 }
@@ -300,6 +364,11 @@ interface TrackScanResult {
 	textEvents: { tick: number; text: string }[]
 	versusPhrases: { tick: number; length: number; isPlayer2: boolean }[]
 	animations: { tick: number; length: number; noteNumber: number }[]
+	/** Per-difficulty raw MIDI notes, populated for instrument types that store
+	 *  raw notes (pro guitar/bass, pro keys, elite drums). Empty otherwise. */
+	rawNotesByDifficulty: { [key in Difficulty]: RawNote[] }
+	/** Pro Keys range shift markers (notes 0, 2, 4, 5, 7, 9). Empty for other instruments. */
+	proKeysRangeShifts: { tick: number; length: number; noteNumber: number }[]
 }
 
 /**
@@ -308,7 +377,8 @@ interface TrackScanResult {
  *     `distributeInstrumentEvents` / `getTrackEvents`)
  *   - data-carrying events that ride alongside the notes: `textEvents`,
  *     `versusPhrases` (notes 105/106), `animations` (notes 24-51 drums,
- *     40-59 fret)
+ *     40-59 fret), and for pro instruments: `rawNotesByDifficulty` and
+ *     `proKeysRangeShifts`
  *
  * Versus phrases and animations live in the same MIDI event stream as the
  * playable notes, so they're emitted from this single iteration.
@@ -335,6 +405,14 @@ function scanInstrumentTrack(
 	const animationFilter = instrumentType === instrumentTypes.drums
 		? (n: number) => n >= 24 && n <= 51
 		: (n: number) => n >= 40 && n <= 59
+	// Raw notes + pro keys range shifts (pro guitar/bass, pro keys, elite drums).
+	const collectRawNotes = storesRawNotes(instrumentType)
+	const fixedRawNoteDifficulty = proKeysDifficultyMap[trackName]
+	const rawStarts = new Map<string, { tick: number; noteNumber: number; velocity: number; channel: number }>() // keyed by noteNumber+channel
+	const rawNotesByDifficulty: { [key in Difficulty]: RawNote[] } = { expert: [], hard: [], medium: [], easy: [] }
+	const rangeShiftStarts = new Map<number, number>() // noteNumber → startTick
+	const proKeysRangeShifts: { tick: number; length: number; noteNumber: number }[] = []
+	const isProKeys = instrumentType === instrumentTypes.proKeys
 
 	for (const event of events) {
 		// SysEx event (tap modifier or open)
@@ -358,6 +436,52 @@ function scanInstrumentTrack(
 			}
 		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
 			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+
+			// Collect per-difficulty raw MIDI notes for pro guitar/bass, pro keys,
+			// and elite drums. These instruments store notes verbatim with
+			// velocity+channel (matching YARG.Core) rather than being dispatched
+			// through the difficulty-range noteOn logic below.
+			if (collectRawNotes) {
+				const key = `${event.noteNumber}:${event.channel}`
+				if (!isOff) {
+					if (!rawStarts.has(key)) {
+						rawStarts.set(key, { tick: event.deltaTime, noteNumber: event.noteNumber, velocity: event.velocity, channel: event.channel })
+					}
+				} else {
+					const start = rawStarts.get(key)
+					if (start) {
+						const diff = getRawNoteDifficulty(event.noteNumber, instrumentType, fixedRawNoteDifficulty)
+						if (diff) {
+							rawNotesByDifficulty[diff].push({
+								tick: start.tick,
+								length: event.deltaTime - start.tick,
+								noteNumber: start.noteNumber,
+								velocity: start.velocity,
+								channel: start.channel,
+							})
+						}
+						rawStarts.delete(key)
+					}
+				}
+			}
+
+			// Pro Keys range shift markers (notes 0, 2, 4, 5, 7, 9 — no overlap
+			// with Pro Keys playable notes 48-72, so exclusive).
+			if (isProKeys && (event.noteNumber === 0 || event.noteNumber === 2 || event.noteNumber === 4
+				|| event.noteNumber === 5 || event.noteNumber === 7 || event.noteNumber === 9)) {
+				if (!isOff) {
+					if (!rangeShiftStarts.has(event.noteNumber)) {
+						rangeShiftStarts.set(event.noteNumber, event.deltaTime)
+					}
+				} else {
+					const startTick = rangeShiftStarts.get(event.noteNumber)
+					if (startTick !== undefined) {
+						proKeysRangeShifts.push({ tick: startTick, length: event.deltaTime - startTick, noteNumber: event.noteNumber })
+						rangeShiftStarts.delete(event.noteNumber)
+					}
+				}
+				continue
+			}
 
 			// Collect versus phrase markers (notes 105/106). These don't overlap
 			// with any note-shaped events, so we don't fall through.
@@ -402,7 +526,7 @@ function scanInstrumentTrack(
 				: 'all'
 			if (difficulty === 'all') {
 				// Instrument-wide event (solo marker, star power, etc...) (applies to all difficulties)
-				const type = getInstrumentEventType(event.noteNumber)
+				const type = getInstrumentEventType(event.noteNumber, instrumentType)
 				if (type !== null) {
 					eventEnds[difficulty].push({
 						tick: event.deltaTime,
@@ -414,9 +538,10 @@ function scanInstrumentTrack(
 				}
 			} else {
 				const type =
-					(instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
+					instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
 					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(event.noteNumber, difficulty)
-					: get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)) ?? null
+					: instrumentType === instrumentTypes.fiveFret ? get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)
+					: null // New instrument types: per-difficulty notes not parsed yet
 				if (type !== null) {
 					eventEnds[difficulty].push({
 						tick: event.deltaTime,
@@ -468,24 +593,45 @@ function scanInstrumentTrack(
 
 	versusPhrases.sort((a, b) => a.tick - b.tick)
 	animations.sort((a, b) => a.tick - b.tick)
-	return { eventEnds, textEvents, versusPhrases, animations }
+	proKeysRangeShifts.sort((a, b) => a.tick - b.tick)
+	for (const diff of difficulties) {
+		rawNotesByDifficulty[diff].sort((a, b) => a.tick - b.tick || a.noteNumber - b.noteNumber)
+	}
+	return { eventEnds, textEvents, versusPhrases, animations, rawNotesByDifficulty, proKeysRangeShifts }
 }
 
 /** These apply to the entire instrument, not specific difficulties. */
-function getInstrumentEventType(note: number) {
+function getInstrumentEventType(note: number, instrumentType: InstrumentType) {
 	switch (note) {
 		case 103:
+			// Solo on standard instruments and elite drums. NOT solo on pro guitar/bass/keys (they use 115).
+			if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys) return null
 			return eventTypes.soloSection
+		case 115:
+			// Solo on pro guitar/bass and pro keys only
+			if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys) {
+				return eventTypes.soloSection
+			}
+			return null
 		case 104:
-			return eventTypes.forceTap
+			// forceTap on standard fret instruments only
+			if (instrumentType === instrumentTypes.fiveFret || instrumentType === instrumentTypes.sixFret) {
+				return eventTypes.forceTap
+			}
+			return null
 		case 109:
-			return eventTypes.forceFlam
+			// forceFlam on standard drums only
+			if (instrumentType === instrumentTypes.drums) return eventTypes.forceFlam
+			return null
 		case 110:
-			return eventTypes.yellowTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.yellowTomMarker
+			return null
 		case 111:
-			return eventTypes.blueTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.blueTomMarker
+			return null
 		case 112:
-			return eventTypes.greenTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.greenTomMarker
+			return null
 		case 116:
 			return eventTypes.starPower
 		case 120:
@@ -584,10 +730,10 @@ function getDrumsNoteType(note: number, difficulty: Difficulty) {
  * enableChartDynamics is meant to apply to all charted difficulties.
  * Distributes all of these to each difficulty in the instrument.
  */
-function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] }) {
+function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] }, forceDistribute = false) {
 	for (const instrumentEvent of eventEnds.all) {
 		for (const difficulty of difficulties) {
-			if (eventEnds[difficulty].length === 0) {
+			if (!forceDistribute && eventEnds[difficulty].length === 0) {
 				continue // Skip adding modifiers to uncharted difficulties
 			}
 			eventEnds[difficulty].push(_.clone(instrumentEvent))
@@ -666,6 +812,10 @@ function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }
 function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent[] }, instrumentType: InstrumentType) {
 	let enableChartDynamics = false
 	const t = eventTypes
+	// New instrument types have no per-difficulty notes to modify; return as-is
+	if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys || instrumentType === instrumentTypes.eliteDrums) {
+		return events
+	}
 	const modifierSustains: EventType[] =
 		instrumentType === instrumentTypes.drums ?
 			[t.forceFlam, t.yellowTomMarker, t.blueTomMarker, t.greenTomMarker]
@@ -824,6 +974,85 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	)
 
 	return events
+}
+
+export type RawNote = { tick: number; length: number; noteNumber: number; velocity: number; channel: number }
+
+/**
+ * Instruments that store per-difficulty raw MIDI notes (pro guitar/bass, pro keys,
+ * elite drums) instead of the standard difficulty-range noteOn dispatch.
+ */
+function storesRawNotes(instrumentType: InstrumentType): boolean {
+	return instrumentType === instrumentTypes.proGuitar
+		|| instrumentType === instrumentTypes.proKeys
+		|| instrumentType === instrumentTypes.eliteDrums
+}
+
+/**
+ * Determine which difficulty a raw MIDI note belongs to. Pro guitar/bass uses
+ * per-difficulty note ranges; pro keys has one MIDI track per difficulty; elite
+ * drums uses per-difficulty offsets.
+ */
+function getRawNoteDifficulty(
+	noteNumber: number,
+	instrumentType: InstrumentType,
+	fixedDifficulty?: Difficulty,
+): Difficulty | null {
+	if (instrumentType === instrumentTypes.proGuitar) {
+		// Pro Guitar/Bass: 6 strings + per-difficulty modifiers
+		// Easy=24-34, Medium=48-58, Hard=72-82, Expert=96-108
+		if (noteNumber >= 24 && noteNumber <= 34) return 'easy'
+		if (noteNumber >= 48 && noteNumber <= 58) return 'medium'
+		if (noteNumber >= 72 && noteNumber <= 82) return 'hard'
+		if (noteNumber >= 96 && noteNumber <= 108) return 'expert'
+		// Root note markers (4-18) apply to all difficulties — store on expert
+		if (noteNumber >= 4 && noteNumber <= 18) return 'expert'
+		return null
+	}
+
+	if (instrumentType === instrumentTypes.proKeys) {
+		// Pro Keys: notes 48-72 (25 keys). Each track is one difficulty.
+		if (noteNumber >= 48 && noteNumber <= 72) return fixedDifficulty ?? 'expert'
+		return null
+	}
+
+	if (instrumentType === instrumentTypes.eliteDrums) {
+		// Elite Drums: base offsets Easy=2, Medium=26, Hard=50, Expert=74
+		// 10 pads (offset -2 to +8) + modifiers (offset +13, +14, +16)
+		if (noteNumber >= 0 && noteNumber <= 18) return 'easy'
+		if (noteNumber >= 24 && noteNumber <= 42) return 'medium'
+		if (noteNumber >= 48 && noteNumber <= 66) return 'hard'
+		if (noteNumber >= 72 && noteNumber <= 90) return 'expert'
+		return null
+	}
+
+	return null
+}
+
+
+/**
+ * YARG copies star power and solo sections from the Pro Keys expert track to all other
+ * Pro Keys difficulties (each Pro Keys difficulty is a separate MIDI track, but star power
+ * and solo are only charted on the expert track).
+ */
+function copyDownProKeysPhrases(tracks: RawChartData['trackData']): RawChartData['trackData'] {
+	const expertProKeys = tracks.find(t => t.instrument === 'prokeys' && t.difficulty === 'expert')
+	if (!expertProKeys) return tracks
+
+	for (const track of tracks) {
+		if (track.instrument !== 'prokeys' || track.difficulty === 'expert') continue
+		if (track.starPowerSections.length === 0 && expertProKeys.starPowerSections.length > 0) {
+			track.starPowerSections = expertProKeys.starPowerSections.map(p => ({ ...p }))
+		}
+		if (track.soloSections.length === 0 && expertProKeys.soloSections.length > 0) {
+			track.soloSections = expertProKeys.soloSections.map(p => ({ ...p }))
+		}
+		// Range shifts are charted per-difficulty, but if missing, copy from expert
+		if (track.proKeysRangeShifts.length === 0 && expertProKeys.proKeysRangeShifts.length > 0) {
+			track.proKeysRangeShifts = expertProKeys.proKeysRangeShifts.map(p => ({ ...p }))
+		}
+	}
+	return tracks
 }
 
 /**

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -145,11 +145,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		}
 	}
 
-	const codaEvents =
-		tracks
-			.find(t => t.trackName === 'EVENTS')
-			?.trackEvents.filter(e => e.type === 'text' && (e.text.trim() === 'coda' || e.text.trim() === '[coda]')) ?? []
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].deltaTime : null
+	// Classify each text-like event on the EVENTS track into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents (the remainder).
+	const eventsScan = scanEventsTrack(tracks)
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: midiFile.header.ticksPerBeat,
@@ -193,24 +192,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				}
 			})
 			.value(),
-		sections: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-				name: e.text.match(/^\[?(?:section|prc)[ _]([^\]]*)\]?$/)![1],
-			}))
-			.value(),
-		endEvents: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?end\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-			}))
-			.value(),
-		parseIssues: [],
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
+		parseIssues: eventsScan.parseIssues,
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -839,5 +824,84 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	)
 
 	return events
+}
+
+/**
+ * YARG/MoonSong reads text-like events from multiple MIDI meta event types:
+ * text (FF 01), lyrics (FF 05), marker (FF 06), cuePoint (FF 07).
+ * trackName (FF 03) and instrumentName (FF 04) are excluded.
+ */
+function isTextLikeEvent(event: MidiEvent): event is MidiTextEvent {
+	return event.type === 'text' || event.type === 'lyrics' || event.type === 'marker' || event.type === 'cuePoint'
+}
+
+interface EventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining text-like events not recognized as sections/endEvents/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocals path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+	/** Issues raised while classifying EVENTS track text events (e.g. stray lyric/phrase
+	 *  events that belong on PART VOCALS, not EVENTS). */
+	parseIssues: RawChartData['parseIssues']
+}
+
+/**
+ * Single-pass scan of the EVENTS track that classifies each text-like event
+ * into one of {section, endEvent, coda, lyric, phrase, unrecognized}. Lyrics
+ * and phrase_start/phrase_end are consumed by the vocal parsing path — we
+ * don't re-emit them here. Everything else that matches a recognized pattern
+ * goes into its typed array; all remaining text-like events fall through to
+ * `unrecognizedEvents`.
+ *
+ * Reads from all text-like event types (text, lyrics, marker, cuePoint),
+ * matching YARG.Core's MoonText behavior.
+ */
+function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[]): EventsScanResult {
+	const result: EventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+		parseIssues: [],
+	}
+	const eventsTrack = tracks.find(t => t.trackName === 'EVENTS')
+	if (!eventsTrack) return result
+
+	for (const event of eventsTrack.trackEvents) {
+		if (!isTextLikeEvent(event)) continue
+		const text = event.text
+		const tick = event.deltaTime
+
+		const sectionMatch = /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
+		// the EVENTS track. Game engines silently drop them when they show up
+		// here. Record a parse issue so consumers can surface the misplacement,
+		// then fall through to unrecognizedEvents so the value round-trips back
+		// out — users can move it to PART VOCALS manually.
+		if (/^\[?\s*lyric[ \t]/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
+		} else if (/^\[?phrase_start\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
+		} else if (/^\[?phrase_end\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
+		}
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -159,6 +159,34 @@ export interface RawChartData {
 			/** The MIDI note number identifying the animation */
 			noteNumber: number
 		}[]
+		/**
+		 * Pro Keys range shift markers (MIDI notes 0/2/4/5/7/9). Each shift
+		 * changes which 10-key portion of the 25-key range is visible.
+		 * Only present on prokeys instrument tracks.
+		 */
+		proKeysRangeShifts: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** The MIDI note number: 0=C1-E2, 2=D1-F2, 4=E1-G2, 5=F1-A2, 7=G1-B2, 9=A1-C3 */
+			noteNumber: number
+		}[]
+		/**
+		 * Raw MIDI note data for instruments whose note format is not yet fully parsed
+		 * into NoteEvent (pro guitar/bass, pro keys, elite drums). Contains all per-difficulty
+		 * noteOn/noteOff pairs with full MIDI properties for roundtrip writing.
+		 */
+		rawNotes: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** The MIDI note number (instrument-type-specific meaning) */
+			noteNumber: number
+			/** MIDI velocity (pro guitar: fret + 100; elite drums: 1=ghost, 127=accent) */
+			velocity: number
+			/** MIDI channel (pro guitar: 0=normal, 1=ghost, 2=bend, 3=muted, 4=tapped, 5=harmonics, 6=pinch harmonics) */
+			channel: number
+		}[]
 	}[]
 }
 

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -74,6 +74,16 @@ export interface RawChartData {
 		tick: number
 	}[]
 	/**
+	 * Remaining text-like events from the EVENTS track that weren't recognized
+	 * and routed to a typed field (sections, endEvents, vocalTracks). These
+	 * include crowd events, music_start/end, drums mix events, coda markers,
+	 * and any custom/unknown text events.
+	 */
+	unrecognizedEvents: {
+		tick: number
+		text: string
+	}[]
+	/**
 	 * Issues detected at parse time (before `findChartIssues` runs). `chart-scanner`
 	 * concatenates these into the final `chartIssues` array, attaching the standard
 	 * description from `chartIssueDescriptions`. Use this for issues that the parser

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -91,6 +91,8 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 				textEvents: setEventMsTimes(track.textEvents, timedTempos, rawChartData.chartTicksPerBeat),
 				versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, rawChartData.chartTicksPerBeat),
 				animations: setEventMsTimes(track.animations, timedTempos, rawChartData.chartTicksPerBeat),
+				proKeysRangeShifts: setEventMsTimes(track.proKeysRangeShifts, timedTempos, rawChartData.chartTicksPerBeat),
+				rawNotes: setEventMsTimes(track.rawNotes, timedTempos, rawChartData.chartTicksPerBeat),
 				noteEventGroups: _.chain(track.trackEvents)
 					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.groupBy(note => note.tick)

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -64,6 +64,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		parseIssues: rawChartData.parseIssues,
 		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -213,6 +213,13 @@ export const instruments = [
 	'guitarcoopghl', // GHL (6-fret) Co-op Guitar
 	'rhythmghl', // GHL (6-fret) Rhythm Guitar
 	'bassghl', // GHL (6-fret) Bass Guitar
+	'keysghl', // GHL (6-fret) Keys
+	'proguitar', // Pro Guitar (17-fret)
+	'proguitar22', // Pro Guitar (22-fret)
+	'probass', // Pro Bass (17-fret)
+	'probass22', // Pro Bass (22-fret)
+	'prokeys', // Pro Keys
+	'elitedrums', // Elite Drums
 ] as const
 
 export type InstrumentType = ObjectValues<typeof instrumentTypes>
@@ -220,14 +227,25 @@ export const instrumentTypes = {
 	sixFret: 0,
 	fiveFret: 1,
 	drums: 2,
+	proGuitar: 3,
+	proKeys: 4,
+	eliteDrums: 5,
 } as const
-export function getInstrumentType(instrument: Instrument) {
-	if (instrument === 'drums') {
-		return instrumentTypes.drums
-	} else if (instrument === 'guitarghl' || instrument === 'guitarcoopghl' || instrument === 'rhythmghl' || instrument === 'bassghl') {
-		return instrumentTypes.sixFret
-	} else {
-		return instrumentTypes.fiveFret
+export function getInstrumentType(instrument: Instrument): InstrumentType {
+	switch (instrument) {
+		case 'drums': return instrumentTypes.drums
+		case 'guitarghl':
+		case 'guitarcoopghl':
+		case 'rhythmghl':
+		case 'bassghl':
+		case 'keysghl': return instrumentTypes.sixFret
+		case 'proguitar':
+		case 'proguitar22':
+		case 'probass':
+		case 'probass22': return instrumentTypes.proGuitar
+		case 'prokeys': return instrumentTypes.proKeys
+		case 'elitedrums': return instrumentTypes.eliteDrums
+		default: return instrumentTypes.fiveFret
 	}
 }
 
@@ -264,6 +282,7 @@ export type ChartIssueType =
 	| 'invalidLyric' // A lyric event was found on the EVENTS track in a .mid chart and will not be displayed
 	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
+	| 'duplicateDrumsTrack' // Chart has both PART DRUMS and PART REAL_DRUMS_PS; the fallback (PART REAL_DRUMS_PS) was dropped
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -261,6 +261,9 @@ export type ChartIssueType =
 	| 'brokenNote' // This note is so close to the previous note that this was likely a charting mistake
 	| 'badSustainGap' // This note is not far enough ahead of the previous sustain
 	| 'babySustain' // The sustain on this note is too short
+	| 'invalidLyric' // A lyric event was found on the EVENTS track in a .mid chart and will not be displayed
+	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
+	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"


### PR DESCRIPTION
## Summary
- Add parsing for Pro Guitar, Pro Bass, Pro Keys, Elite Drums, GHL Keys, and Phase Shift Real Drums

## Stack
PR 6/9. Depends on #80. Please merge in order:
1. Lyrics & vocal phrases (#76)
2. Harmonies (#77)
3. Complete vocal parsing (#78)
4. Per-track textEvents, versusPhrases, animations (#79)
5. globalEvents, gameMode, text-like MIDI events (#80)
6. **This PR** — new instruments
7. Semantic labels, typed animations, HandMap/StrumMap/CharacterState, glissando
8. VENUE track parsing
9. Unrecognized song.ini values