### PR TITLE
Preserve unrecognized song.ini values for round-trip writing

### DIFF
--- a/src/__tests__/ini-scanner.test.ts
+++ b/src/__tests__/ini-scanner.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for song.ini scanning: known property extraction and unknown value preservation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { scanIni } from '../ini/ini-scanner'
+
+function buildIni(lines: string[]): { fileName: string; data: Uint8Array }[] {
+	const text = lines.join('\r\n')
+	return [{ fileName: 'song.ini', data: new TextEncoder().encode(text) }]
+}
+
+describe('scanIni: unknownIniValues', () => {
+	it('returns unrecognized keys from [Song] section', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test Song',
+			'artist = Test Artist',
+			'diff_vocals_harm = 3',
+			'sysex_slider = True',
+			'rating = 2',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({
+			diff_vocals_harm: '3',
+			sysex_slider: 'True',
+			rating: '2',
+		})
+	})
+
+	it('does not include recognized keys in unknownIniValues', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test Song',
+			'artist = Test Artist',
+			'album = Test Album',
+			'genre = Rock',
+			'year = 2024',
+			'charter = Tester',
+			'diff_guitar = 4',
+			'pro_drums = True',
+			'hopo_frequency = 170',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+	})
+
+	it('does not include legacy alias keys in unknownIniValues', () => {
+		const files = buildIni([
+			'[Song]',
+			'frets = Legacy Charter',    // legacy alias for charter
+			'track = 5',                 // legacy alias for album_track
+			'hopofreq = 170',           // legacy alias for hopo_frequency
+			'star_power_note = 116',    // legacy alias for multiplier_note
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+	})
+
+	it('preserves common unrecognized keys found in real charts', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'diff_vocals_harm = 3',
+			'diff_guitar_real = 5',
+			'diff_bass_real = 4',
+			'diff_keys_real = 3',
+			'diff_guitar_real_22 = 5',
+			'diff_bass_real_22 = 4',
+			'diff_dance = 2',
+			'diff_drums_real_ps = 3',
+			'diff_keys_real_ps = 2',
+			'sysex_slider = True',
+			'sysex_open_bass = True',
+			'sysex_high_hat_ctrl = True',
+			'sysex_rimshot = True',
+			'sysex_pro_slide = True',
+			'kit_type = 1',
+			'guitar_type = 0',
+			'bass_type = 0',
+			'keys_type = 0',
+			'dance_type = 0',
+			'real_guitar_tuning = 0 0 0 0 0 0',
+			'real_bass_tuning = 0 0 0 0',
+			'real_keys_lane_count_right = 5',
+			'real_keys_lane_count_left = 5',
+			'vocal_gender = male',
+			'vocal_scroll_speed = 100',
+			'rating = 1',
+			'count = 42',
+			'version = 2',
+			'playlist = My Setlist',
+			'sub_playlist = Favorites',
+			'explicit_lyrics = True',
+			'video_loop = True',
+			'video_end_time = 180000',
+			'drum_fallback_blue = True',
+			'link_name_a = YouTube',
+			'banner_link_a = https://youtube.com',
+			'link_name_b = Spotify',
+			'banner_link_b = https://spotify.com',
+		])
+
+		const result = scanIni(files)
+		// All 38 non-standard keys should be preserved
+		expect(Object.keys(result.unknownIniValues).length).toBeGreaterThanOrEqual(36)
+		expect(result.unknownIniValues.diff_vocals_harm).toBe('3')
+		expect(result.unknownIniValues.diff_guitar_real).toBe('5')
+		expect(result.unknownIniValues.sysex_slider).toBe('True')
+		expect(result.unknownIniValues.kit_type).toBe('1')
+		expect(result.unknownIniValues.real_guitar_tuning).toBe('0 0 0 0 0 0')
+		expect(result.unknownIniValues.vocal_gender).toBe('male')
+		expect(result.unknownIniValues.rating).toBe('1')
+		expect(result.unknownIniValues.playlist).toBe('My Setlist')
+		expect(result.unknownIniValues.link_name_a).toBe('YouTube')
+		expect(result.unknownIniValues.banner_link_a).toBe('https://youtube.com')
+	})
+
+	it('preserves typo keys without correcting them', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'loading_phase = Almost there',     // typo for loading_phrase
+			'previw_start_time = 5000',          // typo for preview_start_time
+			'diff_drums_ real = 3',              // typo with space
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues.loading_phase).toBe('Almost there')
+		expect(result.unknownIniValues.previw_start_time).toBe('5000')
+		expect(result.unknownIniValues['diff_drums_ real']).toBe('3')
+	})
+
+	it('returns empty unknownIniValues when no ini file found', () => {
+		const result = scanIni([])
+		expect(result.unknownIniValues).toEqual({})
+		expect(result.metadata).toBeNull()
+	})
+
+	it('returns empty unknownIniValues when ini has no [Song] section', () => {
+		const files = buildIni(['[Other]', 'key = value'])
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+		expect(result.metadata).toBeNull()
+	})
+
+	it('preserves values with special characters', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'real_guitar_22_tuning = -2 -2 -2 -2 -2 -2 Standard Drop D',
+			'tags = cover',
+			'credit_composed_by = John Doe & Jane Doe',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues.real_guitar_22_tuning).toBe('-2 -2 -2 -2 -2 -2 Standard Drop D')
+		expect(result.unknownIniValues.tags).toBe('cover')
+		expect(result.unknownIniValues.credit_composed_by).toBe('John Doe & Jane Doe')
+	})
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { scanVideo } from './video'
 export * from './interfaces'
 export * from './chart/note-parsing-interfaces'
 export { parseChartFile } from './chart/notes-parser'
