### PR TITLE
Round-trip extraChartSongFields / unrecognizedSyncTrackEvents / unrecognizedEventsTrackMidiEvents

### DIFF
--- a/src/ini/ini-scanner.ts
+++ b/src/ini/ini-scanner.ts
@@ -276,19 +276,27 @@ function getIniInteger(songSection: { [key: string]: string }, key: MetaNumberKe
  * Then falls back to the default value if `legacyKey` is not found or invalid.
  */
 function getIniBoolean(songSection: { [key: string]: string }, key: MetaBooleanKey, legacyKey?: Exclude<InputMetaBooleanKey, MetaBooleanKey>) {
-	const value = songSection[key]
-	if (value === 'True' || value === '1') {
-		return true
-	} else if (value === 'False' || value === '0') {
-		return false
+	const parsed = parseBoolean(songSection[key])
+	if (parsed !== null) {
+		return parsed
 	} else if (legacyKey) {
-		const legacyValue = songSection[legacyKey]
-		if (legacyValue === 'True' || legacyValue === '1') {
-			return true
-		} else if (legacyValue === 'False' || legacyValue === '0') {
-			return false
+		const legacyParsed = parseBoolean(songSection[legacyKey])
+		if (legacyParsed !== null) {
+			return legacyParsed
 		}
 	}
 
 	return defaultMetadata[key]
+}
+
+/**
+ * Clone Hero and YARG both accept ini booleans in any case (e.g. `true`, `True`, `TRUE`).
+ * @returns `true`/`false` if `value` is a recognized boolean literal, or `null` otherwise.
+ */
+function parseBoolean(value: string | undefined): boolean | null {
+	if (value === undefined) return null
+	const lowered = value.toLowerCase()
+	if (lowered === 'true' || lowered === '1') return true
+	if (lowered === 'false' || lowered === '0') return false
+	return null
 }


### PR DESCRIPTION
Stacked on top of #78 (ChartDocument + writeChartFolder). Depends on #68 through #78 merging first.

## Summary

The parser preserves three round-trip buckets that landed after the writer stack was authored (#118, #120, #121):

- **\`metadata.extraChartSongFields\`** — unknown \`[Song]\` keys from \`.chart\` sources.
- **\`unrecognizedSyncTrackEvents\`** — \`[SyncTrack]\` lines that aren't \`B\` / \`TS\` (today: tempo anchors \`A <microseconds>\`, plus anything future).
- **\`unrecognizedEventsTrackMidiEvents\`** — non-text MIDI events on the EVENTS track (Rock Band practice-mode assist-sample notes 24/25/26, stray sysex / channel / meta events).

This PR makes \`writeChartFile\` and \`writeMidiFile\` actually emit them.

## Changes

- **\`writeChartFile\` / \`[Song]\`** — appends \`extraChartSongFields\` entries at the tail of the section. Values written verbatim (no quoting added or stripped). Editors should not synthesize or modify these — this is strictly a round-trip aid for tools like Moonscraper that author deprecated fields (\`Player2\`, \`HoPo\`, \`PreviewEnd\`, audio-stream filenames, etc.). Audio file discovery should go through folder scan, not \`[Song].*Stream\` values.

- **\`writeChartFile\` / \`[SyncTrack]\`** — emits \`unrecognizedSyncTrackEvents\` alongside tempos and time signatures, sorted by tick (TS < B < raw at the same tick for determinism). Text written verbatim as \`\${tick} = \${text}\`, so tempo anchors and any future \`[SyncTrack]\` event types survive parse → write without a parser change.

- **\`writeMidiFile\` / EVENTS track** — appends \`unrecognizedEventsTrackMidiEvents\` after sections / end events / unrecognized text events / coda. Events arrive with absolute-tick \`deltaTime\` (scan-chart post-process) and get re-deltified by \`finalizeMidiTrack\`.

Cross-format drops (\`extraChartSongFields\` and \`unrecognizedSyncTrackEvents\` are lost on \`.mid\` output; \`unrecognizedEventsTrackMidiEvents\` is lost on \`.chart\` output) are pinned by contract tests so a future writer change can't smuggle them through as something else.

## Test plan

- [x] 11 new tests in \`src/__tests__/round-trip-unrecognized-extras.test.ts\` cover: legacy \`[Song]\` fields preserved, quoted string values (parser-strips-quotes contract), forward-compat for unknown \`[Song]\` keys, tempo anchor round-trip, forward-compat for unknown \`[SyncTrack]\` event types, co-existence with tempos/TS at the same tick, RB practice-assist notes 24/25/26 round-trip, empty defaults, and cross-format drop contracts.
- [x] **1020/1020 tests pass** (1009 existing + 11 new).
- [x] No new \`tsc --noEmit\` errors introduced.

## Notes for review

The stack below this PR was rebased on current \`master\` (which now has #118/#120/#121). A few writer stack commits were amended to update \`chart.unrecognizedEvents\` → \`chart.unrecognizedEventsTrackTextEvents\` references. Those are minor rename updates, not behavior changes.