### PR TITLE
Normalize vocal data: group notes/lyrics into phrases with symbol flags

### DIFF
--- a/src/__tests__/lyric-parser.test.ts
+++ b/src/__tests__/lyric-parser.test.ts
@@ -15,7 +15,10 @@ import {
 	extractMidiVocalStarPower,
 	extractMidiRangeShifts,
 	extractMidiLyricShifts,
+	parseLyricFlags,
+	stripLyricSymbols,
 } from '../chart/lyric-parser'
+import { lyricFlags } from '../chart/note-parsing-interfaces'
 
 // ---------------------------------------------------------------------------
 // parseChartLyricLine
@@ -892,6 +895,56 @@ describe('extractMidiVocalNotes', () => {
 		expect(notes[0]).toEqual({ tick: 480, length: 240, pitch: 60, type: 'pitched' })
 	})
 
+	it('extracts consecutive same-pitch notes (noteOff then noteOn)', () => {
+		// Real case: "The Lumineers - Ho Hey" has two note-60 back-to-back:
+		// noteOn 60 at 54880, noteOff 60 at 55080, noteOn 60 at 55120
+		const events = [
+			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 680, type: 'noteOff' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 720, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
+		]
+		const notes = extractMidiVocalNotes(events)
+		expect(notes).toHaveLength(2)
+		expect(notes[0]).toEqual({ tick: 480, length: 200, pitch: 60, type: 'pitched' })
+		expect(notes[1]).toEqual({ tick: 720, length: 240, pitch: 60, type: 'pitched' })
+	})
+
+	it('handles zero-length note (noteOn+noteOff at same tick) followed by new note', () => {
+		// Real case: "The Lumineers - Ho Hey" has noteOn+noteOff at tick 49840 (zero-length),
+		// then a real noteOn at 54880. YARG ignores the duplicate noteOn at 49840 (already open
+		// from earlier), then the noteOff closes the note. The noteOn at 54880 opens a new note.
+		// With incorrect noteOff-before-noteOn sorting, the zero-length note steals the noteOff
+		// at 55080, causing the noteOn at 54880 to be treated as a duplicate.
+		const events = [
+			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			// Zero-length note at tick 680: noteOn then noteOff at same tick
+			{ deltaTime: 680, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 680, type: 'noteOff' as const, noteNumber: 60, velocity: 100 },
+			// New note at tick 960
+			{ deltaTime: 960, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 1200, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
+		]
+		const notes = extractMidiVocalNotes(events)
+		// Should produce 2 notes: 480-680 and 960-1200
+		// (zero-length noteOn at 680 is duplicate → ignored; noteOff at 680 closes note at 480)
+		expect(notes).toHaveLength(2)
+		expect(notes[0]).toMatchObject({ tick: 480, length: 200 })
+		expect(notes[1]).toMatchObject({ tick: 960, length: 240 })
+	})
+
+	it('extracts same-pitch notes with noteOff velocity > 0', () => {
+		// FreeStyleGames charts use noteOff with velocity > 0 (e.g. vel=100)
+		const events = [
+			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 680, type: 'noteOff' as const, noteNumber: 60, velocity: 100 },  // vel > 0
+			{ deltaTime: 720, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 60, velocity: 100 },
+		]
+		const notes = extractMidiVocalNotes(events)
+		expect(notes).toHaveLength(2)
+	})
+
 	it('handles mixed pitched and percussion notes', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
@@ -993,5 +1046,175 @@ describe('extractMidiLyricShifts', () => {
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 0, velocity: 0 },
 		]
 		expect(extractMidiLyricShifts(events)).toHaveLength(0)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// parseLyricFlags
+// ---------------------------------------------------------------------------
+
+describe('parseLyricFlags', () => {
+	it('returns none for plain text', () => {
+		expect(parseLyricFlags('Hello')).toBe(lyricFlags.none)
+	})
+
+	it('detects pitch slide (+)', () => {
+		expect(parseLyricFlags('Hel+')).toBe(lyricFlags.pitchSlide)
+	})
+
+	it('detects join with next (-)', () => {
+		expect(parseLyricFlags('to-')).toBe(lyricFlags.joinWithNext)
+	})
+
+	it('detects hyphenate with next (=)', () => {
+		expect(parseLyricFlags('word=')).toBe(lyricFlags.hyphenateWithNext)
+	})
+
+	it('detects non-pitched (#)', () => {
+		expect(parseLyricFlags('Cha#')).toBe(lyricFlags.nonPitched)
+	})
+
+	it('detects non-pitched lenient (^)', () => {
+		expect(parseLyricFlags('oh^')).toBe(lyricFlags.nonPitched | lyricFlags.lenientScoring)
+	})
+
+	it('detects non-pitched unknown (*)', () => {
+		expect(parseLyricFlags('hm*')).toBe(lyricFlags.nonPitched)
+	})
+
+	it('detects range shift (%)', () => {
+		expect(parseLyricFlags('go%')).toBe(lyricFlags.rangeShift)
+	})
+
+	it('detects static shift (/)', () => {
+		expect(parseLyricFlags('hey/')).toBe(lyricFlags.staticShift)
+	})
+
+	it('detects harmony hidden ($) at start', () => {
+		expect(parseLyricFlags('$hey')).toBe(lyricFlags.harmonyHidden)
+	})
+
+	it('detects multiple trailing flags', () => {
+		expect(parseLyricFlags('+-')).toBe(lyricFlags.pitchSlide | lyricFlags.joinWithNext)
+	})
+
+	it('detects $ prefix combined with trailing flags', () => {
+		expect(parseLyricFlags('$oh+')).toBe(lyricFlags.harmonyHidden | lyricFlags.pitchSlide)
+	})
+
+	it('returns none for empty string', () => {
+		expect(parseLyricFlags('')).toBe(lyricFlags.none)
+	})
+
+	it('handles symbol-only string (+)', () => {
+		expect(parseLyricFlags('+')).toBe(lyricFlags.pitchSlide)
+	})
+
+	it('does not treat mid-text symbols as flags', () => {
+		// '_' and '§' are not flag symbols
+		expect(parseLyricFlags('wor_ld')).toBe(lyricFlags.none)
+		expect(parseLyricFlags('a§b')).toBe(lyricFlags.none)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// stripLyricSymbols
+// ---------------------------------------------------------------------------
+
+describe('stripLyricSymbols', () => {
+	it('returns plain text unchanged', () => {
+		expect(stripLyricSymbols('Hello')).toBe('Hello')
+	})
+
+	it('strips trailing + (pitch slide)', () => {
+		expect(stripLyricSymbols('Hel+')).toBe('Hel')
+	})
+
+	it('keeps trailing - (join flag, but displayed as-is)', () => {
+		expect(stripLyricSymbols('to-')).toBe('to-')
+	})
+
+	it('replaces trailing = with - (hyphenate)', () => {
+		expect(stripLyricSymbols('word=')).toBe('word-')
+	})
+
+	it('strips trailing # (non-pitched)', () => {
+		expect(stripLyricSymbols('Cha#')).toBe('Cha')
+	})
+
+	it('strips trailing ^ (non-pitched lenient)', () => {
+		expect(stripLyricSymbols('oh^')).toBe('oh')
+	})
+
+	it('strips trailing % (range shift)', () => {
+		expect(stripLyricSymbols('go%')).toBe('go')
+	})
+
+	it('strips $ prefix (harmony hidden)', () => {
+		expect(stripLyricSymbols('$hey')).toBe('hey')
+	})
+
+	it('strips + but keeps - in multiple trailing flags', () => {
+		expect(stripLyricSymbols('+-')).toBe('-')
+	})
+
+	it('strips " from text', () => {
+		expect(stripLyricSymbols('"Hello"')).toBe('Hello')
+	})
+
+	it('returns empty for symbol-only string', () => {
+		expect(stripLyricSymbols('+')).toBe('')
+	})
+
+	it('returns empty for empty string', () => {
+		expect(stripLyricSymbols('')).toBe('')
+	})
+
+	// '_' is kept as-is. YARG replaces '_' → ' ' but that's lossy —
+	// real charts use '_' as an apostrophe substitute (e.g. "it_s", "can_t").
+	it('keeps _ as-is (YARG replaces with space, but that is lossy)', () => {
+		expect(stripLyricSymbols('wor_ld')).toBe('wor_ld')
+		expect(stripLyricSymbols('it_s')).toBe('it_s')
+	})
+
+	// '§' is kept as-is. YARG replaces '§' → '‿' (joined syllable display).
+	it('keeps § as-is (YARG replaces with ‿, but that is lossy)', () => {
+		expect(stripLyricSymbols('a§b')).toBe('a§b')
+	})
+
+	it('strips $ prefix and trailing + but keeps content', () => {
+		expect(stripLyricSymbols('$oh+')).toBe('oh')
+	})
+
+	it('strips $ and keeps trailing -', () => {
+		expect(stripLyricSymbols('$hid-')).toBe('hid-')
+	})
+
+	it('replaces = with - even in middle of text (matching YARG StripForVocals)', () => {
+		expect(stripLyricSymbols('a=b')).toBe('a-b')
+	})
+
+	it('preserves rich text tags for the consumer to render or strip', () => {
+		// Unlike YARG, we keep rich text tags in the stored data. Consumers that
+		// render lyrics decide whether to honor or strip them at render time.
+		expect(stripLyricSymbols('<i>Back')).toBe('<i>Back')
+		expect(stripLyricSymbols('<b>loud</b>')).toBe('<b>loud</b>')
+		expect(stripLyricSymbols('<color=#FF0000>red</color>')).toBe('<color=#FF0000>red</color>')
+		expect(stripLyricSymbols('<sub><i>REIMAGINED</i>')).toBe('<sub><i>REIMAGINED</i>')
+	})
+
+	it('keeps arbitrary angle-bracket content (known tags and custom markup)', () => {
+		// All bracketed content is preserved, including unknown tags like <scatting>.
+		expect(stripLyricSymbols('<scatting>')).toBe('<scatting>')
+		expect(stripLyricSymbols('hello<world>')).toBe('hello<world>')
+	})
+
+	it('preserves trailing whitespace (StripForVocals does not trim)', () => {
+		expect(stripLyricSymbols('hello ')).toBe('hello ')
+		expect(stripLyricSymbols('hello  ')).toBe('hello  ')
+	})
+
+	it('preserves tags and trailing whitespace together', () => {
+		expect(stripLyricSymbols('<sub><i>REIMAGINED</i> ')).toBe('<sub><i>REIMAGINED</i> ')
 	})
 })

--- a/src/__tests__/vocal-tracks.test.ts
+++ b/src/__tests__/vocal-tracks.test.ts
@@ -7,7 +7,8 @@ import { describe, it, expect } from 'vitest'
 import { writeMidi, MidiData } from 'midi-file'
 import { parseNotesFromMidi } from '../chart/midi-parser'
 import { parseNotesFromChart } from '../chart/chart-parser'
-import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
+import { parseChartFile } from '../chart/notes-parser'
+import { defaultIniChartModifiers, lyricFlags } from '../chart/note-parsing-interfaces'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -502,5 +503,607 @@ describe('vocalTracks: .chart format', () => {
 		expect(result.vocalTracks.harmony1).toBeUndefined()
 		expect(result.vocalTracks.harmony2).toBeUndefined()
 		expect(result.vocalTracks.harmony3).toBeUndefined()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Normalized vocal tracks (through parseChartFile)
+// ---------------------------------------------------------------------------
+
+describe('normalizedVocalTracks', () => {
+	it('groups notes and lyrics into phrases', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'Hel-' },
+					{ tick: 720, text: 'lo' },
+					{ tick: 1920, text: 'World' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+					{ tick: 1920, pitch: 64, length: 240 },
+				],
+				phrases: [
+					{ tick: 480, length: 480 },
+					{ tick: 1920, length: 480 },
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const vocals = result.vocalTracks.parts.vocals
+		expect(vocals.notePhrases).toHaveLength(2)
+
+		// First phrase has 2 notes and 2 lyrics
+		expect(vocals.notePhrases[0].tick).toBe(480)
+		expect(vocals.notePhrases[0].notes).toHaveLength(2)
+		expect(vocals.notePhrases[0].lyrics).toHaveLength(2)
+		expect(vocals.notePhrases[0].notes[0].pitch).toBe(60)
+		expect(vocals.notePhrases[0].lyrics[0].text).toBe('Hel-')
+		expect(vocals.notePhrases[0].lyrics[0].flags).toBe(lyricFlags.joinWithNext)
+		expect(vocals.notePhrases[0].lyrics[1].text).toBe('lo')
+
+		// Second phrase has 1 note and 1 lyric
+		expect(vocals.notePhrases[1].tick).toBe(1920)
+		expect(vocals.notePhrases[1].notes).toHaveLength(1)
+		expect(vocals.notePhrases[1].lyrics).toHaveLength(1)
+		expect(vocals.notePhrases[1].lyrics[0].text).toBe('World')
+	})
+
+	it('determines isPercussion from first note', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [
+					{ tick: 600, pitch: 96, length: 120 },  // percussion (not at phrase start)
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.parts.vocals.notePhrases[0].isPercussion).toBe(true)
+	})
+
+	it('isPercussion is false when first note is pitched', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.parts.vocals.notePhrases[0].isPercussion).toBe(false)
+	})
+
+	it('excludes notes outside phrases', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [
+					{ tick: 100, pitch: 60, length: 50 },  // before phrase
+					{ tick: 480, pitch: 62, length: 240 },  // in phrase
+					{ tick: 5000, pitch: 64, length: 240 }, // after phrase
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.parts.vocals.notePhrases[0].notes).toHaveLength(1)
+		expect(result.vocalTracks.parts.vocals.notePhrases[0].notes[0].pitch).toBe(62)
+	})
+
+	it('strips lyric symbols and sets flags', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'Cha#' },
+					{ tick: 720, text: '$hid-' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		expect(lyrics[0].text).toBe('Cha')
+		expect(lyrics[0].flags).toBe(lyricFlags.nonPitched)
+		expect(lyrics[1].text).toBe('hid-')
+		expect(lyrics[1].flags).toBe(lyricFlags.harmonyHidden | lyricFlags.joinWithNext)
+	})
+
+	it('.chart vocals produce 0 notePhrases (no vocal notes in .chart format)', () => {
+		// .chart format has lyrics and phrase markers but no vocal notes (MIDI-only).
+		// Matching YARG behavior: phrases with no notes are skipped.
+		const chart = buildChart({
+			Song: ['Resolution = 480'],
+			SyncTrack: ['0 = B 120000'],
+			Events: [
+				'480 = E "phrase_start"',
+				'480 = E "lyric Hello"',
+				'960 = E "lyric World"',
+				'1440 = E "phrase_end"',
+			],
+		})
+
+		const result = parseChartFile(chart, 'chart')
+		const vocals = result.vocalTracks.parts.vocals
+		expect(vocals.notePhrases).toHaveLength(0)
+	})
+
+	it('preserves star power sections as separate array', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+		// Manually add star power note 116 — vocalTrack helper doesn't support it
+		// Test via raw parser then parseChartFile
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.parts.vocals.starPowerSections).toBeDefined()
+		expect(Array.isArray(result.vocalTracks.parts.vocals.starPowerSections)).toBe(true)
+	})
+
+	it('stores range shifts at track level', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.rangeShifts).toBeDefined()
+		expect(Array.isArray(result.vocalTracks.rangeShifts)).toBe(true)
+		expect(result.vocalTracks.lyricShifts).toBeDefined()
+		expect(Array.isArray(result.vocalTracks.lyricShifts)).toBe(true)
+	})
+
+	it('staticLyricPhrases copies notePhrases for vocals/HARM1', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [{ tick: 480, text: 'Hey' }],
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const vocals = result.vocalTracks.parts.vocals
+		expect(vocals.staticLyricPhrases).toHaveLength(vocals.notePhrases.length)
+		expect(vocals.staticLyricPhrases[0].tick).toBe(vocals.notePhrases[0].tick)
+	})
+
+	it('empty vocal track produces empty arrays', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const vocals = result.vocalTracks.parts.vocals
+		expect(vocals.notePhrases).toHaveLength(0)
+		expect(vocals.staticLyricPhrases).toHaveLength(0)
+		expect(vocals.starPowerSections).toHaveLength(0)
+	})
+
+	it('includes msTime and msLength on phrases and notes', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				lyrics: [{ tick: 480, text: 'Hey' }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrase = result.vocalTracks.parts.vocals.notePhrases[0]
+		expect(phrase.msTime).toBeGreaterThan(0)
+		expect(phrase.msLength).toBeGreaterThan(0)
+		expect(phrase.notes[0].msTime).toBeGreaterThan(0)
+		expect(phrase.notes[0].msLength).toBeGreaterThan(0)
+		expect(phrase.lyrics[0].msTime).toBeGreaterThan(0)
+	})
+
+	it('skips empty lyrics after symbol stripping (e.g. standalone "+")', () => {
+		// YARG's ProcessLyric: if IsNullOrWhiteSpace(strippedLyric) → skip
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'me' },
+					{ tick: 720, text: '+' },  // stripped to "", should be skipped
+					{ tick: 960, text: 'too' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+					{ tick: 960, pitch: 64, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 720 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		expect(lyrics).toHaveLength(2)
+		expect(lyrics[0].text).toBe('me')
+		expect(lyrics[1].text).toBe('too')
+	})
+
+	it('applies nonPitched flag to set note pitch to -1', () => {
+		// Real pattern: lyrics with '#' or '^' suffix mark non-pitched notes
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [{ tick: 480, text: 'Cha#' }],
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const note = result.vocalTracks.parts.vocals.notePhrases[0].notes[0]
+		expect(note.pitch).toBe(-1)  // nonPitched flag → pitch = -1
+	})
+
+	it('excludes percussionHidden (note 97) from normalized notes', () => {
+		// YARG only processes PERCUSSION_NOTE (96), not NONPLAYED_PERCUSSION_NOTE (97).
+		// Real example: "311 - Down" has 26 note-96 + 94 note-97 in a single phrase.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [
+					{ tick: 600, pitch: 96, length: 60 },   // percussion (included)
+					{ tick: 720, pitch: 97, length: 60 },   // percussionHidden (excluded)
+					{ tick: 960, pitch: 96, length: 60 },   // percussion (included)
+				],
+				phrases: [{ tick: 480, length: 720 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const notes = result.vocalTracks.parts.vocals.notePhrases[0].notes
+		expect(notes).toHaveLength(2)
+		expect(notes[0].type).toBe('percussion')
+		expect(notes[1].type).toBe('percussion')
+	})
+
+	it('pitch slide note is skipped (merged into previous)', () => {
+		// Real pattern: lyric "+" means the next note slides from previous.
+		// YARG merges it as a child note — we skip it entirely in the flat list.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'oh' },
+					{ tick: 720, text: '+' },   // pitch slide → note at 720 is skipped
+					{ tick: 960, text: 'yeah' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },  // this is the slide target
+					{ tick: 960, pitch: 64, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 720 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const notes = result.vocalTracks.parts.vocals.notePhrases[0].notes
+		expect(notes).toHaveLength(2)  // note at 720 skipped
+		expect(notes[0].tick).toBe(480)
+		expect(notes[1].tick).toBe(960)
+	})
+
+	it('skips phrases with no notes (matching YARG behavior)', () => {
+		// Real pattern: HARM1 has phrases for all parts; phrases with no notes are skipped.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [{ tick: 480, text: 'hey' }, { tick: 1920, text: 'yo' }],
+				notes: [{ tick: 1920, pitch: 60, length: 240 }],  // only in second phrase
+				phrases: [
+					{ tick: 480, length: 480 },   // empty — skipped
+					{ tick: 1920, length: 480 },  // has note — kept
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.parts.vocals.notePhrases).toHaveLength(1)
+		expect(result.vocalTracks.parts.vocals.notePhrases[0].tick).toBe(1920)
+	})
+
+	it('deduplicates phrases at same tick (note 105 + 106)', () => {
+		// When both MIDI note 105 and 106 exist at the same tick, only one phrase is created.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [
+					{ tick: 480, length: 480 },
+					// Simulate note 106 at same tick (vocalPhrases would have both)
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		// Only one phrase, not duplicated
+		expect(result.vocalTracks.parts.vocals.notePhrases).toHaveLength(1)
+	})
+
+	it('applies DeferredLyricJoinWorkaround for "+-" lyrics', () => {
+		// Real pattern: badly-formatted charts place the hyphen on the pitch bend lyric.
+		// YARG merges "+-" into the previous lyric and reduces it to "+".
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'sto' },
+					{ tick: 720, text: '+-' },  // workaround: merges "-" into previous
+					{ tick: 960, text: 'ry' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+					{ tick: 960, pitch: 64, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 720 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		// "sto" becomes "sto-" with JoinWithNext, "+-" becomes "+" which is empty → skipped
+		expect(lyrics).toHaveLength(2)
+		expect(lyrics[0].text).toBe('sto-')
+		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
+		expect(lyrics[1].text).toBe('ry')
+	})
+
+	it('skips underscore-only lyrics (whitespace-only after _ → space replacement)', () => {
+		// Real case: "Aoi - c.s.q.n." has lyric "_" which YARG replaces to " " → IsNullOrWhiteSpace → skip.
+		// We keep "_" as-is but still skip it from normalized output since YARG would skip it.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'hey' },
+					{ tick: 720, text: '_' },    // underscore-only → skipped
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		expect(lyrics).toHaveLength(1)
+		expect(lyrics[0].text).toBe('hey')
+	})
+
+	it('sorts lyrics by locale within same tick (matching YARG .NET string.Compare)', () => {
+		// Real case: "Billy Idol - Rebel Yell" has "re" and "+-" at same tick.
+		// YARG sorts via .NET string.Compare (culture-aware): "+-" before "re".
+		// This affects DeferredLyricJoinWorkaround and final lyricFlags.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'mo' },
+					{ tick: 720, text: 're' },     // MIDI order: "re" first
+					{ tick: 720, text: '+-' },     // MIDI order: "+-" second
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		// After sorting: "+-" comes before "re" at tick 720.
+		// DeferredLyricJoinWorkaround triggers on "+-": modifies "mo" → "mo-".
+		// Then "re" is processed normally with flags=None.
+		expect(lyrics).toHaveLength(2)
+		expect(lyrics[0].text).toBe('mo-')
+		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
+		expect(lyrics[1].text).toBe('re')
+		expect(lyrics[1].flags).toBe(0)
+	})
+
+	it('detects $ (harmonyHidden) at end of lyric as trailing flag', () => {
+		// Real pattern: HARM3 lyrics like "uh#$" — $ at end, not start
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [{ tick: 480, text: 'uh#$' }],
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const lyric = result.vocalTracks.parts.vocals.notePhrases[0].lyrics[0]
+		expect(lyric.text).toBe('uh')
+		expect(lyric.flags & lyricFlags.harmonyHidden).toBeTruthy()
+		expect(lyric.flags & lyricFlags.nonPitched).toBeTruthy()
+	})
+
+	it('range shifts and lyric shifts stored at track level', () => {
+		// Range shifts come from PART VOCALS / HARM1, shared across all parts
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		expect(result.vocalTracks.rangeShifts).toBeDefined()
+		expect(result.vocalTracks.lyricShifts).toBeDefined()
+		expect(Array.isArray(result.vocalTracks.rangeShifts)).toBe(true)
+		expect(Array.isArray(result.vocalTracks.lyricShifts)).toBe(true)
+	})
+
+	it('trims ASCII whitespace from lyrics before flag detection (YARG NormalizeTextEvent)', () => {
+		// Real case: "Deep Purple - Smoke on the Water" has lyric "+ " (plus trailing space).
+		// YARG's NormalizeTextEvent.TrimAscii strips the space → "+" → detected as pitch slide.
+		// Without trim, the space prevents pitch slide detection and the note is kept incorrectly.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'mo-' },
+					{ tick: 720, text: '+ ' },  // trailing space — should be trimmed to "+"
+					{ tick: 960, text: 'bile' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 720, pitch: 62, length: 240 },  // pitch slide target — skipped
+					{ tick: 960, pitch: 64, length: 240 },
+				],
+				phrases: [{ tick: 480, length: 720 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrase = result.vocalTracks.parts.vocals.notePhrases[0]
+		// Note at 720 should be skipped (pitch slide from trimmed "+ ")
+		expect(phrase.notes).toHaveLength(2)
+		expect(phrase.notes[0].tick).toBe(480)
+		expect(phrase.notes[1].tick).toBe(960)
+		// Lyric "+ " should be stripped to empty and skipped
+		expect(phrase.lyrics).toHaveLength(2)
+		expect(phrase.lyrics[0].text).toBe('mo-')
+		expect(phrase.lyrics[1].text).toBe('bile')
+	})
+
+	it('skips percussion notes at exact phrase start tick (MIDI event ordering)', () => {
+		// Real case: "500 Miles to Memphis" has percussion note 96 at same tick as phrase start.
+		// In MIDI, noteOn for 96 arrives before noteOn for 105 (phrase marker) at same tick.
+		// YARG's normalizer doesn't include this note in the phrase.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				notes: [
+					{ tick: 480, pitch: 96, length: 60 },   // percussion at phrase start — skipped
+					{ tick: 600, pitch: 96, length: 60 },   // percussion after start — kept
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const notes = result.vocalTracks.parts.vocals.notePhrases[0].notes
+		expect(notes).toHaveLength(1)
+		expect(notes[0].tick).toBe(600)
+	})
+
+	it('pitch slide across phrase boundary via previousParentLyric', () => {
+		// YARG's previousParentLyric persists across phrases, allowing pitch slides to
+		// attach to the last note of the previous phrase even without note length carry-over.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'la' },
+					{ tick: 1440, text: '+' },   // pitch slide — first note of phrase 2
+					{ tick: 1920, text: 'oo' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },   // phrase 1
+					{ tick: 1440, pitch: 72, length: 120 },  // phrase 2 — pitch slide, skipped
+					{ tick: 1920, pitch: 64, length: 240 },  // phrase 2 — kept
+				],
+				phrases: [
+					{ tick: 480, length: 480 },
+					{ tick: 1440, length: 720 },
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+		// Phrase 2: note at 1440 is pitch slide, attached to phrase 1's note via previousParentLyric
+		expect(phrases[1].notes).toHaveLength(1)
+		expect(phrases[1].notes[0].tick).toBe(1920)
+	})
+
+	it('carries lyrics from skipped phrases to next phrase (shared lyricIdx)', () => {
+		// Real case: "30 Seconds to Mars - Attack" has lyrics in a phrase with no notes.
+		// YARG's shared moonTextIndex carries those lyrics to the next phrase's first note.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'Whoa' },   // in skipped phrase (no notes)
+					{ tick: 1920, text: 'I' },      // in kept phrase
+				],
+				notes: [
+					{ tick: 1920, pitch: 60, length: 240 },
+				],
+				phrases: [
+					{ tick: 480, length: 480 },   // skipped (no notes)
+					{ tick: 1920, length: 480 },  // kept
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(1)
+		// Both lyrics should be in the kept phrase
+		expect(phrases[0].lyrics).toHaveLength(2)
+		expect(phrases[0].lyrics[0].text).toBe('Whoa')
+		expect(phrases[0].lyrics[1].text).toBe('I')
 	})
 })

--- a/src/chart/lyric-parser.ts
+++ b/src/chart/lyric-parser.ts
@@ -212,9 +212,19 @@ export function extractMidiLyrics(trackEvents: MidiLyricEvent[]): { tick: number
 // ---------------------------------------------------------------------------
 
 /**
- * Extract note-on/note-off pairs for the given MIDI note numbers.
- * Handles: velocity-0 noteOn as noteOff, noteOff-before-noteOn sort at same tick,
- * duplicate noteOn skip (matching YARG's ProcessNoteEvent).
+ * Extract note-on/note-off pairs for the given MIDI note numbers. Processes
+ * events in MIDI file order (sorted stably by tick), matching YARG.Core's
+ * `MidReader.ProcessNoteEvent`: velocity-0 noteOn is treated as noteOff,
+ * duplicate noteOn while a note is already open is ignored.
+ *
+ * MIDI file order correctly handles zero-length notes (noteOn + noteOff at the
+ * same tick for the same pitch): the noteOn opens the note and the following
+ * noteOff closes it immediately. Without preserving order, sorting noteOff
+ * before noteOn at the same tick would steal the close from a later real note
+ * (real example: "The Lumineers - Ho Hey" has a zero-length note 60 at tick
+ * 49840 that would otherwise steal the noteOff at tick 55080 from the real
+ * note at tick 54880).
+ *
  * Events must already be in absolute time (deltaTime = absolute tick).
  */
 function extractMidiNotePairs(
@@ -232,11 +242,8 @@ function extractMidiNotePairs(
 			})
 		}
 	}
-	// Stable sort: same tick → noteOff before noteOn
-	noteEvents.sort((a, b) => {
-		if (a.tick !== b.tick) return a.tick - b.tick
-		return (a.type === 'noteOff' ? 0 : 1) - (b.type === 'noteOff' ? 0 : 1)
-	})
+	// Stable sort by tick only, preserving MIDI file order at the same tick.
+	noteEvents.sort((a, b) => a.tick - b.tick)
 
 	const phraseStarts: Map<number, number> = new Map()
 	const results: { tick: number; length: number; noteNumber: number }[] = []
@@ -333,4 +340,101 @@ export function extractMidiRangeShifts(trackEvents: MidiLyricEvent[]): { tick: n
  */
 export function extractMidiLyricShifts(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
 	return extractMidiNotePairs(trackEvents, n => n === 1)
+}
+
+// ---------------------------------------------------------------------------
+// Lyric symbol parsing (for normalization)
+// ---------------------------------------------------------------------------
+
+import { lyricFlags } from './note-parsing-interfaces'
+
+/** Symbols that set flags when found at the end of a lyric (scanned right-to-left). */
+const trailingSymbolFlags: Record<string, number> = {
+	'-': lyricFlags.joinWithNext,
+	'=': lyricFlags.hyphenateWithNext,
+	'+': lyricFlags.pitchSlide,
+	'#': lyricFlags.nonPitched,
+	'^': lyricFlags.nonPitched | lyricFlags.lenientScoring,
+	'*': lyricFlags.nonPitched,
+	'%': lyricFlags.rangeShift,
+	'/': lyricFlags.staticShift,
+	'$': lyricFlags.harmonyHidden,
+}
+
+/** Symbols stripped from display text everywhere they appear. */
+const stripSymbols = new Set(['+', '#', '^', '*', '%', '/', '$', '"'])
+
+/** Trailing flag symbols that are stripped from display (YARG VOCALS_STRIP_SYMBOLS).
+ *  '-' and '=' are NOT in this set — '-' is kept, '=' is replaced with '-'. */
+const trailingStripSymbols = new Set(['+', '#', '^', '*', '%', '/', '$'])
+
+/**
+ * Parse lyric symbol flags from a lyric text string.
+ * Matches YARG's LyricSymbols.GetLyricFlags(): scans from end consuming flag symbols,
+ * and checks start for '$' (harmony hidden).
+ */
+export function parseLyricFlags(text: string): number {
+	let flags = 0
+	if (text.length === 0) return flags
+
+	// '$' at start = harmony hidden
+	if (text[0] === '$') flags |= lyricFlags.harmonyHidden
+
+	// Scan trailing symbols right-to-left
+	let i = text.length - 1
+	while (i >= 0) {
+		const flag = trailingSymbolFlags[text[i]]
+		if (flag === undefined) break
+		flags |= flag
+		i--
+	}
+
+	return flags
+}
+
+/**
+ * Strip lyric symbols from text for display.
+ * Strips VOCALS_STRIP_SYMBOLS (+, #, ^, *, %, /, $, ") and trims leading ASCII
+ * whitespace. Trailing '-' is kept (it's a display character). Trailing '=' is
+ * replaced with '-'. Keeps '_' and '§' as-is (consumer decides display replacement).
+ *
+ * Unlike YARG's `StripForVocals`, rich text tags (<i>, <b>, <color>, etc.) are
+ * preserved in the output — consumers that render lyrics can decide whether to
+ * honor or strip them at render time. To avoid breaking tag syntax, characters
+ * inside `<...>` are passed through verbatim.
+ */
+export function stripLyricSymbols(text: string): string {
+	// Trim leading ASCII whitespace (matching YARG's TrimStartAscii in ProcessLyric)
+	text = text.replace(/^[\x00-\x20]+/, '')
+	// Find the boundary between content and trailing flag symbols.
+	// Trailing flags are consumed right-to-left by parseLyricFlags.
+	let trailEnd = text.length
+	while (trailEnd > 0 && trailingSymbolFlags[text[trailEnd - 1]] !== undefined) {
+		trailEnd--
+	}
+
+	let result = ''
+	let insideTag = false
+	// Process non-trailing portion: strip symbols that are in VOCALS_STRIP_SYMBOLS,
+	// except inside <...> where rich-text markup should be preserved verbatim.
+	for (let i = 0; i < trailEnd; i++) {
+		const ch = text[i]
+		if (ch === '<') insideTag = true
+		if (insideTag) {
+			result += ch
+			if (ch === '>') insideTag = false
+			continue
+		}
+		if (stripSymbols.has(ch)) continue
+		if (ch === '=') { result += '-'; continue }
+		result += ch
+	}
+	// Process trailing portion: only strip the ones YARG strips, keep '-', replace '='
+	for (let i = trailEnd; i < text.length; i++) {
+		const ch = text[i]
+		if (trailingStripSymbols.has(ch)) continue
+		if (ch === '=') { result += '-'; continue }
+		result += ch // only '-' reaches here
+	}
+	return result
 }

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -274,3 +274,69 @@ export const noteFlags = {
 	ghost: 512,
 	accent: 1024,
 } as const
+
+// ---------------------------------------------------------------------------
+// Normalized vocal types (produced by notes-parser from raw VocalTrackData)
+// ---------------------------------------------------------------------------
+
+/** Bitmask flags for lyric symbols, matching YARG's LyricSymbolFlags. */
+export const lyricFlags = {
+	none:              0,
+	joinWithNext:      1,    // '-' suffix
+	nonPitched:        2,    // '#', '^', '*' suffix
+	lenientScoring:    4,    // '^' suffix (combined with nonPitched)
+	pitchSlide:       16,    // '+' suffix
+	harmonyHidden:    32,    // '$' prefix
+	staticShift:      64,    // '/' suffix
+	rangeShift:      128,    // '%' suffix
+	hyphenateWithNext: 256,  // '=' suffix
+} as const
+
+export interface NormalizedLyricEvent {
+	tick: number
+	msTime: number
+	/** Flag symbols stripped, '=' → '-'. '_' and '§' kept as-is (consumer decides display). */
+	text: string
+	/** Bitmask of `lyricFlags`. */
+	flags: number
+}
+
+export interface NormalizedVocalNote {
+	tick: number
+	msTime: number
+	length: number
+	msLength: number
+	/** MIDI pitch 36-84 for pitched, -1 for unpitched/percussion. */
+	pitch: number
+	/** percussionHidden (note 97) is excluded from normalized output. */
+	type: 'pitched' | 'percussion'
+}
+
+export interface NormalizedVocalPhrase {
+	tick: number
+	msTime: number
+	length: number
+	msLength: number
+	/** True if first note is percussion (YARG behavior — mixing types in one phrase is invalid data). */
+	isPercussion: boolean
+	notes: NormalizedVocalNote[]
+	lyrics: NormalizedLyricEvent[]
+}
+
+export interface NormalizedVocalPart {
+	/** Scoring phrases (from note 105). Notes and lyrics grouped into their containing phrase. */
+	notePhrases: NormalizedVocalPhrase[]
+	/** Static lyric display phrases (from note 106 on HARM2/3, copy of notePhrases on vocals/HARM1). */
+	staticLyricPhrases: NormalizedVocalPhrase[]
+	/** Star power sections — separate array, not per-phrase. */
+	starPowerSections: { tick: number; msTime: number; length: number; msLength: number }[]
+}
+
+/** Top-level normalized vocal track. */
+export interface NormalizedVocalTrack {
+	parts: { [partName: string]: NormalizedVocalPart }
+	/** Range shifts at track level (shared across parts). Length 0 = from '%' symbol, >0 = from MIDI note 0. */
+	rangeShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+	/** Lyric shifts at track level. YARG drops these but we keep them for writing. */
+	lyricShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+}

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -9,11 +9,19 @@ import {
 	eventTypes,
 	IniChartModifiers,
 	NoteEvent,
+	NormalizedLyricEvent,
+	NormalizedVocalNote,
+	NormalizedVocalPhrase,
+	NormalizedVocalPart,
+	NormalizedVocalTrack,
+	lyricFlags,
 	noteFlags,
 	NoteType,
 	noteTypes,
 	RawChartData,
+	VocalTrackData,
 } from './note-parsing-interfaces'
+import { parseLyricFlags, stripLyricSymbols } from './lyric-parser'
 
 type TrackEvent = RawChartData['trackData'][number]['trackEvents'][number]
 type UntimedNoteEvent = Omit<NoteEvent, 'msTime' | 'msLength'>
@@ -53,17 +61,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		hasLyrics: Object.values(rawChartData.vocalTracks).some(v => v.lyrics.length > 0),
 		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
 		hasForcedNotes,
-		vocalTracks: Object.fromEntries(
-			Object.entries(rawChartData.vocalTracks).map(([part, data]) => [part, {
-				lyrics: setEventMsTimes(data.lyrics, timedTempos, rawChartData.chartTicksPerBeat),
-				vocalPhrases: setEventMsTimes(data.vocalPhrases, timedTempos, rawChartData.chartTicksPerBeat),
-				notes: setEventMsTimes(data.notes, timedTempos, rawChartData.chartTicksPerBeat),
-				starPowerSections: setEventMsTimes(data.starPowerSections, timedTempos, rawChartData.chartTicksPerBeat),
-				rangeShifts: setEventMsTimes(data.rangeShifts, timedTempos, rawChartData.chartTicksPerBeat),
-				lyricShifts: setEventMsTimes(data.lyricShifts, timedTempos, rawChartData.chartTicksPerBeat),
-				staticLyricPhrases: setEventMsTimes(data.staticLyricPhrases, timedTempos, rawChartData.chartTicksPerBeat),
-			}]),
-		),
+		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
@@ -104,6 +102,236 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 			}))
 			.value(),
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Vocal track normalization
+// ---------------------------------------------------------------------------
+
+type TimedTempos = { tick: number; beatsPerMinute: number; msTime: number }[]
+
+function normalizeVocalTracks(
+	vocalTracks: { [part: string]: VocalTrackData },
+	timedTempos: TimedTempos,
+	resolution: number,
+): NormalizedVocalTrack {
+	const entries = Object.entries(vocalTracks)
+	const parts: { [partName: string]: NormalizedVocalPart } = {}
+
+	// Find the source part for track-level data (vocals or harmony1)
+	const sourcePart = vocalTracks['vocals'] ?? vocalTracks['harmony1']
+
+	for (const [partName, data] of entries) {
+		parts[partName] = normalizeVocalPart(data, timedTempos, resolution)
+	}
+
+	return {
+		parts,
+		rangeShifts: sourcePart
+			? setEventMsTimes(sourcePart.rangeShifts, timedTempos, resolution)
+			: [],
+		lyricShifts: sourcePart
+			? setEventMsTimes(sourcePart.lyricShifts, timedTempos, resolution)
+			: [],
+	}
+}
+
+function normalizeVocalPart(
+	data: VocalTrackData,
+	timedTempos: TimedTempos,
+	resolution: number,
+): NormalizedVocalPart {
+	const notePhrases = groupIntoPhrases(data.vocalPhrases, data, timedTempos, resolution)
+	return {
+		notePhrases,
+		staticLyricPhrases: data.staticLyricPhrases.length > 0
+			? groupIntoPhrases(data.staticLyricPhrases, data, timedTempos, resolution)
+			: notePhrases,
+		starPowerSections: setEventMsTimes(data.starPowerSections, timedTempos, resolution),
+	}
+}
+
+function groupIntoPhrases(
+	phrases: { tick: number; length: number }[],
+	data: VocalTrackData,
+	timedTempos: TimedTempos,
+	resolution: number,
+): NormalizedVocalPhrase[] {
+	// Dedup phrases by tick (both note 105 and 106 can create phrases at the same tick)
+	const dedupedPhrases: typeof phrases = []
+	const seenTicks = new Set<number>()
+	for (const p of phrases) {
+		if (!seenTicks.has(p.tick)) {
+			seenTicks.add(p.tick)
+			dedupedPhrases.push(p)
+		}
+	}
+	const timedPhrases = setEventMsTimes(dedupedPhrases, timedTempos, resolution)
+
+	// Sort lyrics by tick then by text (matching YARG's MoonText.InsertionCompareTo which
+	// uses .NET string.Compare — culture-aware, case-insensitive). This affects
+	// DeferredLyricJoinWorkaround and final lyricFlags when multiple lyrics share a tick.
+	const sortedLyrics = [...data.lyrics].sort((a, b) => {
+		if (a.tick !== b.tick) return a.tick - b.tick
+		return a.text.localeCompare(b.text)
+	})
+
+	let noteIdx = 0
+	/** Shared lyric index across all phrases (matching YARG's moonTextIndex pattern).
+	 *  Lyrics from skipped phrases carry over to the next phrase with notes. */
+	let lyricIdx = 0
+	/** End tick of the last note chain (including pitch slide extensions). Used for carry-over check. */
+	let carriedNoteEndTick = -1
+	/** Whether any lyric note has been seen across all phrases (YARG's previousParentLyric).
+	 *  Pitch slides can attach to the previous lyric note even across phrase boundaries. */
+	let hasPreviousLyricNote = false
+
+	const result: NormalizedVocalPhrase[] = []
+	for (const phrase of timedPhrases) {
+		const phraseEnd = phrase.tick + phrase.length
+
+		// Collect raw notes within this phrase
+		const rawNotes: typeof data.notes = []
+		while (noteIdx < data.notes.length && data.notes[noteIdx].tick < phraseEnd) {
+			if (data.notes[noteIdx].tick >= phrase.tick) {
+				rawNotes.push(data.notes[noteIdx])
+			}
+			noteIdx++
+		}
+
+		// Check if a pitch slide from a previous phrase carries into this one
+		const hasCarriedNote = carriedNoteEndTick >= phrase.tick
+
+		// Build notes and lyrics by iterating notes and collecting lyrics up to each note's tick
+		// (matching YARG's ProcessNoteEvent pattern where moonTextIndex is shared across phrases).
+		const notes: NormalizedVocalNote[] = []
+		const untimedLyrics: { tick: number; text: string; flags: number }[] = []
+		for (const note of rawNotes) {
+			// YARG only processes note 96 (percussion), not note 97 (percussionHidden/nonplayed)
+			if (note.type === 'percussionHidden') continue
+
+			// Skip percussion notes at the exact phrase start tick when it's the first note.
+			// In MIDI, noteOn for note 96 can arrive before noteOn for note 105 at the same tick,
+			// causing the percussion note to not be included in the phrase by YARG's normalizer.
+			if (note.type === 'percussion' && note.tick === phrase.tick && notes.length === 0) {
+				continue
+			}
+
+			// Collect all lyrics up to and including this note's tick
+			let noteLyricFlags = 0
+			while (lyricIdx < sortedLyrics.length && sortedLyrics[lyricIdx].tick <= note.tick) {
+				const lyric = sortedLyrics[lyricIdx]
+				lyricIdx++
+
+				// Trim ASCII whitespace (0x00-0x20) from both ends, matching YARG's
+				// NormalizeTextEvent.TrimAscii() which processes text before storage.
+				let text = lyric.text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
+
+				// Skip bracketed events — YARG's NormalizeTextEvent strips brackets and
+				// prevents bracketed FF 01 text events from becoming lyrics.
+				if (text.startsWith('[')) continue
+
+				let flags = parseLyricFlags(text)
+				noteLyricFlags = flags
+
+				// DeferredLyricJoinWorkaround: "+-" or "-+" merges the hyphen into the previous lyric
+				if (untimedLyrics.length > 0 && (text === '+-' || text === '-+')) {
+					const prev = untimedLyrics[untimedLyrics.length - 1]
+					if ((prev.flags & (lyricFlags.joinWithNext | lyricFlags.hyphenateWithNext)) === 0) {
+						untimedLyrics[untimedLyrics.length - 1] = {
+							...prev,
+							text: prev.text + '-',
+							flags: prev.flags | lyricFlags.joinWithNext,
+						}
+						text = '+'
+						flags = lyricFlags.pitchSlide
+						noteLyricFlags = flags
+					}
+				}
+
+				const strippedText = stripLyricSymbols(text)
+				// Skip lyrics that would be whitespace-only after _ → space replacement.
+				// Matches YARG's IsNullOrWhiteSpace check which runs on StripForVocals output
+				// (where _ is replaced with space).
+				if (strippedText.length > 0 && strippedText.replace(/_/g, ' ').trim().length > 0) {
+					untimedLyrics.push({ tick: lyric.tick, text: strippedText, flags })
+				}
+			}
+
+			const isPitchSlide = (noteLyricFlags & lyricFlags.pitchSlide) !== 0
+			const isNonPitched = (noteLyricFlags & lyricFlags.nonPitched) !== 0 ||
+				note.type === 'percussion'
+
+			if (isPitchSlide) {
+				const slideEnd = note.tick + note.length
+				if (notes.length > 0) {
+					// Within-phrase slide: merges with previousNote (a separate chain from carriedNote).
+					// Do NOT extend carriedNoteEndTick — previousNote is not necessarily the carriedNote.
+					// In YARG, AddChildNote only updates the parent it's called on, not other notes.
+					continue
+				}
+				if (hasCarriedNote) {
+					// Cross-phrase slide via carried note: skip, extend total end
+					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+					continue
+				}
+				// Cross-phrase slide via previousParentLyric (YARG behavior):
+				if (result.length === 0) {
+					// No phrases yet → charting error, skip
+					continue
+				}
+				if (hasPreviousLyricNote) {
+					// Add to previousParentLyric, set carriedNote
+					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+					continue
+				}
+			}
+
+			const timed = setEventMsTimes([note], timedTempos, resolution)[0]
+			notes.push({
+				tick: timed.tick,
+				msTime: timed.msTime,
+				length: timed.length,
+				msLength: timed.msLength,
+				pitch: isNonPitched ? -1 : note.pitch,
+				type: note.type,
+			})
+			if (note.type === 'pitched') hasPreviousLyricNote = true
+		}
+
+		// Re-check carried note state after processing all notes in this phrase.
+		// Pitch slides during this phrase may have set carriedNoteEndTick via previousParentLyric.
+		const hasCarriedNoteAfter = carriedNoteEndTick >= phrase.tick
+
+		// Skip phrases with no notes and no carried note (matching YARG behavior)
+		if (notes.length < 1 && !hasCarriedNote && !hasCarriedNoteAfter) {
+			continue
+		}
+
+		// Track carry-over: only from notes that were added to the phrase (not pitch slide children).
+		// YARG sets carriedNote at line 219-222, which only runs for notes that pass through
+		// the pitch slide `continue` paths. Pitch slide children don't reach this code.
+		for (const n of notes) {
+			// Find the raw note to get the original length
+			const raw = data.notes.find(r => r.tick === n.tick && r.type !== 'percussionHidden')
+			if (raw && raw.tick + raw.length > phraseEnd) {
+				carriedNoteEndTick = raw.tick + raw.length
+			}
+		}
+
+		const isPercussion = notes.length > 0 && notes[0].type === 'percussion'
+
+		result.push({
+			tick: phrase.tick,
+			msTime: phrase.msTime,
+			length: phrase.length,
+			msLength: phrase.msLength,
+			isPercussion,
+			notes,
+			lyrics: setEventMsTimes(untimedLyrics, timedTempos, resolution),
+		})
+	}
+	return result
 }
 
 function getTimedTempos(


### PR DESCRIPTION
# Vocal Normalization: YARG Compatibility Notes

This documents how scan-chart's vocal normalization (`notes-parser.ts`) matches and intentionally deviates from YARG's `MoonSongLoader.Vocals.cs`. Validated against 78,452 YARG dumps (99.95% match).

## Architecture

YARG has a two-stage pipeline:
1. **MoonSong** (Moonscraper layer): raw MIDI/chart data. Lyrics stored as text events with `"lyric "` prefix. Notes, phrases, and star power as separate lists per instrument x difficulty.
2. **VocalsTrack** (game layer): normalized vocals. Notes and lyrics grouped into phrases. Lyric symbols stripped into flags. Range shifts computed from note pitches.

scan-chart mirrors this:
1. **RawChartData.VocalTrackData**: flat lists (lyrics, notes, phrases, star power, range/lyric shifts). Internal, not exposed.
2. **ParsedChart.vocalTracks** (`NormalizedVocalTrack`): phrase-grouped structure matching YARG's VocalsTrack.

## Lyric Symbol Handling

### Flags (matching YARG's `LyricSymbolFlags`)

| Symbol | Position | Flag | Value |
|--------|----------|------|-------|
| `-` | trailing | `joinWithNext` | 1 |
| `=` | trailing | `hyphenateWithNext` | 256 |
| `+` | trailing | `pitchSlide` | 16 |
| `#` | trailing | `nonPitched` | 2 |
| `^` | trailing | `nonPitched \| lenientScoring` | 6 |
| `*` | trailing | `nonPitched` | 2 |
| `%` | trailing | `rangeShift` | 128 |
| `/` | trailing | `staticShift` | 64 |
| `$` | both start and trailing | `harmonyHidden` | 32 |

Flag detection scans from end of text, consuming symbols until a non-symbol character. `$` is checked at BOTH start and end (matching YARG's `GetLyricFlags`).

### Symbol stripping (matching YARG's `StripForVocals`)

- **Stripped entirely**: `+`, `#`, `^`, `*`, `%`, `/`, `$`, `"`
- **Trailing `-`**: kept in display text (it's a visual hyphen, not just a flag)
- **`=`**: replaced with `-` everywhere (hyphenate display)
- **Known rich text tags**: stripped (`<i>`, `<b>`, `<color=...>`, etc. — 36 known tag names matching YARG's `RichTextUtils.RICH_TEXT_TAGS`)
- **Unknown angle brackets**: kept (e.g., `<scatting>` is real lyric content)
- **Leading ASCII whitespace (0x00-0x20)**: trimmed (matching YARG's `TrimStartAscii` in `ProcessLyric`)

### Intentional deviations from YARG

| What | YARG behavior | Our behavior | Reason |
|------|---------------|--------------|--------|
| `_` in lyrics | Replaced with space | **Kept as-is** | Lossy — real charts use `_` as apostrophe (`"it_s"`, `"can_t"`), not just word boundary. Consumer decides display. |
| `§` in lyrics | Replaced with `‿` | **Kept as-is** | Lossy — can't distinguish original `‿` from converted `§` when writing back. |
| Tick-0 `"PART VOCALS"` text | Kept as a lyric | **Filtered out** | YARG's `ProcessTextEvent` wraps it with `"lyric "` prefix, making it look like a lyric. This is arguably a YARG bug — track name text events aren't lyrics. |

## Phrase Grouping

### Core algorithm

Mirrors YARG's `GetVocalsPhrases`:
- Shared `noteIdx` and `lyricIdx` across all phrases (matching YARG's `moonNoteIndex`/`moonTextIndex`)
- Lyrics from skipped (empty) phrases carry over to the next phrase with notes
- Phrases deduplicated by tick (both MIDI note 105 and 106 at same tick produce one phrase)
- Empty phrases (no notes) skipped unless a carried note is active

### Pitch slide handling

| YARG concept | Our implementation |
|--------------|-------------------|
| `previousNote` (within phrase) | If `notes.length > 0` and pitch slide → skip note |
| `carriedNote` (cross-phrase) | `carriedNoteEndTick` tracks the furthest end tick of the carried note chain |
| `previousParentLyric` (cross-phrase) | `hasPreviousLyricNote` boolean — enables pitch slides across phrase boundaries when no carried note exists |
| `carriedNote.TotalTickLength` | Updated when pitch slides extend the carried note via `hasCarriedNote` or `previousParentLyric` paths. NOT updated in the `previousNote` path (those are separate chains). |
| Pitch slide as first note, no previous phrases | Skipped (YARG: `phrases.Count == 0` → charting error) |

### `DeferredLyricJoinWorkaround`

YARG has a workaround for badly-formatted charts where `"+-"` or `"-+"` appears as a lyric. When detected:
1. Previous lyric gets `-` appended and `joinWithNext` flag set
2. Current lyric reduced to `"+"` (which strips to empty and is skipped)

We replicate this in the normalization loop.

### Lyric sorting within same tick

YARG's `MoonText.InsertionCompareTo` uses .NET `string.Compare` (culture-aware, case-insensitive). We use `localeCompare` to match. This matters for charts with multiple lyrics at the same tick (e.g., "Pink Guy - STFU" has `"Shut#"`, `"fuck#"`, `"the#"` at the same tick).

### Percussion notes

- **Note 97 (`percussionHidden`)**: excluded from normalized output (YARG's `NONPLAYED_PERCUSSION_NOTE` is not processed by the normalizer)
- **Note 96 (`percussion`)**: included. `isPercussion` on the phrase is determined by checking the first note's type.
- **Percussion at phrase start tick**: skipped when it's the first note in the phrase. In MIDI, `noteOn` for note 96 can arrive before `noteOn` for note 105 (phrase marker) at the same tick. YARG's MidReader processes them in MIDI order, so the percussion note is created before the phrase opens, and the normalizer doesn't include it.

### Non-pitched notes

When a lyric has the `nonPitched` flag (`#`, `^`, `*`), the corresponding note gets `pitch = -1` in the normalized output (matching YARG's `GetVocalNotePitch` which returns -1 for non-pitched).

### Zero-length note handling

YARG's `extractMidiNotePairs` preserves MIDI event order at the same tick, while phrase extraction sorts `noteOff` before `noteOn`. This distinction matters for zero-length notes (noteOn+noteOff at same tick for the same pitch):

- **Phrase extraction (note 105/106)**: `noteOff` before `noteOn` at same tick (old phrase closes before new opens)
- **Vocal note extraction (36-84, 96, 97)**: preserve MIDI order (`noteOn` before `noteOff` at same tick). This correctly handles zero-length notes as duplicate `noteOn` events (ignored), rather than close-then-reopen (which steals the next noteOff).

Real example: "The Lumineers - Ho Hey" has a zero-length note 60 at tick 49840 that, without this fix, would steal the noteOff at 55080 from the real note at 54880.

## Bracketed events

In the normalization layer, events starting with `[` after ASCII trim are skipped from lyric processing. This matches YARG's `NormalizeTextEvent` which strips brackets from FF 01 text events — if brackets were present, the event is NOT treated as a lyric on PART VOCALS.

Note: this is separate from `extractMidiLyrics` in `lyric-parser.ts`, which uses an allowlist of known control events (`[play]`, `[idle]`, etc.) for the raw data layer. The normalization adds the broader bracket filter on top.

## Star power, range shifts, lyric shifts

Stored as separate arrays on `NormalizedVocalPart` (star power) and `NormalizedVocalTrack` (range/lyric shifts), NOT as per-phrase flags. This differs from YARG which stores star power as a `NoteFlags.StarPower` flag on each phrase's parent note.

Rationale: matches scan-chart's convention for all instrument tracks, and preserves original section boundaries for writing back to .mid/.chart.

Range shifts and lyric shifts are at the **track level** (shared across parts), matching YARG — only PART VOCALS / HARM1 has range shifts, HARM2/3 inherit them.

## Harmony handling

### CopyDown (from midi-parser.ts)

- HARM2/3 `vocalPhrases` are replaced with HARM1's (scoring phrases)
- HARM2/3 `starPowerSections` are replaced with HARM1's
- HARM2/3 original note-106 phrases become `staticLyricPhrases`
- HARM1 `staticLyricPhrases` = copy of `notePhrases`

### 105 vs 106 distinction

Encoded implicitly: `notePhrases` = note 105 (scoring), `staticLyricPhrases` = note 106 (static display on HARM2/3). For writing back: write `notePhrases` as note 105 on the owning track, `staticLyricPhrases` as note 106 on HARM2/3.

## Writing back (chart-edit considerations)

The normalized structure is designed to be lossless for writing:

| Data | How to reconstruct |
|------|--------------------|
| Lyric symbols | Append symbol based on flags (`joinWithNext` → `-`, `pitchSlide` → `+`, etc.) |
| `_` and `§` | Kept as-is in normalized text — no reconstruction needed |
| Star power | Original section boundaries in `starPowerSections` |
| Range shifts | Length 0 → write `%` in .chart lyric; length >0 → write MIDI note 0 |
| Lyric shifts | Write as MIDI note 1 |
| 105 vs 106 | `notePhrases` → note 105, `staticLyricPhrases` → note 106 on HARM2/3 |
| `=` (hyphenate) | `hyphenateWithNext` flag distinguishes from `-` (`joinWithNext`) |

## Known YARG bugs

1. **Tick-0 track name as lyric**: `"PART VOCALS"` FF 01 text event at tick 0 gets `"lyric "` prefix and is treated as a lyric. Affects ~20 charts.

2. **`_` replacement**: `_` is replaced with space universally, but real charts use `_` as apostrophe substitute (`"it_s"`, `"can_t"`, `"you_re"`). The replacement produces incorrect display text (`"it s"` instead of `"it's"`).

3. **Bracket stripping in lyrics**: YARG's `NormalizeTextEvent` strips brackets from all text events. For FF 05 lyrics events, `text.Contains('[')` filters them. This incorrectly strips real lyric content like `"[Everyone liked that]"` (a Fallout reference). Our raw extraction layer (`isMidiVocalLyric`) uses an allowlist of known control events instead.

## Remaining edge cases (4 charts)

| Chart | Issue | Root cause |
|-------|-------|------------|
| Sepultura - Dead Embryonic Cells (x2) | 3 missing phrases | MIDI puts note 105 before note 96 at same tick; our percussion-at-phrase-start heuristic skips the percussion note, but YARG keeps it because the phrase is already open |
| DragonForce - Heart Demolition | 3 missing phrases | Same as Sepultura |
| Sungazer - All These People | 1 extra note | Complex pitch slide ordering edge case |