+export { scanIni } from './ini'
 export { calculateTrackHash } from './chart/track-hasher'
 
 /**

--- a/src/ini/ini-scanner.ts
+++ b/src/ini/ini-scanner.ts
@@ -93,7 +93,7 @@ export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
 	const findIniDataResult = findIniData(files)
 	folderIssues.push(...findIniDataResult.folderIssues)
 	if (!findIniDataResult.iniData) {
-		return { metadata: null, folderIssues, metadataIssues: [] }
+		return { metadata: null, folderIssues, metadataIssues: [], unknownIniValues: {} }
 	}
 
 	const parseIniResult = parseIni(findIniDataResult.iniData)
@@ -101,12 +101,12 @@ export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
 	const songSection = parseIniResult.iniObject.song || parseIniResult.iniObject.Song || parseIniResult.iniObject.SONG
 	if (songSection === undefined) {
 		folderIssues.push({ folderIssue: 'invalidMetadata', description: '"song.ini" doesn\'t have a "[Song]" section.' })
-		return { metadata: null, folderIssues, metadataIssues: [] }
+		return { metadata: null, folderIssues, metadataIssues: [], unknownIniValues: {} }
 	}
 
-	const { metadata, metadataIssues } = extractSongMetadata(songSection)
+	const { metadata, metadataIssues, unknownIniValues } = extractSongMetadata(songSection)
 
-	return { metadata, folderIssues, metadataIssues }
+	return { metadata, folderIssues, metadataIssues, unknownIniValues }
 }
 
 /**
@@ -147,12 +147,20 @@ function findIniData(files: { fileName: string; data: Uint8Array }[]): {
 	}
 }
 
+/** All keys that extractSongMetadata reads (primary + legacy aliases). */
+const knownIniKeys = new Set([
+	...Object.keys(defaultMetadata),
+	'frets', 'track', 'hopofreq', 'star_power_note', // legacy aliases
+])
+
 /**
  * @returns the chart metadata found in `songSection`, using default values if not found.
+ * Also returns all unrecognized key-value pairs for roundtrip preservation.
  */
 function extractSongMetadata(songSection: { [key: string]: string }): {
 	metadata: typeof defaultMetadata
 	metadataIssues: { metadataIssue: MetadataIssueType; description: string }[]
+	unknownIniValues: { [key: string]: string }
 } {
 	const metadataIssues: { metadataIssue: MetadataIssueType; description: string }[] = []
 
@@ -228,7 +236,15 @@ function extractSongMetadata(songSection: { [key: string]: string }): {
 		})
 	}
 
-	return { metadata, metadataIssues }
+	// Collect all unrecognized key-value pairs for roundtrip writing
+	const unknownIniValues: { [key: string]: string } = {}
+	for (const key of Object.keys(songSection)) {
+		if (!knownIniKeys.has(key)) {
+			unknownIniValues[key] = songSection[key]
+		}
+	}
+
+	return { metadata, metadataIssues, unknownIniValues }
 }
 
 /**


### PR DESCRIPTION
Captures unrecognized keys from song.ini into a typed field on ParsedChart so round-trip writers can re-emit them verbatim. Foundation for round-trip preservation work.

Validated: 0 hash regressions across 78,046 charts.