### PR TITLE
[WIP, has hash changes] Vocal phrase refactor with supporting parser improvements

### DIFF
--- a/src/__tests__/drum-pads.test.ts
+++ b/src/__tests__/drum-pads.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Tests for drum pad parsing across 4-lane, 4-lane-pro, and 5-lane drum types.
+ *
+ * The scan-chart parser has subtle rules for mapping MIDI drum notes (96–101)
+ * to the public `noteTypes` enum depending on drumType:
+ *
+ *   - 4-lane / 4-lane-pro: MIDI 100 → greenDrum (4th lane)
+ *   - 5-lane:              MIDI 100 → greenDrum with `cymbal` flag (orange, 4th lane)
+ *                          MIDI 101 → greenDrum with `tom` flag (5th lane) if the
+ *                                     chord does NOT also contain MIDI 100
+ *                                   → blueDrum with `tom` flag (5th lane) if the
+ *                                     chord DOES contain MIDI 100 (hasOrangeAndGreen)
+ *
+ * The scan-chart public `noteTypes` enum only has 4 drum slots (kick, redDrum,
+ * yellowDrum, blueDrum, greenDrum), so 5-lane drums are represented ambiguously
+ * and must be disambiguated by the `tom`/`cymbal` flag plus chord co-occurrence.
+ *
+ * These tests document and lock in that behavior so it round-trips correctly
+ * through consumers like chart-edit's writer.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { writeMidi, MidiData } from 'midi-file'
+import { parseChartFile } from '../chart/notes-parser'
+import { noteTypes, noteFlags } from '../chart/note-parsing-interfaces'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMidi(ticksPerBeat: number, tracks: MidiData['tracks']): Uint8Array {
+	const data: MidiData = {
+		header: { format: 1, numTracks: tracks.length, ticksPerBeat },
+		tracks,
+	}
+	return new Uint8Array(writeMidi(data))
+}
+
+function tempoTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: '' },
+		{ deltaTime: 0, type: 'setTempo', microsecondsPerBeat: 500000 },
+		{ deltaTime: 0, type: 'timeSignature', numerator: 4, denominator: 4, metronome: 24, thirtyseconds: 8 },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+function eventsTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+type TimedEvent = { absTick: number; event: MidiData['tracks'][number][number] }
+
+/** Build a PART DRUMS track with notes at absolute ticks (delta-times computed automatically). */
+function drumsTrack(opts: {
+	notes: { tick: number; noteNumber: number; length?: number; velocity?: number }[]
+}): MidiData['tracks'][number] {
+	const track: MidiData['tracks'][number] = [
+		{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+	]
+	const timed: TimedEvent[] = []
+	for (const n of opts.notes) {
+		const len = n.length ?? 0
+		timed.push({
+			absTick: n.tick,
+			event: { deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: n.noteNumber, velocity: n.velocity ?? 100 },
+		})
+		timed.push({
+			absTick: n.tick + (len || 1),
+			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: n.noteNumber, velocity: 0 },
+		})
+	}
+	timed.sort((a, b) => a.absTick - b.absTick)
+	let prev = 0
+	for (const te of timed) {
+		te.event.deltaTime = te.absTick - prev
+		prev = te.absTick
+		track.push(te.event)
+	}
+	track.push({ deltaTime: 0, type: 'endOfTrack' })
+	return track
+}
+
+/** Parse a drums-only MIDI with the given ini modifiers and return the expert track. */
+function parseDrumsExpert(midi: Uint8Array, modifiers: { pro_drums?: boolean; five_lane_drums?: boolean } = {}) {
+	const parsed = parseChartFile(midi, 'mid', modifiers)
+	return parsed.trackData.find(t => t.instrument === 'drums' && t.difficulty === 'expert')!
+}
+
+/** Return chord at tick as array of {type, flags} (sorted by type for stable assertions). */
+function chordAt(track: ReturnType<typeof parseDrumsExpert>, tick: number) {
+	const group = track.noteEventGroups.find(g => g[0]?.tick === tick)
+	if (!group) return null
+	return group
+		.map(n => ({ type: n.type, flags: n.flags }))
+		.sort((a, b) => a.type - b.type || a.flags - b.flags)
+}
+
+// Drum expert base: drumsDiffStarts.expert = 96
+const KICK = 96
+const RED = 97
+const YELLOW = 98
+const BLUE = 99
+const ORANGE_OR_GREEN = 100 // 4-lane green / 5-lane orange
+const FIVE_GREEN = 101
+
+// ---------------------------------------------------------------------------
+// 4-lane drums
+// ---------------------------------------------------------------------------
+
+describe('MIDI: 4-lane drums pad mapping', () => {
+	it('maps kick/red/yellow/blue/green to the 5 canonical noteTypes', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: KICK },
+					{ tick: 960, noteNumber: RED },
+					{ tick: 1440, noteNumber: YELLOW },
+					{ tick: 1920, noteNumber: BLUE },
+					{ tick: 2400, noteNumber: ORANGE_OR_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi) // no ini → default detection
+
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.kick, flags: noteFlags.none }])
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.redDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 1440)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 1920)).toEqual([{ type: noteTypes.blueDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 2400)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+
+	it('treats all non-kick drums as tom (no tom markers present)', () => {
+		// 4-lane (pro_drums=false, no cymbal markers) marks every pad as tom.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: YELLOW },
+					{ tick: 960, noteNumber: BLUE },
+					{ tick: 1440, noteNumber: ORANGE_OR_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi)
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.blueDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 1440)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// 4-lane-pro drums
+// ---------------------------------------------------------------------------
+
+describe('MIDI: 4-lane-pro drums pad mapping', () => {
+	it('marks yellow/blue/green as cymbal by default, tom with marker', () => {
+		// Yellow tom marker = MIDI 110, blue = 111, green = 112. Without a
+		// marker, yellow/blue/green default to cymbal in 4-lane-pro.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					// Unmarked yellow/blue/green → cymbal
+					{ tick: 480, noteNumber: YELLOW },
+					{ tick: 480, noteNumber: BLUE },
+					{ tick: 480, noteNumber: ORANGE_OR_GREEN },
+					// Marked yellow → tom (using a sustained yellowTomMarker)
+					{ tick: 960, noteNumber: YELLOW },
+					{ tick: 960, noteNumber: 110, length: 120 },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { pro_drums: true })
+
+		const chord480 = chordAt(track, 480)!
+		expect(chord480).toContainEqual({ type: noteTypes.yellowDrum, flags: noteFlags.cymbal })
+		expect(chord480).toContainEqual({ type: noteTypes.blueDrum, flags: noteFlags.cymbal })
+		// In 4-lane-pro MIDI, green (MIDI 100) is also cymbal by default — only
+		// becomes tom if a greenTomMarker range covers it.
+		expect(chord480).toContainEqual({ type: noteTypes.greenDrum, flags: noteFlags.cymbal })
+
+		// Yellow-tom-marker: the 110 note range covers the yellow at 960.
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.tom }])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// 5-lane drums — the interesting cases
+// ---------------------------------------------------------------------------
+
+describe('MIDI: 5-lane drums pad mapping', () => {
+	// The bug that motivated these tests: chord with MIDI 100 (orange) +
+	// MIDI 101 (5L green) collapses to `greenDrum + blueDrum`, not two greens.
+	// Consumers must be able to re-derive the MIDI note from the chord shape.
+
+	it('MIDI 100 alone → orangeDrum with cymbal flag (4th pad)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({ notes: [{ tick: 480, noteNumber: ORANGE_OR_GREEN }] }),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		// In 5-lane, MIDI 100 is the orange pad (4th lane). The tom/cymbal
+		// flag is cosmetic in 5-lane — pads don't have tom/cymbal semantics.
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.orangeDrum, flags: noteFlags.cymbal }])
+	})
+
+	it('MIDI 101 alone → greenDrum with tom flag (5th pad)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({ notes: [{ tick: 480, noteNumber: FIVE_GREEN }] }),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		// In 5-lane, MIDI 101 is the green pad (5th lane). Always greenDrum,
+		// regardless of what else is in the chord.
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+
+	it('MIDI 99 alone → blueDrum with tom flag (blue pad)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({ notes: [{ tick: 480, noteNumber: BLUE }] }),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.blueDrum, flags: noteFlags.tom }])
+	})
+
+	it('MIDI 99 + 101 chord (blue + 5L green, no orange) → blueDrum + greenDrum', () => {
+		// Blue + 5L-green chord. With the new noteType split, the output is
+		// unambiguous — no dependence on chord composition.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: BLUE },
+					{ tick: 480, noteNumber: FIVE_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		expect(chordAt(track, 480)).toEqual([
+			{ type: noteTypes.blueDrum, flags: noteFlags.tom },
+			{ type: noteTypes.greenDrum, flags: noteFlags.tom },
+		])
+	})
+
+	it('MIDI 99 + 100 chord (blue + orange) → blueDrum + orangeDrum (Avenged Sevenfold regression)', () => {
+		// Avenged Sevenfold - Scream (Neversoft) has this chord pattern.
+		// Before the orangeDrum split, scan-chart mapped MIDI 100 to greenDrum
+		// and could not distinguish {MIDI 99 + MIDI 100} from {MIDI 100 + MIDI 101}.
+		// Now the output is {blueDrum, orangeDrum} — cleanly distinct from
+		// {orangeDrum, greenDrum} (which would be the Ben Harper chord).
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: BLUE },
+					{ tick: 480, noteNumber: ORANGE_OR_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		expect(chordAt(track, 480)).toEqual([
+			{ type: noteTypes.blueDrum, flags: noteFlags.tom },
+			{ type: noteTypes.orangeDrum, flags: noteFlags.cymbal },
+		])
+	})
+
+	it('MIDI 100 + 101 chord (orange + 5L green, no blue) → orangeDrum + greenDrum (Ben Harper regression)', () => {
+		// Ben Harper - Number with No Name (Neversoft) activator chord.
+		// Verifies that a {MIDI 100, MIDI 101} chord on 5-lane drums emits
+		// {orangeDrum, greenDrum} as two distinct pads — without collapsing
+		// into a single pad and without colliding with the Avenged Sevenfold
+		// {MIDI 99, MIDI 100} = {blueDrum, orangeDrum} chord.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: ORANGE_OR_GREEN },
+					{ tick: 480, noteNumber: FIVE_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		// Sorted by type asc: greenDrum (17) before orangeDrum (18)
+		expect(chordAt(track, 480)).toEqual([
+			{ type: noteTypes.greenDrum, flags: noteFlags.tom },
+			{ type: noteTypes.orangeDrum, flags: noteFlags.cymbal },
+		])
+	})
+
+	it('star-power activator chord with kick + orange + 5L green (Ben Harper full regression)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: KICK },
+					{ tick: 480, noteNumber: ORANGE_OR_GREEN },
+					{ tick: 480, noteNumber: FIVE_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		// Sorted by type asc: kick(13) < greenDrum(17) < orangeDrum(18)
+		expect(chordAt(track, 480)).toEqual([
+			{ type: noteTypes.kick, flags: noteFlags.none },
+			{ type: noteTypes.greenDrum, flags: noteFlags.tom },
+			{ type: noteTypes.orangeDrum, flags: noteFlags.cymbal },
+		])
+	})
+
+	it('full 5-lane chord with all 5 pads at distinct ticks', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: RED },
+					{ tick: 960, noteNumber: YELLOW },
+					{ tick: 1440, noteNumber: BLUE },
+					{ tick: 1920, noteNumber: ORANGE_OR_GREEN }, // 5L orange
+					{ tick: 2400, noteNumber: FIVE_GREEN }, // 5L green
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { five_lane_drums: true })
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.redDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.cymbal }])
+		expect(chordAt(track, 1440)).toEqual([{ type: noteTypes.blueDrum, flags: noteFlags.tom }])
+		expect(chordAt(track, 1920)).toEqual([{ type: noteTypes.orangeDrum, flags: noteFlags.cymbal }])
+		expect(chordAt(track, 2400)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+
+	it('detects 5-lane automatically when MIDI 101 is present (no ini hint)', () => {
+		// Without five_lane_drums or pro_drums in the ini, scan-chart falls
+		// through to "5-lane if any fiveGreenDrum event exists". This test
+		// locks in that auto-detection path.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: YELLOW },
+					{ tick: 960, noteNumber: FIVE_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi)
+		// In 5-lane mode, yellow is cymbal.
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.cymbal }])
+		// fiveGreenDrum alone → greenDrum + tom.
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+
+	describe('noteOn/noteOff pairing (BTrack spec)', () => {
+		// The BTrack spec says:
+		//   "Each end event is paired with the closest previous start event that
+		//    (1) hasn't been paired yet, (2) has the same event type, and (3) has
+		//    the same midi channel (if applicable). Events must be composed of
+		//    both a start and an end event; unpaired start and end events are
+		//    ignored."
+		// i.e. LIFO (stack) pairing, with unpaired starts/ends dropped.
+
+		it('on(t1), on(t2), off → off pairs with on(t2); on(t1) unpaired and dropped', () => {
+			// For "Battles - Atlas (Dichotic)": a MIDI file that writes a
+			// duplicate noteOn at the same tick as the prior sustain's noteOff,
+			// in `on, on, off` order. Per spec, the off pairs with the most
+			// recent unpaired on (tick 960). The tick-480 start is unpaired and
+			// gets dropped. Result: a single zero-length note at tick 960.
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 96, velocity: 100 },
+				{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 96, velocity: 0 },
+				{ deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseDrumsExpert(midi, { pro_drums: true })
+
+			// No note group at tick 480 — the unpaired start was dropped.
+			expect(parsed.noteEventGroups.find(g => g[0].tick === 480)).toBeUndefined()
+
+			// Tick 960 has kick + zero-length green drum.
+			const g960 = parsed.noteEventGroups.find(g => g[0].tick === 960)!
+			expect(g960).toBeDefined()
+			const green = g960.find(n => n.type === noteTypes.greenDrum)!
+			expect(green).toBeDefined()
+			expect(green.length).toBe(0)
+			const kick = g960.find(n => n.type === noteTypes.kick)!
+			expect(kick).toBeDefined()
+		})
+
+		it('on, off, on, off on same note → two sequential notes, no ambiguity', () => {
+			// Baseline: properly paired back-to-back notes work correctly.
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseDrumsExpert(midi, { pro_drums: true })
+
+			const g480 = parsed.noteEventGroups.find(g => g[0].tick === 480)!
+			expect(g480).toHaveLength(1)
+			expect(g480[0].type).toBe(noteTypes.greenDrum)
+			expect(g480[0].length).toBe(480)
+
+			const g960 = parsed.noteEventGroups.find(g => g[0].tick === 960)!
+			expect(g960).toHaveLength(1)
+			expect(g960[0].type).toBe(noteTypes.greenDrum)
+			expect(g960[0].length).toBe(480)
+		})
+
+		it('on, on, off, off → both starts kept; offs pair LIFO', () => {
+			// Spec: first off pairs with most recent on (tick 960). Second off
+			// pairs with the remaining on (tick 480). Both notes are kept
+			// (overlap resolution runs later and clamps the earlier note's end
+			// to the later note's start).
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 }, // t=480
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 }, // t=960
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },  // t=1440 — pairs with 960 start (LIFO)
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },  // t=1920 — pairs with 480 start
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseDrumsExpert(midi, { pro_drums: true })
+
+			// Both starts survive (the LIFO pairing doesn't drop either).
+			const g480 = parsed.noteEventGroups.find(g => g[0].tick === 480)!
+			expect(g480).toBeDefined()
+			expect(g480.some(n => n.type === noteTypes.greenDrum)).toBe(true)
+			const g960 = parsed.noteEventGroups.find(g => g[0].tick === 960)!
+			expect(g960).toBeDefined()
+			expect(g960.some(n => n.type === noteTypes.greenDrum)).toBe(true)
+		})
+
+		it('off with no matching on → unpaired off is dropped', () => {
+			// Unpaired noteOff (velocity-0 noteOn) with nothing to close.
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseDrumsExpert(midi, { pro_drums: true })
+
+			// Only the 960→1440 note should exist.
+			const g960 = parsed.noteEventGroups.find(g => g[0].tick === 960)!
+			expect(g960).toBeDefined()
+			expect(g960[0].type).toBe(noteTypes.greenDrum)
+			expect(g960[0].length).toBe(480)
+			expect(parsed.noteEventGroups).toHaveLength(1)
+		})
+
+		it('on with no matching off → unpaired start at end of track is dropped', () => {
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				// No matching noteOff before endOfTrack.
+				{ deltaTime: 960, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			// The unpaired start leaves 0 drum notes. The drums track is omitted
+			// entirely from trackData because empty tracks are filtered out.
+			const track_ = parseDrumsExpert(midi, { pro_drums: true })
+			expect(track_).toBeUndefined()
+		})
+
+		it('pairing is per-channel: different-channel off does not close a different-channel on', () => {
+			// on ch=0, on ch=1, off ch=0 (closes ch=0), off ch=1 (closes ch=1).
+			// All on note 100 (greenDrum).
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 0, type: 'noteOn', channel: 1, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 240, type: 'noteOff', channel: 1, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseDrumsExpert(midi, { pro_drums: true })
+
+			// Both starts at tick 480 survive — one per channel.
+			const g480 = parsed.noteEventGroups.find(g => g[0].tick === 480)!
+			expect(g480).toBeDefined()
+			// Both greenDrum entries exist with different lengths (ch0=480, ch1=720).
+			const greens = g480.filter(n => n.type === noteTypes.greenDrum)
+			expect(greens.length).toBeGreaterThanOrEqual(1)
+		})
+
+		it('emits `orphanedNoteStart` parse issue when a noteOn has no matching noteOff', () => {
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				// No matching noteOff.
+				{ deltaTime: 960, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseChartFile(midi, 'mid', { pro_drums: true })
+			const orphanStarts = parsed.parseIssues.filter(i => i.noteIssue === 'orphanedNoteStart')
+			expect(orphanStarts.length).toBeGreaterThanOrEqual(1)
+			expect(orphanStarts[0].instrument).toBe('drums')
+		})
+
+		it('emits `orphanedNoteEnd` parse issue when a noteOff has no matching noteOn', () => {
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 }, // orphan
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseChartFile(midi, 'mid', { pro_drums: true })
+			const orphanEnds = parsed.parseIssues.filter(i => i.noteIssue === 'orphanedNoteEnd')
+			expect(orphanEnds.length).toBeGreaterThanOrEqual(1)
+			expect(orphanEnds[0].instrument).toBe('drums')
+		})
+
+		it('emits no orphan parse issues when all notes are properly paired', () => {
+			const track: MidiData['tracks'][number] = [
+				{ deltaTime: 0, type: 'trackName', text: 'PART DRUMS' },
+				{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 100, velocity: 100 },
+				{ deltaTime: 480, type: 'noteOff', channel: 0, noteNumber: 100, velocity: 0 },
+				{ deltaTime: 0, type: 'endOfTrack' },
+			]
+			const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+			const parsed = parseChartFile(midi, 'mid', { pro_drums: true })
+			const orphanIssues = parsed.parseIssues.filter(i =>
+				i.noteIssue === 'orphanedNoteStart' || i.noteIssue === 'orphanedNoteEnd')
+			expect(orphanIssues).toHaveLength(0)
+		})
+	})
+
+	it('prefers ini pro_drums over automatic 5-lane detection', () => {
+		// If both ini says pro_drums=true AND chart has fiveGreenDrum events,
+		// the ini wins and we get 4-lane-pro semantics (no 5th lane).
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			drumsTrack({
+				notes: [
+					{ tick: 480, noteNumber: YELLOW },
+					{ tick: 960, noteNumber: FIVE_GREEN },
+				],
+			}),
+		])
+		const track = parseDrumsExpert(midi, { pro_drums: true })
+		// In 4-lane-pro, unmarked yellow is cymbal.
+		expect(chordAt(track, 480)).toEqual([{ type: noteTypes.yellowDrum, flags: noteFlags.cymbal }])
+		// fiveGreenDrum in 4-lane-pro still maps to greenDrum with tom flag.
+		expect(chordAt(track, 960)).toEqual([{ type: noteTypes.greenDrum, flags: noteFlags.tom }])
+	})
+})

--- a/src/__tests__/guitar-force-modifiers.test.ts
+++ b/src/__tests__/guitar-force-modifiers.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for guitar force modifier parsing (forceHopo, forceStrum, forceTap).
+ *
+ * All force modifier sustains in YARG.Core's MidReader are END-EXCLUSIVE:
+ * the range covers `[start, end - 1]` after YARG's `if (endTick > startTick) --endTick`
+ * decrement. scan-chart must match, otherwise back-to-back modifier phrases (very
+ * common in FreeStyleGames/Neversoft charts) overlap by one tick and the last
+ * note of one phrase accidentally inherits the next phrase's force.
+ *
+ * These tests also lock in the resolution order when multiple conflicting
+ * force modifiers overlap on the same note.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { writeMidi, MidiData } from 'midi-file'
+import { parseChartFile } from '../chart/notes-parser'
+import { noteTypes, noteFlags } from '../chart/note-parsing-interfaces'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMidi(ticksPerBeat: number, tracks: MidiData['tracks']): Uint8Array {
+	return new Uint8Array(writeMidi({
+		header: { format: 1, numTracks: tracks.length, ticksPerBeat },
+		tracks,
+	}))
+}
+
+function tempoTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: '' },
+		{ deltaTime: 0, type: 'setTempo', microsecondsPerBeat: 500000 },
+		{ deltaTime: 0, type: 'timeSignature', numerator: 4, denominator: 4, metronome: 24, thirtyseconds: 8 },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+function eventsTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+type TimedEvent = { absTick: number; order: number; event: MidiData['tracks'][number][number] }
+
+function guitarTrack(difficulty: 'easy' | 'expert', opts: {
+	notes: { tick: number; noteNumber: number; length?: number; velocity?: number }[]
+}): MidiData['tracks'][number] {
+	const track: MidiData['tracks'][number] = [
+		{ deltaTime: 0, type: 'trackName', text: 'PART GUITAR' },
+	]
+	const timed: TimedEvent[] = []
+	let seq = 0
+	for (const n of opts.notes) {
+		const len = n.length ?? 0
+		timed.push({
+			absTick: n.tick,
+			order: seq++,
+			event: { deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: n.noteNumber, velocity: n.velocity ?? 100 },
+		})
+		timed.push({
+			absTick: n.tick + (len || 1),
+			order: seq++,
+			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: n.noteNumber, velocity: 0 },
+		})
+	}
+	// Stable sort by tick, then by original insertion order so the test can
+	// control fine-grained event ordering within a single tick.
+	timed.sort((a, b) => a.absTick - b.absTick || a.order - b.order)
+	let prev = 0
+	for (const te of timed) {
+		te.event.deltaTime = te.absTick - prev
+		prev = te.absTick
+		track.push(te.event)
+	}
+	track.push({ deltaTime: 0, type: 'endOfTrack' })
+	return track
+}
+
+function parseGuitarExpert(midi: Uint8Array) {
+	const parsed = parseChartFile(midi, 'mid')
+	return parsed.trackData.find(t => t.instrument === 'guitar' && t.difficulty === 'expert')!
+}
+
+function parseGuitarEasy(midi: Uint8Array) {
+	const parsed = parseChartFile(midi, 'mid')
+	return parsed.trackData.find(t => t.instrument === 'guitar' && t.difficulty === 'easy')!
+}
+
+// 5-fret guitar layout in YARG/CH MIDI. Per YARG.Core's MidIOHelper:
+//   GUITAR_DIFF_START_LOOKUP.Expert = 96 (Green)
+// Offsets: Green=0, Red=1, Yellow=2, Blue=3, Orange=4, forceHopo=5, forceStrum=6
+// So: expert = [96..102], easy = [60..66]. TAP_NOTE_CH is a single global 104.
+const EXPERT_GREEN = 96
+const EXPERT_RED = 97
+const EXPERT_YELLOW = 98
+const EXPERT_BLUE = 99
+const EXPERT_ORANGE = 100
+const EXPERT_FORCE_HOPO = 101
+const EXPERT_FORCE_STRUM = 102
+
+const EASY_GREEN = 60
+const EASY_RED = 61
+const EASY_YELLOW = 62
+const EASY_FORCE_HOPO = 65
+const EASY_FORCE_STRUM = 66
+
+// Tap is a single global note (not per-difficulty).
+const TAP_NOTE = 104
+
+// ---------------------------------------------------------------------------
+// End-exclusive range tests
+// ---------------------------------------------------------------------------
+
+describe('MIDI: forceTap range is end-exclusive', () => {
+	it('BAND-MAID regression: forceTap on note A does NOT spill onto next note', () => {
+		// Regression for "BAND-MAID - Hate (Alpucat)" easy guitar: two consecutive
+		// yellow notes at ticks T and T+960. The forceTap range covers only the
+		// first note. Verifies that the tap end tick is end-EXCLUSIVE — a tap
+		// modifier ending at the same tick as the next note must not flag it.
+		const track: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'PART GUITAR' },
+			// Note A at tick 480 (easy yellow)
+			{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: EASY_YELLOW, velocity: 100 },
+			// Tap sustain: noteOn 104 at 480, noteOff at 960 (exactly where note B starts)
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: TAP_NOTE, velocity: 100 },
+			// Note A off at 600
+			{ deltaTime: 120, type: 'noteOff', channel: 0, noteNumber: EASY_YELLOW, velocity: 0 },
+			// Tap sustain off at 960
+			{ deltaTime: 360, type: 'noteOff', channel: 0, noteNumber: TAP_NOTE, velocity: 0 },
+			// Note B at 960 (easy yellow) — should NOT be tap
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: EASY_YELLOW, velocity: 100 },
+			{ deltaTime: 120, type: 'noteOff', channel: 0, noteNumber: EASY_YELLOW, velocity: 0 },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+		const parsed = parseGuitarEasy(midi)
+
+		const gA = parsed.noteEventGroups.find(g => g[0].tick === 480)!
+		const gB = parsed.noteEventGroups.find(g => g[0].tick === 960)!
+
+		expect(gA[0].flags & noteFlags.tap).toBe(noteFlags.tap)
+		expect(gB[0].flags & noteFlags.tap).toBe(0) // NOT tap
+	})
+})
+
+describe('MIDI: forceHopo / forceStrum range is end-exclusive', () => {
+	it('back-to-back forceHopo phrases do not spill onto the next phrase', () => {
+		// Two forceHopo sustains: [480, 960] and [960, 1440]. The note at tick
+		// 960 should be covered by the SECOND sustain (which starts at 960),
+		// not the first (which ends at 960). End-exclusive means the first
+		// sustain covers [480, 959] only, so the note at 960 picks up the
+		// second sustain cleanly — same flag but the ordering matters for
+		// sustain boundaries.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			guitarTrack('expert', {
+				notes: [
+					// Notes: two green notes (natural strums, far apart)
+					{ tick: 480, noteNumber: EXPERT_GREEN, length: 120 },
+					{ tick: 960, noteNumber: EXPERT_GREEN, length: 120 },
+					// forceHopo #1: covers note at 480, ends at 960
+					{ tick: 480, noteNumber: EXPERT_FORCE_HOPO, length: 480 },
+					// forceHopo #2: starts at 960, covers note at 960
+					{ tick: 960, noteNumber: EXPERT_FORCE_HOPO, length: 480 },
+				],
+			}),
+		])
+		const track = parseGuitarExpert(midi)
+		const g480 = track.noteEventGroups.find(g => g[0].tick === 480)!
+		const g960 = track.noteEventGroups.find(g => g[0].tick === 960)!
+		expect(g480[0].flags & noteFlags.hopo).toBe(noteFlags.hopo)
+		expect(g960[0].flags & noteFlags.hopo).toBe(noteFlags.hopo)
+	})
+})

--- a/src/__tests__/ini-scanner.test.ts
+++ b/src/__tests__/ini-scanner.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for song.ini scanning: known property extraction and unknown value preservation.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { scanIni } from '../ini/ini-scanner'
+
+function buildIni(lines: string[]): { fileName: string; data: Uint8Array }[] {
+	const text = lines.join('\r\n')
+	return [{ fileName: 'song.ini', data: new TextEncoder().encode(text) }]
+}
+
+describe('scanIni: unknownIniValues', () => {
+	it('returns unrecognized keys from [Song] section', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test Song',
+			'artist = Test Artist',
+			'diff_vocals_harm = 3',
+			'sysex_slider = True',
+			'rating = 2',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({
+			diff_vocals_harm: '3',
+			sysex_slider: 'True',
+			rating: '2',
+		})
+	})
+
+	it('does not include recognized keys in unknownIniValues', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test Song',
+			'artist = Test Artist',
+			'album = Test Album',
+			'genre = Rock',
+			'year = 2024',
+			'charter = Tester',
+			'diff_guitar = 4',
+			'pro_drums = True',
+			'hopo_frequency = 170',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+	})
+
+	it('does not include legacy alias keys in unknownIniValues', () => {
+		const files = buildIni([
+			'[Song]',
+			'frets = Legacy Charter',    // legacy alias for charter
+			'track = 5',                 // legacy alias for album_track
+			'hopofreq = 170',           // legacy alias for hopo_frequency
+			'star_power_note = 116',    // legacy alias for multiplier_note
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+	})
+
+	it('preserves common unrecognized keys found in real charts', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'diff_vocals_harm = 3',
+			'diff_guitar_real = 5',
+			'diff_bass_real = 4',
+			'diff_keys_real = 3',
+			'diff_guitar_real_22 = 5',
+			'diff_bass_real_22 = 4',
+			'diff_dance = 2',
+			'diff_drums_real_ps = 3',
+			'diff_keys_real_ps = 2',
+			'sysex_slider = True',
+			'sysex_open_bass = True',
+			'sysex_high_hat_ctrl = True',
+			'sysex_rimshot = True',
+			'sysex_pro_slide = True',
+			'kit_type = 1',
+			'guitar_type = 0',
+			'bass_type = 0',
+			'keys_type = 0',
+			'dance_type = 0',
+			'real_guitar_tuning = 0 0 0 0 0 0',
+			'real_bass_tuning = 0 0 0 0',
+			'real_keys_lane_count_right = 5',
+			'real_keys_lane_count_left = 5',
+			'vocal_gender = male',
+			'vocal_scroll_speed = 100',
+			'rating = 1',
+			'count = 42',
+			'version = 2',
+			'playlist = My Setlist',
+			'sub_playlist = Favorites',
+			'explicit_lyrics = True',
+			'video_loop = True',
+			'video_end_time = 180000',
+			'drum_fallback_blue = True',
+			'link_name_a = YouTube',
+			'banner_link_a = https://youtube.com',
+			'link_name_b = Spotify',
+			'banner_link_b = https://spotify.com',
+		])
+
+		const result = scanIni(files)
+		// All 38 non-standard keys should be preserved
+		expect(Object.keys(result.unknownIniValues).length).toBeGreaterThanOrEqual(36)
+		expect(result.unknownIniValues.diff_vocals_harm).toBe('3')
+		expect(result.unknownIniValues.diff_guitar_real).toBe('5')
+		expect(result.unknownIniValues.sysex_slider).toBe('True')
+		expect(result.unknownIniValues.kit_type).toBe('1')
+		expect(result.unknownIniValues.real_guitar_tuning).toBe('0 0 0 0 0 0')
+		expect(result.unknownIniValues.vocal_gender).toBe('male')
+		expect(result.unknownIniValues.rating).toBe('1')
+		expect(result.unknownIniValues.playlist).toBe('My Setlist')
+		expect(result.unknownIniValues.link_name_a).toBe('YouTube')
+		expect(result.unknownIniValues.banner_link_a).toBe('https://youtube.com')
+	})
+
+	it('preserves typo keys without correcting them', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'loading_phase = Almost there',     // typo for loading_phrase
+			'previw_start_time = 5000',          // typo for preview_start_time
+			'diff_drums_ real = 3',              // typo with space
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues.loading_phase).toBe('Almost there')
+		expect(result.unknownIniValues.previw_start_time).toBe('5000')
+		expect(result.unknownIniValues['diff_drums_ real']).toBe('3')
+	})
+
+	it('returns empty unknownIniValues when no ini file found', () => {
+		const result = scanIni([])
+		expect(result.unknownIniValues).toEqual({})
+		expect(result.metadata).toBeNull()
+	})
+
+	it('returns empty unknownIniValues when ini has no [Song] section', () => {
+		const files = buildIni(['[Other]', 'key = value'])
+		const result = scanIni(files)
+		expect(result.unknownIniValues).toEqual({})
+		expect(result.metadata).toBeNull()
+	})
+
+	it('preserves values with special characters', () => {
+		const files = buildIni([
+			'[Song]',
+			'name = Test',
+			'real_guitar_22_tuning = -2 -2 -2 -2 -2 -2 Standard Drop D',
+			'tags = cover',
+			'credit_composed_by = John Doe & Jane Doe',
+		])
+
+		const result = scanIni(files)
+		expect(result.unknownIniValues.real_guitar_22_tuning).toBe('-2 -2 -2 -2 -2 -2 Standard Drop D')
+		expect(result.unknownIniValues.tags).toBe('cover')
+		expect(result.unknownIniValues.credit_composed_by).toBe('John Doe & Jane Doe')
+	})
+})

--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -1002,3 +1002,279 @@ describe('MIDI: invalid lyric/phrase events on EVENTS track', () => {
 		expect(types).toEqual(['invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
 	})
 })
+
+// ---------------------------------------------------------------------------
+// New instruments
+// ---------------------------------------------------------------------------
+
+describe('MIDI: Pro Guitar', () => {
+	it('recognizes PART REAL_GUITAR and extracts star power and solo', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 116, length: 960 },  // star power
+					{ tick: 480, noteNumber: 115, length: 960 },  // solo (pro guitar uses 115)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+		expect(track.starPowerSections[0]).toMatchObject({ tick: 480, length: 960 })
+		expect(track.soloSections).toHaveLength(1)
+		expect(track.soloSections[0]).toMatchObject({ tick: 480, length: 960 })
+		expect(track.trackEvents).toEqual([]) // standard note parsing skipped for pro instruments
+	})
+
+	it('extracts raw notes with fret and channel data', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120, velocity: 105 },  // expert string 0 (low E), fret 5
+					{ tick: 480, noteNumber: 97, length: 120, velocity: 100 },  // expert string 1 (A), open
+					{ tick: 960, noteNumber: 96, length: 240, velocity: 107 },  // expert string 0, fret 7
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track.rawNotes).toHaveLength(3)
+		expect(track.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 96, velocity: 105 })
+		expect(track.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 97, velocity: 100 })
+		expect(track.rawNotes[2]).toMatchObject({ tick: 960, noteNumber: 96, velocity: 107 })
+	})
+
+	it('assigns raw notes to correct difficulties', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },  // expert (96-101)
+					{ tick: 480, noteNumber: 72, length: 120 },  // hard (72-77)
+					{ tick: 480, noteNumber: 48, length: 120 },  // medium (48-53)
+					{ tick: 480, noteNumber: 24, length: 120 },  // easy (24-29)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(getTrack(result, 'proguitar', 'expert')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'hard')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'medium')!.rawNotes).toHaveLength(1)
+		expect(getTrack(result, 'proguitar', 'easy')!.rawNotes).toHaveLength(1)
+	})
+
+	it('extracts text events from Pro Guitar track', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+				textEvents: [{ tick: 0, text: 'begin_pg song_trainer_pg_1' }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar', 'expert')!
+		expect(track.textEvents).toEqual([{ tick: 0, text: 'begin_pg song_trainer_pg_1' }])
+	})
+
+	it('recognizes PART REAL_GUITAR_22 as proguitar22', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR_22', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'proguitar22', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+	})
+})
+
+describe('MIDI: Pro Bass', () => {
+	it('recognizes PART REAL_BASS and PART REAL_BASS_22', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_BASS', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_BASS_22', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(getTrack(result, 'probass', 'expert')).toBeDefined()
+		expect(getTrack(result, 'probass22', 'expert')).toBeDefined()
+	})
+})
+
+describe('MIDI: Pro Keys', () => {
+	it('maps each PART REAL_KEYS_* track to a single difficulty', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_H', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_M', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+			instrumentTrack('PART REAL_KEYS_E', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const prokeys = result.trackData.filter(t => t.instrument === 'prokeys')
+		expect(prokeys).toHaveLength(4)
+		expect(prokeys.map(t => t.difficulty).sort()).toEqual(['easy', 'expert', 'hard', 'medium'])
+	})
+
+	it('extracts star power on Pro Keys', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'prokeys', 'expert')!
+		expect(track.starPowerSections).toHaveLength(1)
+		// Should NOT create entries for other difficulties from this track
+		expect(getTrack(result, 'prokeys', 'hard')).toBeUndefined()
+	})
+
+	it('extracts raw key notes (MIDI 48-72)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [
+					{ tick: 480, noteNumber: 48, length: 240 },  // C1 (lowest key)
+					{ tick: 480, noteNumber: 60, length: 240 },  // C2 (middle)
+					{ tick: 960, noteNumber: 72, length: 120 },  // C3 (highest key)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'prokeys', 'expert')!
+		expect(track.rawNotes).toHaveLength(3)
+		expect(track.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 48 })
+		expect(track.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 60 })
+		expect(track.rawNotes[2]).toMatchObject({ tick: 960, noteNumber: 72 })
+	})
+})
+
+describe('MIDI: Elite Drums', () => {
+	it('recognizes PART ELITE_DRUMS and extracts star power', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART ELITE_DRUMS', {
+				notes: [{ tick: 480, noteNumber: 116, length: 960 }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'elitedrums', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.starPowerSections).toHaveLength(1)
+	})
+
+	it('extracts raw pad notes with velocity and assigns to correct difficulty', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART ELITE_DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 74, length: 0, velocity: 100 },  // expert kick (base=74, offset 0)
+					{ tick: 480, noteNumber: 75, length: 0, velocity: 127 },  // expert snare, accent (velocity 127)
+					{ tick: 960, noteNumber: 50, length: 0, velocity: 100 },  // hard kick (base=50)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const expert = getTrack(result, 'elitedrums', 'expert')!
+		expect(expert.rawNotes).toHaveLength(2)
+		expect(expert.rawNotes[0]).toMatchObject({ tick: 480, noteNumber: 74, velocity: 100 })
+		expect(expert.rawNotes[1]).toMatchObject({ tick: 480, noteNumber: 75, velocity: 127 })
+		const hard = getTrack(result, 'elitedrums', 'hard')!
+		expect(hard.rawNotes).toHaveLength(1)
+		expect(hard.rawNotes[0]).toMatchObject({ tick: 960, noteNumber: 50 })
+	})
+})
+
+describe('MIDI: Phase Shift Real Drums', () => {
+	it('maps PART REAL_DRUMS_PS to drums instrument', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_DRUMS_PS', {
+				notes: [{ tick: 480, noteNumber: 97, length: 120 }], // expert red drum
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'drums', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0) // notes should be parsed as standard drums
+	})
+})
+
+describe('MIDI: GHL Keys', () => {
+	it('recognizes PART KEYS GHL as keysghl with sixFret note parsing', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART KEYS GHL', {
+				notes: [
+					{ tick: 480, noteNumber: 94, length: 120 },  // expert open (sixFretDiffStart.expert = 94)
+					{ tick: 960, noteNumber: 95, length: 120 },  // expert white1
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'keysghl', 'expert')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0)
+	})
+
+})
+
+describe('.chart: GHL Keys', () => {
+	it('parses ExpertGHLKeys section', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+			ExpertGHLKeys: ['0 = N 0 0', '192 = N 1 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		const track = getTrack(result, 'keysghl')!
+		expect(track).toBeDefined()
+		expect(track.trackEvents.length).toBeGreaterThan(0)
+	})
+})

--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -1616,3 +1616,59 @@ describe('Pro Keys glissando', () => {
 	})
 })
 
+// ---------------------------------------------------------------------------
+// VENUE track
+// ---------------------------------------------------------------------------
+
+describe('VENUE track parsing', () => {
+	it('extracts note-based venue events', () => {
+		const venue: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'VENUE' },
+			{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 48, velocity: 100 },  // lighting: next
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 103, velocity: 100 },   // postProcessing: bloom
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 39, velocity: 100 },    // spotlight: guitar
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 60, velocity: 100 },    // cameraCut: random
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 70, velocity: 100 },    // constraint: no_behind
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 86, velocity: 100 },    // singalong: drums
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), venue])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.venue).toHaveLength(6)
+		expect(result.venue).toContainEqual({ tick: 480, type: 'lighting', name: 'next' })
+		expect(result.venue).toContainEqual({ tick: 480, type: 'postProcessing', name: 'bloom' })
+		expect(result.venue).toContainEqual({ tick: 480, type: 'spotlight', name: 'guitar' })
+		expect(result.venue).toContainEqual({ tick: 480, type: 'cameraCut', name: 'random' })
+		expect(result.venue).toContainEqual({ tick: 480, type: 'cameraCutConstraint', name: 'no_behind' })
+		expect(result.venue).toContainEqual({ tick: 480, type: 'singalong', name: 'drums' })
+	})
+
+	it('extracts text-based venue events', () => {
+		const venue: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'VENUE' },
+			{ deltaTime: 480, type: 'text', text: '[lighting (verse)]' },
+			{ deltaTime: 480, type: 'text', text: '[bloom.pp]' },
+			{ deltaTime: 480, type: 'text', text: '[directed_guitar]' },
+			{ deltaTime: 0, type: 'text', text: '[coop_v_closeup]' },
+			{ deltaTime: 480, type: 'text', text: '[FogOn]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), venue])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.venue).toEqual([
+			{ tick: 480, type: 'lighting', name: 'verse' },
+			{ tick: 960, type: 'postProcessing', name: 'bloom' },
+			{ tick: 1440, type: 'cameraCut', name: 'directed_guitar' },
+			{ tick: 1440, type: 'cameraCut', name: 'v_closeup' },
+			{ tick: 1920, type: 'stageEffect', name: 'fog_on' },
+		])
+	})
+
+	it('returns empty array when no VENUE track', () => {
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack()])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.venue).toEqual([])
+	})
+})

--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest'
 import { writeMidi, MidiData } from 'midi-file'
 import { parseNotesFromMidi } from '../chart/midi-parser'
 import { parseNotesFromChart } from '../chart/chart-parser'
+import { parseChartFile } from '../chart/notes-parser'
 import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
 
 // ---------------------------------------------------------------------------
@@ -721,5 +722,283 @@ describe('per-track data edge cases', () => {
 		expect(track.textEvents).toEqual([])
 		expect(track.versusPhrases).toEqual([])
 		expect(track.animations).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: Global Events
+// ---------------------------------------------------------------------------
+
+describe('MIDI: global events', () => {
+	it('captures crowd and music events from EVENTS track', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[music_start]' },
+			{ deltaTime: 960, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('excludes sections from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_intense]' },
+			{ deltaTime: 480, type: 'text', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: '[crowd_intense]' },
+		])
+	})
+
+	it('excludes end events and coda from unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'text', text: '[coda]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_clap]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 960, text: '[crowd_clap]' },
+		])
+	})
+
+	it('includes misplaced lyric/phrase events in unrecognizedEvents (alongside parseIssues)', () => {
+		// Lyrics and phrase markers belong on PART VOCALS, not EVENTS. Game engines
+		// drop them, but we round-trip them out so users can see and fix them.
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: 'lyric Hello' },
+			{ tick: 960, text: 'phrase_start' },
+			{ tick: 1440, text: 'phrase_end' },
+			{ tick: 1920, text: '[music_end]' },
+		])
+	})
+
+	it('reads from lyrics, marker, and cuePoint event types (not just text)', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'lyrics', text: '[music_start]' },
+			{ deltaTime: 480, type: 'marker', text: '[crowd_clap]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[music_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: '[crowd_normal]' },
+			{ tick: 480, text: '[music_start]' },
+			{ tick: 960, text: '[crowd_clap]' },
+			{ tick: 1440, text: '[music_end]' },
+		])
+	})
+
+	it('reads sections from lyrics/marker event types', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'lyrics', text: '[section intro]' },
+			{ deltaTime: 480, type: 'marker', text: '[section verse]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: 'intro' },
+			{ tick: 480, name: 'verse' },
+		])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('reads end events from lyrics event type', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 960, type: 'lyrics', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.endEvents).toEqual([{ tick: 960 }])
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+
+	it('returns empty array when no EVENTS track', () => {
+		const midi = buildMidi(480, [tempoTrack()])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// .chart: Global Events
+// ---------------------------------------------------------------------------
+
+describe('.chart: global events', () => {
+	it('captures non-section/end/lyric/phrase events from [Events]', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "crowd_normal"',
+				'192 = E "music_start"',
+				'384 = E "section intro"',
+				'768 = E "music_end"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: 'crowd_normal' },
+			{ tick: 192, text: 'music_start' },
+			{ tick: 768, text: 'music_end' },
+		])
+	})
+
+	it('excludes end events, coda, lyrics, and phrase markers', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "end"',
+				'0 = E "coda"',
+				'192 = E "lyric Hello"',
+				'384 = E "phrase_start"',
+				'576 = E "phrase_end"',
+				'768 = E "crowd_clap"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 768, text: 'crowd_clap' },
+		])
+	})
+
+	it('returns empty array when no Events section', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			ExpertSingle: ['0 = N 0 0'],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.unrecognizedEvents).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// MIDI: parseIssues for stray vocal events on the EVENTS track
+// ---------------------------------------------------------------------------
+
+describe('MIDI: invalid lyric/phrase events on EVENTS track', () => {
+	it('emits invalidLyric for lyric text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'lyric Hello' },
+			{ deltaTime: 480, type: 'text', text: '[lyric world]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidLyric')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[lyric world]', 'lyric Hello'])
+	})
+
+	it('emits invalidPhraseStart for phrase_start text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_start' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseStart')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_start]', 'phrase_start'])
+	})
+
+	it('emits invalidPhraseEnd for phrase_end text events on EVENTS and round-trips them via unrecognizedEvents', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: 'phrase_end' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues.filter(i => i.noteIssue === 'invalidPhraseEnd')).toHaveLength(2)
+		expect(result.unrecognizedEvents.map(e => e.text).sort()).toEqual(['[phrase_end]', 'phrase_end'])
+	})
+
+	it('emits a mix of invalidLyric/PhraseStart/PhraseEnd when all coexist', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'text', text: '[phrase_start]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric Hel-]' },
+			{ deltaTime: 240, type: 'text', text: '[lyric lo]' },
+			{ deltaTime: 240, type: 'text', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
+	})
+
+	it('does NOT emit issues for properly-formed EVENTS-track text', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section intro]' },
+			{ deltaTime: 480, type: 'text', text: '[crowd_normal]' },
+			{ deltaTime: 480, type: 'text', text: '[end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.parseIssues).toEqual([])
+	})
+
+	it('reads invalid events from lyrics/marker/cuePoint event types too', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 480, type: 'lyrics', text: '[lyric foo]' },
+			{ deltaTime: 480, type: 'marker', text: '[phrase_start]' },
+			{ deltaTime: 480, type: 'cuePoint', text: '[phrase_end]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const types = result.parseIssues.map(i => i.noteIssue).sort()
+		expect(types).toEqual(['invalidLyric', 'invalidPhraseEnd', 'invalidPhraseStart'])
 	})
 })

--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -764,7 +764,7 @@ describe('MIDI: global events', () => {
 		])
 	})
 
-	it('excludes end events and coda from unrecognizedEvents', () => {
+	it('excludes end events from unrecognizedEvents (keeps coda)', () => {
 		const events: MidiData['tracks'][number] = [
 			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
 			{ deltaTime: 480, type: 'text', text: '[end]' },
@@ -776,6 +776,7 @@ describe('MIDI: global events', () => {
 		const midi = buildMidi(480, [tempoTrack(), events])
 		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
 		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 480, text: '[coda]' },
 			{ tick: 960, text: '[crowd_clap]' },
 		])
 	})
@@ -884,7 +885,7 @@ describe('.chart: global events', () => {
 		])
 	})
 
-	it('excludes end events, coda, lyrics, and phrase markers', () => {
+	it('excludes end events, lyrics, and phrase markers (keeps coda)', () => {
 		const chart = buildChart({
 			Song: ['Resolution = 192'],
 			SyncTrack: ['0 = B 120000', '0 = TS 4'],
@@ -900,6 +901,7 @@ describe('.chart: global events', () => {
 
 		const result = parseNotesFromChart(chart)
 		expect(result.unrecognizedEvents).toEqual([
+			{ tick: 0, text: 'coda' },
 			{ tick: 768, text: 'crowd_clap' },
 		])
 	})
@@ -1278,3 +1280,339 @@ describe('.chart: GHL Keys', () => {
 		expect(track.trackEvents.length).toBeGreaterThan(0)
 	})
 })
+
+// ---------------------------------------------------------------------------
+// Semantic labels on rawNotes
+// ---------------------------------------------------------------------------
+
+describe('rawNotes semantic labels', () => {
+	it('adds string/fret/noteModifier for Pro Guitar', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 98, length: 120, velocity: 107 }, // expert, string 2 (D), fret 7
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'proguitar' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0]).toMatchObject({ string: 2, fret: 7, noteModifier: 'normal' })
+	})
+
+	it('maps MIDI channel to pro guitar note modifier', () => {
+		// Build MIDI with channel 3 (muted)
+		const track: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'PART REAL_GUITAR' },
+			{ deltaTime: 0, type: 'noteOn', channel: 3, noteNumber: 96, velocity: 103 },
+			{ deltaTime: 120, type: 'noteOff', channel: 3, noteNumber: 96, velocity: 0 },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+		const parsed = parseChartFile(midi, 'mid')
+		const gtr = parsed.trackData.find(t => t.instrument === 'proguitar' && t.difficulty === 'expert')!
+		expect(gtr.rawNotes[0]).toMatchObject({ string: 0, fret: 3, noteModifier: 'muted' })
+	})
+
+	it('adds key index for Pro Keys', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 60, length: 120 }], // C2 = key 12
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'prokeys' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0]).toMatchObject({ key: 12 })
+	})
+
+	it('adds pad name for Elite Drums', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART ELITE_DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 74, length: 0 },  // expert kick (base=74, offset 0)
+					{ tick: 480, noteNumber: 72, length: 0 },  // expert hatPedal (base=74, offset -2)
+					{ tick: 480, noteNumber: 75, length: 0 },  // expert snare (offset 1)
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'elitedrums' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0]).toMatchObject({ pad: 'hatPedal' })
+		expect(track.rawNotes[1]).toMatchObject({ pad: 'kick' })
+		expect(track.rawNotes[2]).toMatchObject({ pad: 'snare' })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Pro instrument sustain trimming and fret capping
+// ---------------------------------------------------------------------------
+
+describe('Pro instrument sustain trimming', () => {
+	it('trims short sustains to 0 on Pro Keys (length < resolution/3)', () => {
+		// resolution=480 → threshold=160 → notes with length < 160 are trimmed
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [
+					{ tick: 480, noteNumber: 60, length: 60 },   // 60 < 160 → trimmed to 0
+					{ tick: 960, noteNumber: 60, length: 120 },  // 120 < 160 → trimmed to 0
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'prokeys' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].length).toBe(0)
+		expect(track.rawNotes[1].length).toBe(0)
+	})
+
+	it('preserves sustains at exactly resolution/3 on Pro instruments', () => {
+		// resolution=480 → threshold=160 → length 160 is NOT trimmed (strict <)
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [{ tick: 480, noteNumber: 60, length: 160 }], // 160 is NOT < 160 → kept
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'prokeys' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].length).toBe(160)
+	})
+
+	it('trims short sustains on Pro Guitar', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 100, velocity: 105 }, // 100 < 160 → trimmed
+					{ tick: 960, noteNumber: 96, length: 200, velocity: 105 }, // 200 > 160 → kept
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'proguitar' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].length).toBe(0)
+		expect(track.rawNotes[1].length).toBe(200)
+	})
+})
+
+describe('Pro Guitar fret capping', () => {
+	it('caps 17-fret guitar at fret 17', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 0, velocity: 120 }, // fret = 120-100 = 20, capped to 17
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'proguitar' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].fret).toBe(17)
+	})
+
+	it('caps 22-fret guitar at fret 22', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR_22', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 0, velocity: 123 }, // fret = 23, capped to 22
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'proguitar22' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].fret).toBe(22)
+	})
+
+	it('does not cap frets within valid range', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_GUITAR_22', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 0, velocity: 100 }, // fret 0 (open)
+					{ tick: 960, noteNumber: 96, length: 0, velocity: 112 }, // fret 12
+					{ tick: 1440, noteNumber: 96, length: 0, velocity: 122 }, // fret 22
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'proguitar22' && t.difficulty === 'expert')!
+		expect(track.rawNotes[0].fret).toBe(0)
+		expect(track.rawNotes[1].fret).toBe(12)
+		expect(track.rawNotes[2].fret).toBe(22)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Animation naming
+// ---------------------------------------------------------------------------
+
+describe('animation semantic names', () => {
+	it('names guitar animations as left hand positions', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },
+					{ tick: 480, noteNumber: 45, length: 120 },
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'guitar' && t.difficulty === 'expert')!
+		expect(track.animations[0]).toMatchObject({ noteNumber: 45, name: 'leftHandPosition6' })
+	})
+
+	it('names drum animations', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART DRUMS', {
+				notes: [
+					{ tick: 480, noteNumber: 97, length: 120 },
+					{ tick: 480, noteNumber: 24, length: 120 },
+					{ tick: 480, noteNumber: 27, length: 120 },
+				],
+			}),
+		])
+
+		const parsed = parseChartFile(midi, 'mid')
+		const track = parsed.trackData.find(t => t.instrument === 'drums' && t.difficulty === 'expert')!
+		expect(track.animations[0]).toMatchObject({ noteNumber: 24, name: 'kick' })
+		expect(track.animations[1]).toMatchObject({ noteNumber: 27, name: 'snareRHHard' })
+	})
+})
+
+// ---------------------------------------------------------------------------
+// HandMap, StrumMap, CharacterState
+// ---------------------------------------------------------------------------
+
+describe('HandMap, StrumMap, CharacterState parsing', () => {
+	it('parses HandMap from text events', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [
+					{ tick: 0, text: '[map HandMap_Default]' },
+					{ tick: 480, text: '[map HandMap_Solo]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.handMaps).toEqual([
+			{ tick: 0, type: 'default' },
+			{ tick: 480, type: 'solo' },
+		])
+	})
+
+	it('parses StrumMap from text events', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART BASS', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [{ tick: 0, text: '[map StrumMap_SlapBass]' }],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'bass')!
+		expect(track.strumMaps).toEqual([{ tick: 0, type: 'slapBass' }])
+	})
+
+	it('parses CharacterState from text events', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [{ tick: 480, noteNumber: 96, length: 120 }],
+				textEvents: [
+					{ tick: 0, text: '[idle]' },
+					{ tick: 480, text: '[play]' },
+					{ tick: 960, text: '[intense]' },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.characterStates).toEqual([
+			{ tick: 0, type: 'idle' },
+			{ tick: 480, type: 'play' },
+			{ tick: 960, type: 'intense' },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Pro Keys glissando
+// ---------------------------------------------------------------------------
+
+describe('Pro Keys glissando', () => {
+	it('extracts note 126 as glissando on Pro Keys (not flexLane)', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART REAL_KEYS_X', {
+				notes: [
+					{ tick: 480, noteNumber: 116, length: 1920 }, // star power (so track is included)
+					{ tick: 480, noteNumber: 126, length: 960 },  // glissando on pro keys
+					{ tick: 480, noteNumber: 127, length: 960 },  // trill (flexLaneDouble)
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'prokeys', 'expert')!
+		expect(track.glissandoSections).toHaveLength(1)
+		expect(track.glissandoSections[0]).toMatchObject({ tick: 480, length: 960 })
+		// Note 127 should be a flex lane (trill)
+		expect(track.flexLanes).toHaveLength(1)
+	})
+
+	it('keeps note 126 as flexLane on standard guitar', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			instrumentTrack('PART GUITAR', {
+				notes: [
+					{ tick: 480, noteNumber: 96, length: 120 },
+					{ tick: 480, noteNumber: 126, length: 960 },
+				],
+			}),
+		])
+
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		const track = getTrack(result, 'guitar')!
+		expect(track.flexLanes).toHaveLength(1)
+		expect(track.glissandoSections).toHaveLength(0)
+	})
+})
+

--- a/src/__tests__/vocal-tracks.test.ts
+++ b/src/__tests__/vocal-tracks.test.ts
@@ -44,7 +44,10 @@ type TimedEvent = { absTick: number; event: MidiData['tracks'][number][number] }
 function vocalTrack(name: string, opts: {
 	notes?: { tick: number; pitch: number; length: number }[]
 	lyrics?: { tick: number; text: string }[]
+	/** Note 105 phrases (scoring phrases). */
 	phrases?: { tick: number; length: number }[]
+	/** Note 106 phrases (static lyric phrases / versus player 2). */
+	phrases106?: { tick: number; length: number }[]
 }): MidiData['tracks'][number] {
 	const track: MidiData['tracks'][number] = [
 		{ deltaTime: 0, type: 'trackName', text: name },
@@ -78,6 +81,17 @@ function vocalTrack(name: string, opts: {
 		timedEvents.push({
 			absTick: p.tick + p.length,
 			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 105, velocity: 0 },
+		})
+	}
+
+	for (const p of opts.phrases106 ?? []) {
+		timedEvents.push({
+			absTick: p.tick,
+			event: { deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 106, velocity: 100 },
+		})
+		timedEvents.push({
+			absTick: p.tick + p.length,
+			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 106, velocity: 0 },
 		})
 	}
 
@@ -602,7 +616,7 @@ describe('normalizedVocalTracks', () => {
 		expect(result.vocalTracks.parts.vocals.notePhrases[0].notes[0].pitch).toBe(62)
 	})
 
-	it('strips lyric symbols and sets flags', () => {
+	it('preserves lyric symbols in text and derives flags', () => {
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -621,15 +635,15 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
-		expect(lyrics[0].text).toBe('Cha')
+		expect(lyrics[0].text).toBe('Cha#')
 		expect(lyrics[0].flags).toBe(lyricFlags.nonPitched)
-		expect(lyrics[1].text).toBe('hid-')
+		expect(lyrics[1].text).toBe('$hid-')
 		expect(lyrics[1].flags).toBe(lyricFlags.harmonyHidden | lyricFlags.joinWithNext)
 	})
 
-	it('.chart vocals produce 0 notePhrases (no vocal notes in .chart format)', () => {
+	it('.chart vocals keep phrases with lyrics (no vocal notes in .chart format)', () => {
 		// .chart format has lyrics and phrase markers but no vocal notes (MIDI-only).
-		// Matching YARG behavior: phrases with no notes are skipped.
+		// Phrases are kept so all lyrics are accessible through phrase grouping.
 		const chart = buildChart({
 			Song: ['Resolution = 480'],
 			SyncTrack: ['0 = B 120000'],
@@ -643,7 +657,11 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(chart, 'chart')
 		const vocals = result.vocalTracks.parts.vocals
-		expect(vocals.notePhrases).toHaveLength(0)
+		expect(vocals.notePhrases).toHaveLength(1)
+		expect(vocals.notePhrases[0].lyrics).toHaveLength(2)
+		expect(vocals.notePhrases[0].lyrics[0].text).toBe('Hello')
+		expect(vocals.notePhrases[0].lyrics[1].text).toBe('World')
+		expect(vocals.notePhrases[0].notes).toHaveLength(0)
 	})
 
 	it('preserves star power sections as separate array', () => {
@@ -730,15 +748,16 @@ describe('normalizedVocalTracks', () => {
 		expect(phrase.lyrics[0].msTime).toBeGreaterThan(0)
 	})
 
-	it('skips empty lyrics after symbol stripping (e.g. standalone "+")', () => {
-		// YARG's ProcessLyric: if IsNullOrWhiteSpace(strippedLyric) → skip
+	it('pitch slide with filtered "+" keeps the note for round-trip consistency', () => {
+		// When "+" strips to empty and is filtered, the pitch slide note is NOT
+		// skipped — on re-parse "+" wouldn't exist, so consistency requires keeping it.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
 					{ tick: 480, text: 'me' },
-					{ tick: 720, text: '+' },  // stripped to "", should be skipped
+					{ tick: 720, text: '+' },  // stripped to "" → filtered → note NOT skipped
 					{ tick: 960, text: 'too' },
 				],
 				notes: [
@@ -752,13 +771,18 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		// "+" stripped to empty → filtered. Pitch slide note NOT skipped.
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('me')
 		expect(lyrics[1].text).toBe('too')
+		// All 3 notes kept (pitch slide at 720 not skipped because "+" was filtered)
+		const notes = result.vocalTracks.parts.vocals.notePhrases[0].notes
+		expect(notes).toHaveLength(3)
 	})
 
-	it('applies nonPitched flag to set note pitch to -1', () => {
-		// Real pattern: lyrics with '#' or '^' suffix mark non-pitched notes
+	it('nonPitched flag keeps original MIDI pitch (consumers check lyric flags)', () => {
+		// NonPitched notes (lyric with '#' suffix) keep their original MIDI pitch
+		// for lossless round-trip. Consumers check lyric flags for nonPitched status.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -771,7 +795,8 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const note = result.vocalTracks.parts.vocals.notePhrases[0].notes[0]
-		expect(note.pitch).toBe(-1)  // nonPitched flag → pitch = -1
+		expect(note.pitch).toBe(60)  // keeps original MIDI pitch
+		expect(note.type).toBe('pitched')
 	})
 
 	it('excludes percussionHidden (note 97) from normalized notes', () => {
@@ -797,21 +822,22 @@ describe('normalizedVocalTracks', () => {
 		expect(notes[1].type).toBe('percussion')
 	})
 
-	it('pitch slide note is skipped (merged into previous)', () => {
-		// Real pattern: lyric "+" means the next note slides from previous.
-		// YARG merges it as a child note — we skip it entirely in the flat list.
+	it('pitch slide note is skipped when lyric survives filtering', () => {
+		// When the pitchSlide lyric has displayable text (e.g. "oh+"), it survives
+		// the emptiness filter → the pitch slide note IS skipped for round-trip
+		// consistency (the lyric will exist on re-parse too).
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
 					{ tick: 480, text: 'oh' },
-					{ tick: 720, text: '+' },   // pitch slide → note at 720 is skipped
+					{ tick: 720, text: 'slide+' },  // pitchSlide with displayable text → survives filter
 					{ tick: 960, text: 'yeah' },
 				],
 				notes: [
 					{ tick: 480, pitch: 60, length: 240 },
-					{ tick: 720, pitch: 62, length: 240 },  // this is the slide target
+					{ tick: 720, pitch: 62, length: 240 },  // pitch slide target → skipped
 					{ tick: 960, pitch: 64, length: 240 },
 				],
 				phrases: [{ tick: 480, length: 720 }],
@@ -825,8 +851,9 @@ describe('normalizedVocalTracks', () => {
 		expect(notes[1].tick).toBe(960)
 	})
 
-	it('skips phrases with no notes (matching YARG behavior)', () => {
-		// Real pattern: HARM1 has phrases for all parts; phrases with no notes are skipped.
+	it('keeps phrases without notes (lyrics stay in their phrase)', () => {
+		// All phrases are kept — even without notes — so that all content is
+		// accessible through phrase grouping and writers can round-trip boundaries.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -834,15 +861,23 @@ describe('normalizedVocalTracks', () => {
 				lyrics: [{ tick: 480, text: 'hey' }, { tick: 1920, text: 'yo' }],
 				notes: [{ tick: 1920, pitch: 60, length: 240 }],  // only in second phrase
 				phrases: [
-					{ tick: 480, length: 480 },   // empty — skipped
-					{ tick: 1920, length: 480 },  // has note — kept
+					{ tick: 480, length: 480 },   // no notes, but has lyrics
+					{ tick: 1920, length: 480 },  // has note + lyric
 				],
 			}),
 		])
 
 		const result = parseChartFile(midi, 'mid')
-		expect(result.vocalTracks.parts.vocals.notePhrases).toHaveLength(1)
-		expect(result.vocalTracks.parts.vocals.notePhrases[0].tick).toBe(1920)
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+		expect(phrases[0].tick).toBe(480)
+		expect(phrases[0].notes).toHaveLength(0)
+		expect(phrases[0].lyrics).toHaveLength(1)
+		expect(phrases[0].lyrics[0].text).toBe('hey')
+		expect(phrases[1].tick).toBe(1920)
+		expect(phrases[1].notes).toHaveLength(1)
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('yo')
 	})
 
 	it('deduplicates phrases at same tick (note 105 + 106)', () => {
@@ -887,7 +922,7 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
-		// "sto" becomes "sto-" with JoinWithNext, "+-" becomes "+" which is empty → skipped
+		// "sto" becomes "sto-" with JoinWithNext, "+-" becomes "+" which is filtered
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('sto-')
 		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
@@ -944,7 +979,7 @@ describe('normalizedVocalTracks', () => {
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
 		// After sorting: "+-" comes before "re" at tick 720.
 		// DeferredLyricJoinWorkaround triggers on "+-": modifies "mo" → "mo-".
-		// Then "re" is processed normally with flags=None.
+		// "+-" becomes "+" which is filtered. "re" processed normally.
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('mo-')
 		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
@@ -966,7 +1001,7 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyric = result.vocalTracks.parts.vocals.notePhrases[0].lyrics[0]
-		expect(lyric.text).toBe('uh')
+		expect(lyric.text).toBe('uh#$')
 		expect(lyric.flags & lyricFlags.harmonyHidden).toBeTruthy()
 		expect(lyric.flags & lyricFlags.nonPitched).toBeTruthy()
 	})
@@ -1013,11 +1048,12 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const phrase = result.vocalTracks.parts.vocals.notePhrases[0]
-		// Note at 720 should be skipped (pitch slide from trimmed "+ ")
-		expect(phrase.notes).toHaveLength(2)
+		// Lyric "+ " trimmed to "+" → stripped to empty → filtered.
+		// Pitch slide note at 720 NOT skipped (filtered lyric → no round-trip marker).
+		expect(phrase.notes).toHaveLength(3)
 		expect(phrase.notes[0].tick).toBe(480)
-		expect(phrase.notes[1].tick).toBe(960)
-		// Lyric "+ " should be stripped to empty and skipped
+		expect(phrase.notes[1].tick).toBe(720)
+		expect(phrase.notes[2].tick).toBe(960)
 		expect(phrase.lyrics).toHaveLength(2)
 		expect(phrase.lyrics[0].text).toBe('mo-')
 		expect(phrase.lyrics[1].text).toBe('bile')
@@ -1072,38 +1108,128 @@ describe('normalizedVocalTracks', () => {
 		const result = parseChartFile(midi, 'mid')
 		const phrases = result.vocalTracks.parts.vocals.notePhrases
 		expect(phrases).toHaveLength(2)
-		// Phrase 2: note at 1440 is pitch slide, attached to phrase 1's note via previousParentLyric
-		expect(phrases[1].notes).toHaveLength(1)
-		expect(phrases[1].notes[0].tick).toBe(1920)
+		// Phrase 2: "+" is filtered → pitch slide note at 1440 is NOT skipped
+		// (ensures round-trip consistency — "+" won't exist on re-parse either)
+		expect(phrases[1].notes).toHaveLength(2)
+		expect(phrases[1].notes[0].tick).toBe(1440)
+		expect(phrases[1].notes[1].tick).toBe(1920)
 	})
 
-	it('carries lyrics from skipped phrases to next phrase (shared lyricIdx)', () => {
-		// Real case: "30 Seconds to Mars - Attack" has lyrics in a phrase with no notes.
-		// YARG's shared moonTextIndex carries those lyrics to the next phrase's first note.
+	it('lyrics stay in their phrase even when phrase has no notes', () => {
+		// All phrases are kept. Lyrics remain in their phrase — the phrase
+		// exists as a boundary even without notes. Writers iterate all phrases.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
-					{ tick: 480, text: 'Whoa' },   // in skipped phrase (no notes)
-					{ tick: 1920, text: 'I' },      // in kept phrase
+					{ tick: 480, text: 'Whoa' },   // in first phrase (no notes)
+					{ tick: 1920, text: 'I' },      // in second phrase
 				],
 				notes: [
 					{ tick: 1920, pitch: 60, length: 240 },
 				],
 				phrases: [
-					{ tick: 480, length: 480 },   // skipped (no notes)
-					{ tick: 1920, length: 480 },  // kept
+					{ tick: 480, length: 480 },   // no notes, has lyric
+					{ tick: 1920, length: 480 },  // has note + lyric
 				],
 			}),
 		])
 
 		const result = parseChartFile(midi, 'mid')
 		const phrases = result.vocalTracks.parts.vocals.notePhrases
-		expect(phrases).toHaveLength(1)
-		// Both lyrics should be in the kept phrase
-		expect(phrases[0].lyrics).toHaveLength(2)
+		expect(phrases).toHaveLength(2)
+		expect(phrases[0].lyrics).toHaveLength(1)
 		expect(phrases[0].lyrics[0].text).toBe('Whoa')
-		expect(phrases[0].lyrics[1].text).toBe('I')
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('I')
+	})
+
+	it('note 106 phrases create player 2 phrases on PART VOCALS (Dani California pattern)', () => {
+		// Test A: note 106 phrase before first note 105 phrase.
+		// Both 105 and 106 create phrases; merged set tagged with player.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 100, text: 'Hel-' },
+					{ tick: 500, text: 'lo' },
+				],
+				notes: [
+					{ tick: 100, pitch: 60, length: 100 },
+					{ tick: 500, pitch: 62, length: 100 },
+				],
+				phrases106: [{ tick: 0, length: 480 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+
+		// First phrase (from note 106) — player 2
+		expect(phrases[0].tick).toBe(0)
+		expect(phrases[0].player).toBe(2)
+		expect(phrases[0].notes).toHaveLength(1)
+		expect(phrases[0].notes[0].tick).toBe(100)
+		expect(phrases[0].lyrics).toHaveLength(1)
+		expect(phrases[0].lyrics[0].text).toBe('Hel-')
+
+		// Second phrase (from note 105) — player 1
+		expect(phrases[1].tick).toBe(480)
+		expect(phrases[1].player).toBe(1)
+		expect(phrases[1].notes).toHaveLength(1)
+		expect(phrases[1].notes[0].tick).toBe(500)
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('lo')
+	})
+
+	it('absorbs orphaned lyrics before first phrase into that phrase', () => {
+		// Test D: lyrics before the first phrase are absorbed into it.
+		// Notes before all phrases are dropped.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 100, text: 'orphan' },  // before all phrases
+					{ tick: 500, text: 'inside' },   // inside phrase
+				],
+				notes: [
+					{ tick: 100, pitch: 60, length: 50 },  // before phrase — dropped
+					{ tick: 500, pitch: 62, length: 100 }, // inside phrase — kept
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(1)
+		// Note at tick 100 is dropped (outside all phrases)
+		expect(phrases[0].notes).toHaveLength(1)
+		expect(phrases[0].notes[0].tick).toBe(500)
+		// Orphaned lyric at tick 100 is absorbed into the phrase
+		expect(phrases[0].lyrics).toHaveLength(2)
+		expect(phrases[0].lyrics[0].text).toBe('orphan')
+		expect(phrases[0].lyrics[1].text).toBe('inside')
+	})
+
+	it('harmony phrases have no player field', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('HARM1', {
+				lyrics: [{ tick: 480, text: 'hey' }],
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrase = result.vocalTracks.parts.harmony1.notePhrases[0]
+		expect(phrase.player).toBeUndefined()
 	})
 })

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -57,6 +57,11 @@ const trackNameMap = {
 	HardGHLBass: { instrument: 'bassghl', difficulty: 'hard' },
 	MediumGHLBass: { instrument: 'bassghl', difficulty: 'medium' },
 	EasyGHLBass: { instrument: 'bassghl', difficulty: 'easy' },
+
+	ExpertGHLKeys: { instrument: 'keysghl', difficulty: 'expert' },
+	HardGHLKeys: { instrument: 'keysghl', difficulty: 'hard' },
+	MediumGHLKeys: { instrument: 'keysghl', difficulty: 'medium' },
+	EasyGHLKeys: { instrument: 'keysghl', difficulty: 'easy' },
 } as const
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -203,6 +208,8 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 					textEvents: [],
 					versusPhrases: [],
 					animations: [], // .chart format does not have note-based animations
+					proKeysRangeShifts: [], // Pro instruments are MIDI-only
+					rawNotes: [], // Pro instruments are MIDI-only
 				}
 
 				for (const event of trackEvents) {

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -5,6 +5,94 @@ import { getEncoding } from 'src/utils'
 import { EventType, eventTypes, RawChartData } from './note-parsing-interfaces'
 import { extractChartLyrics, extractChartVocalPhrases } from './lyric-parser'
 
+/**
+ * Resolve a .chart section name like "ExpertDoubleDrums" into an instrument
+ * + difficulty pair. Matches YARG.Core's ChartReader logic: scan for a
+ * difficulty prefix ("Expert", "Hard", "Medium", "Easy") then match the
+ * suffix against the instrument suffix table (Single, DoubleGuitar,
+ * DoubleBass, DoubleRhythm, Drums, Keyboard, GHL*). Returns null if no match.
+ */
+/**
+ * Replicate YARG.Core's `FastInt32Parse`:
+ * ```
+ * int value = 0;
+ * foreach (char c in text) value = value * 10 + (c - '0');
+ * ```
+ * This intentionally has no error handling — for a non-digit character, it
+ * produces a negative "digit" (c - 48) that folds into the accumulator. YARG
+ * then casts the result to `uint` for the tick value, which wraps negative
+ * int32 values into their two's-complement uint32 equivalents. We match that
+ * by applying `>>> 0` (unsigned right shift by 0) to the final value, which
+ * JavaScript uses for int32 → uint32 conversion.
+ */
+
+/**
+ * Parse a .chart [Events] event text as a section event, matching YARG's
+ * TextEvents.NormalizeTextEvent → TryParseSectionEvent pipeline.
+ * Returns the section name, or null if not a section.
+ */
+function parseChartSectionEventText(innerText: string): string | null {
+	// NormalizeTextEvent: if there's both `[` and `]`, return content between
+	// the FIRST `[` and FIRST `]` (trimmed). Otherwise trim.
+	let text = innerText
+	const openIdx = text.indexOf('[')
+	const closeIdx = text.indexOf(']')
+	if (openIdx >= 0 && closeIdx >= 0 && openIdx <= closeIdx) {
+		text = text.slice(openIdx + 1, closeIdx)
+	}
+	text = text.replace(/^[\s\r\n]+|[\s\r\n]+$/g, '')
+
+	// TryParseSectionEvent: strip "section" or "prc" prefix
+	let name: string
+	if (text.startsWith('section')) {
+		name = text.slice('section'.length)
+	} else if (text.startsWith('prc')) {
+		name = text.slice('prc'.length)
+	} else {
+		return null
+	}
+
+	// TrimStart('_').Trim()
+	while (name.length > 0 && name[0] === '_') name = name.slice(1)
+	name = name.replace(/^[\s\r\n]+|[\s\r\n]+$/g, '')
+
+	if (name.length === 0) return null
+	return name
+}
+
+function resolveChartTrackName(sectionName: string): { instrument: Instrument; difficulty: Difficulty } | null {
+	const difficulties: { prefix: string; difficulty: Difficulty }[] = [
+		{ prefix: 'Expert', difficulty: 'expert' },
+		{ prefix: 'Hard', difficulty: 'hard' },
+		{ prefix: 'Medium', difficulty: 'medium' },
+		{ prefix: 'Easy', difficulty: 'easy' },
+	]
+	const instruments: { suffix: string; instrument: Instrument }[] = [
+		// Order matters: longer/more specific suffixes first so "DoubleGuitar"
+		// doesn't get matched by plain "Guitar", etc.
+		{ suffix: 'DoubleGuitar', instrument: 'guitarcoop' },
+		{ suffix: 'DoubleBass', instrument: 'bass' },
+		{ suffix: 'DoubleRhythm', instrument: 'rhythm' },
+		{ suffix: 'GHLGuitar', instrument: 'guitarghl' },
+		{ suffix: 'GHLBass', instrument: 'bassghl' },
+		{ suffix: 'GHLRhythm', instrument: 'rhythmghl' },
+		{ suffix: 'GHLCoop', instrument: 'guitarcoopghl' },
+		{ suffix: 'Keyboard', instrument: 'keys' },
+		{ suffix: 'Drums', instrument: 'drums' },
+		{ suffix: 'Single', instrument: 'guitar' },
+	]
+	for (const { prefix, difficulty } of difficulties) {
+		if (!sectionName.startsWith(prefix)) continue
+		for (const { suffix, instrument } of instruments) {
+			if (sectionName.endsWith(suffix)) {
+				return { instrument, difficulty }
+			}
+		}
+		return null
+	}
+	return null
+}
+
 /* eslint-disable @typescript-eslint/naming-convention */
 type TrackName = keyof typeof trackNameMap
 const trackNameMap = {
@@ -91,6 +179,10 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		throw 'Invalid .chart file: no sections were found.'
 	}
 
+	// Filter the [Events] section using YARG's strict-ordering + malformed-
+	// line blackhole logic. YARG's ChartReader iterates [Events] line-by-line:
+	// for each line, it calls FastInt32Parse on the tick text (the text
+	// before '='), then throws "tick went backwards" if the new tick is
 	const metadata = _.chain(fileSections['Song'])
 		.map(line => /^(.+?) = "?(.*?)"?$/.exec(line))
 		.compact()
@@ -131,6 +223,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				rangeShifts: [],
 				lyricShifts: [],
 				staticLyricPhrases: [],
+				textEvents: [],
 			},
 		},
 		tempos: _.chain(fileSections['SyncTrack'])
@@ -178,10 +271,18 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		parseIssues: [],
 		venue: [], // VENUE is MIDI-only
 		trackData: _.chain(fileSections)
-			.pick(_.keys(trackNameMap))
+			.pickBy((_lines, sectionName) =>
+				// Match YARG.Core's ChartReader: accept any section whose name
+				// starts with a difficulty ("Expert", "Hard", "Medium", "Easy")
+				// AND ends with a known instrument string. This handles typos
+				// and non-standard names like "ExpertDoubleDrums" (Megadeth -
+				// Bite the Hand) which YARG parses as "Expert" + "Drums".
+				resolveChartTrackName(sectionName) !== null,
+			)
 			.toPairs()
 			.map(([trackName, lines]) => {
-				const { instrument, difficulty } = trackNameMap[trackName as TrackName]
+				// pickBy above guarantees resolveChartTrackName returns non-null here.
+				const { instrument, difficulty } = resolveChartTrackName(trackName)!
 				// Single parsing pass that produces note-shaped events (`{ tick, type, length }`)
 				// plus data-carrying events (text, versus). Note-shaped events flow through
 				// the same distribution loop as before; the data-carrying ones are routed
@@ -506,6 +607,18 @@ function getNEventType(value: string, instrument: Instrument): EventType | null 
 /**
  * Merge `solo` and `soloend` events into `EventType.soloSection`.
  *
+ * Matches YARG.Core's ChartReader solo handling: tracks at most one "next
+ * start", so when a `soloend` closes the current solo, the outermost
+ * currently-open `solo` wins. Multiple nested `solo` events inside an open
+ * solo are treated as no-ops (only the first contributes to the resulting
+ * phrase). `.chart` specs treat `soloend` as inclusive, so length is
+ * soloendTick - startTick + 1 (except when a next `solo` lands on the same
+ * tick as the `soloend`, in which case the existing solo closes exclusively
+ * and the new one opens immediately).
+ */
+/**
+ * Merge `solo` and `soloend` events into `EventType.soloSection`.
+ *
  * Note: .chart specs say that notes in the last tick of the solo section are included, unlike most phrases.
  * This is normalized here by increasing the length by 1.
  */
@@ -552,14 +665,19 @@ function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
 		unrecognizedEvents: [],
 	}
 	for (const line of eventLines) {
-		const match = /^(\d+) = E "([^\r\n]*?)"$/.exec(line)
+		const match = /^(\d+) = E "([\s\S]*)"$/.exec(line)
 		if (!match) continue
 		const tick = Number(match[1])
 		const text = match[2]
 
-		const sectionMatch = /^\[?(?:section|prc)[ _](.*?)\]?$/.exec(text)
-		if (sectionMatch) {
-			result.sections.push({ tick, name: sectionMatch[1] })
+		// Section classification uses the same normalize-then-strip pipeline
+		// YARG uses (`parseChartSectionEventText`), so we and the section
+		// extractor agree on what counts as a section. This handles typos like
+		// "sections Pre-Chorus" that YARG's `StartsWith("section")` accepts.
+		const inner = text.replace(/^[\s\r\n]+|[\s\r\n]+$/g, '')
+		const sectionName = parseChartSectionEventText(inner)
+		if (sectionName !== null) {
+			result.sections.push({ tick, name: sectionName })
 			continue
 		}
 		if (/^\[?end\]?$/.test(text)) {
@@ -579,6 +697,9 @@ function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
 
 		result.unrecognizedEvents.push({ tick, text })
 	}
+	// Sort by (tick, text) for deterministic ordering so round-trips don't
+	// diverge on charts that store same-tick events in file order.
+	result.unrecognizedEvents.sort((a, b) => a.tick - b.tick || a.text.localeCompare(b.text))
 	return result
 }
 

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -202,10 +202,14 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 					starPowerSections: [],
 					rejectedStarPowerSections: [],
 					soloSections: [],
+					glissandoSections: [],
 					flexLanes: [],
 					drumFreestyleSections: [],
 					trackEvents: [],
 					textEvents: [],
+					handMaps: [],     // HandMap/StrumMap/CharacterState are rare in .chart
+					strumMaps: [],
+					characterStates: [],
 					versusPhrases: [],
 					animations: [], // .chart format does not have note-based animations
 					proKeysRangeShifts: [], // Pro instruments are MIDI-only
@@ -563,6 +567,9 @@ function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
 		}
 		if (/^\s*\[?coda\]?\s*$/.test(text)) {
 			result.codaEvents.push({ tick })
+			// Coda is also exposed in unrecognizedEvents for consumer visibility
+			// (matching YARG/MoonSong behavior where coda appears in globalEvents).
+			result.unrecognizedEvents.push({ tick, text })
 			continue
 		}
 		// Lyrics and phrase markers are extracted by the vocal parsing path — skip here

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -98,12 +98,10 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		throw 'Invalid .chart file: resolution not found.'
 	}
 
-	const codaEvents = _.chain(fileSections['Events'])
-		.map(line => /^(\d+) = E "\s*\[?coda\]?\s*"$/.exec(line))
-		.compact()
-		.map(([, stringTick]) => ({ tick: Number(stringTick) }))
-		.value()
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].tick : null
+	// Classify each line of the [Events] section into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents.
+	const eventsScan = scanEventsSection(fileSections['Events'] ?? [])
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: resolution,
@@ -169,21 +167,9 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				}
 			})
 			.value(),
-		sections: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?(?:section|prc)[ _](.*?)\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick, stringName]) => ({
-				tick: Number(stringTick),
-				name: stringName,
-			}))
-			.value(),
-		endEvents: _.chain(fileSections['Events'])
-			.map(line => /^(\d+) = E "\[?end\]?"$/.exec(line))
-			.compact()
-			.map(([, stringTick]) => ({
-				tick: Number(stringTick),
-			}))
-			.value(),
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [],
 		trackData: _.chain(fileSections)
 			.pick(_.keys(trackNameMap))
@@ -529,5 +515,55 @@ function mergeSoloEvents(events: { tick: number; type: EventType; length: number
 	_.remove(events, event => event.type === eventTypes.soloSectionStart || event.type === eventTypes.soloSectionEnd)
 
 	return events
+}
+
+interface ChartEventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining E-events not recognized as sections/end/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocal
+	 *  parsing path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+}
+
+/**
+ * Parse each line of the .chart [Events] section once via the generic
+ * `TICK = E "TEXT"` regex, then classify the text into one of
+ * {section, end, coda, lyric, phrase, unrecognized}.
+ */
+function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
+	const result: ChartEventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+	}
+	for (const line of eventLines) {
+		const match = /^(\d+) = E "([^\r\n]*?)"$/.exec(line)
+		if (!match) continue
+		const tick = Number(match[1])
+		const text = match[2]
+
+		const sectionMatch = /^\[?(?:section|prc)[ _](.*?)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers are extracted by the vocal parsing path — skip here
+		if (/^\s*lyric[ \t]/.test(text)) continue
+		if (/^(?:phrase_start|phrase_end)$/.test(text)) continue
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -176,6 +176,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [],
+		venue: [], // VENUE is MIDI-only
 		trackData: _.chain(fileSections)
 			.pick(_.keys(trackNameMap))
 			.toPairs()

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -195,6 +195,8 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	invalidLyric: 'This lyric is on the EVENTS track instead of PART VOCALS and will not be displayed.',
 	invalidPhraseStart: 'This phrase_start is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
+	duplicateDrumsTrack:
+		'This chart has both PART DRUMS and PART REAL_DRUMS_PS. PART DRUMS takes precedence; the PART REAL_DRUMS_PS track was dropped.',
 } as const
 
 function findChartIssues(

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -197,6 +197,10 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 	duplicateDrumsTrack:
 		'This chart has both PART DRUMS and PART REAL_DRUMS_PS. PART DRUMS takes precedence; the PART REAL_DRUMS_PS track was dropped.',
+	orphanedNoteStart:
+		'This track has a noteOn with no matching noteOff and was dropped.',
+	orphanedNoteEnd:
+		'This track has a noteOff with no matching noteOn and was dropped.',
 } as const
 
 function findChartIssues(

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -192,6 +192,9 @@ const chartIssueDescriptions: { [issue in ChartIssueType]: string } = {
 	brokenNote: 'This note is so close to the previous note that this was likely a charting mistake.',
 	badSustainGap: 'This note is not far enough ahead of the previous sustain.',
 	babySustain: 'The sustain on this note is too short.',
+	invalidLyric: 'This lyric is on the EVENTS track instead of PART VOCALS and will not be displayed.',
+	invalidPhraseStart: 'This phrase_start is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
+	invalidPhraseEnd: 'This phrase_end is on the EVENTS track. Vocal phrase boundaries in .mid charts must be MIDI note 105 (player 1) or 106 (player 2) on PART VOCALS.',
 } as const
 
 function findChartIssues(

--- a/src/chart/lyric-parser.ts
+++ b/src/chart/lyric-parser.ts
@@ -79,6 +79,9 @@ export function extractChartLyrics(eventLines: string[]): { tick: number; length
 
 /**
  * Extract vocal phrase boundaries from .chart [Events] phrase_start/phrase_end pairs.
+ * Returns normal paired phrases. Orphan phrase_end events (no preceding
+ * phrase_start) are NOT included here; use `extractChartOrphanPhraseEnds` to
+ * retrieve them separately.
  */
 export function extractChartVocalPhrases(eventLines: string[]): { tick: number; length: number }[] {
 	const phrases: { tick: number; length: number }[] = []
@@ -94,17 +97,44 @@ export function extractChartVocalPhrases(eventLines: string[]): { tick: number; 
 			}
 			currentStart = result.tick
 		} else {
-			// If no phrase_start is open, treat as starting from tick 0.
-			// Orphaned phrase_ends are kept so editors can surface them for manual fixing.
-			if (currentStart === null) {
-				currentStart = 0
+			// phrase_end: only push if a phrase_start is open. Orphan phrase_ends
+			// (no preceding phrase_start) are skipped here — a synthetic (0, endTick)
+			// phrase would corrupt lyric grouping by "stealing" lyrics from earlier
+			// real phrases via the shared lyricIdx. Orphans are preserved via
+			// `extractChartOrphanPhraseEnds` so writers can re-emit them verbatim.
+			if (currentStart !== null) {
+				phrases.push({ tick: currentStart, length: result.tick - currentStart })
+				currentStart = null
 			}
-			phrases.push({ tick: currentStart, length: result.tick - currentStart })
-			currentStart = null
 		}
 	}
 
 	return phrases
+}
+
+/**
+ * Extract orphan `phrase_end` events from .chart [Events] — a `phrase_end`
+ * whose most recent predecessor is NOT a matching `phrase_start`. These are
+ * malformed but exist in some charts; YARG preserves them as text events in
+ * its globalEvents output, so we keep them here for round-trip fidelity.
+ */
+export function extractChartOrphanPhraseEnds(eventLines: string[]): { tick: number }[] {
+	const orphans: { tick: number }[] = []
+	let currentStart: number | null = null
+	for (const line of eventLines) {
+		const result = parseChartVocalPhraseLine(line)
+		if (!result) continue
+		if (result.type === 'start') {
+			currentStart = result.tick
+		} else {
+			if (currentStart === null) {
+				orphans.push({ tick: result.tick })
+			} else {
+				currentStart = null
+			}
+		}
+	}
+	return orphans
 }
 
 // ---------------------------------------------------------------------------
@@ -179,25 +209,68 @@ export function extractMidiLyricText(event: MidiTextLikeEvent): string {
 }
 
 /**
+ * Extract bracketed control-event text events on a vocal track (stance markers,
+ * facial anim, etc.). These aren't lyrics but YARG's ProcessTextEvent still
+ * adds them to the chart's text events via MoonText, and VocalsPart.IsEmpty
+ * returns `false` iff there's any such event — so dropping them causes a vocal
+ * track with only stance markers to be hidden in ChartDump.
+ *
+ * We intentionally exclude:
+ *   - real lyrics (see `extractMidiLyrics`)
+ *   - disco flip events `[mix N drumsM]` (drum-specific; shouldn't be on vocals)
+ *   - `ENHANCED_OPENS` / `ENABLE_CHART_DYNAMICS` (instrument-wide consumables)
+ *   - `range_shift` (handled via the rangeShifts path on its own)
+ */
+export function extractMidiVocalTextEvents(trackEvents: MidiLyricEvent[]): { tick: number; text: string }[] {
+	const out: { tick: number; text: string }[] = []
+	// Match YARG.Core's MidReader.ReadNotes: it starts iteration at `i = 1`
+	// with the comment "First event is the track name event, which gets
+	// skipped". Some MIDI files have a stray FF 01 text duplicate of the
+	// track name at index 0 — YARG silently drops it, so scan-chart should
+	// too, otherwise we capture a phantom "PART VOCALS" text that appears
+	// as a lyric on re-parse.
+	for (let i = 1; i < trackEvents.length; i++) {
+		const event = trackEvents[i]
+		const isTextLike = event.type === 'lyrics' || event.type === 'text' ||
+			event.type === 'marker' || event.type === 'cuePoint'
+		if (!isTextLike) continue
+		const text = event.text
+		if (text === undefined || text === null) continue
+		const trimmed = text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
+		const isBracketed = trimmed.startsWith('[') && trimmed.endsWith(']')
+		// We capture text-like events that YARG would preserve as MoonText but
+		// scan-chart otherwise drops from `data.lyrics` (via normalizeVocalPart's
+		// bracketed-control-event filter). Lyrics themselves live in `data.lyrics`
+		// and are handled separately.
+		if (!isBracketed) continue
+		// Skip events scan-chart consumes internally
+		if (text === 'ENHANCED_OPENS' || text === '[ENHANCED_OPENS]') continue
+		if (text === 'ENABLE_CHART_DYNAMICS' || text === '[ENABLE_CHART_DYNAMICS]') continue
+		// Skip disco flip markers (drum-track concept; shouldn't appear on vocals)
+		if (/^\s*\[?mix[ _][0-3][ _]drums[0-5](d|dnoflip|easy|easynokick|)\]?\s*$/.test(text)) continue
+		if (trimmed.startsWith('[range_shift')) continue
+		out.push({ tick: event.deltaTime, text })
+	}
+	return out
+}
+
+/**
  * Extract all lyrics from a PART VOCALS MIDI track's events.
  * Events must already be in absolute time (deltaTime = absolute tick).
  * Deduplicates by tick+text (matching MoonSong InsertionEquals).
  */
 export function extractMidiLyrics(trackEvents: MidiLyricEvent[]): { tick: number; length: number; text: string }[] {
-	// Find the track name so we can skip tick-0 text events that duplicate it.
-	// Some MIDI files have an FF 01 text event "PART VOCALS" at tick 0 which is
-	// a duplicate of the FF 03 trackName — not a real lyric. YARG keeps these
-	// (a YARG bug), but we filter them out.
-	const trackNameEvent = trackEvents.find(e => e.type === 'trackName')
-	const trackName = trackNameEvent?.text
-
 	const lyrics: { tick: number; length: number; text: string }[] = []
 	const seen = new Set<string>()
-	for (const event of trackEvents) {
+	// Match YARG.Core's MidReader.ReadNotes: skip the first event (which is
+	// conventionally the trackName and lost by "for (int i = 1; ...)"). Charts
+	// like "Andrew Prahlow - Travelers' Encore" have an FF 01 text event
+	// "PART VOCALS" AS the first event — YARG drops it silently. Skipping it
+	// here matches that behavior.
+	for (let i = 1; i < trackEvents.length; i++) {
+		const event = trackEvents[i]
 		if (isMidiVocalLyric(event)) {
 			const text = extractMidiLyricText(event)
-			// Skip tick-0 text events that match the track name (instrumentName duplicate)
-			if (event.deltaTime === 0 && text === trackName && event.type === 'text') continue
 			const key = `${event.deltaTime}:${text}`
 			if (seen.has(key)) continue
 			seen.add(key)
@@ -271,8 +344,27 @@ function extractMidiNotePairs(
 // ---------------------------------------------------------------------------
 
 /**
- * Extract vocal phrase boundaries from MIDI notes 105/106 on PART VOCALS.
+ * Extract scoring phrase boundaries (note 105) from a MIDI vocal track.
  * Events must already be in absolute time (deltaTime = absolute tick).
+ */
+export function extractMidi105Phrases(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
+	return extractMidiNotePairs(trackEvents, n => n === 105)
+		.map(p => ({ tick: p.tick, length: p.length }))
+}
+
+/**
+ * Extract static lyric display phrase boundaries (note 106) from a MIDI vocal track.
+ * On HARM2/HARM3 these are the "static lyric" phrases that display lyrics
+ * alongside HARM1's scoring phrases. On PART VOCALS this is the player-2 phrase.
+ */
+export function extractMidi106Phrases(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
+	return extractMidiNotePairs(trackEvents, n => n === 106)
+		.map(p => ({ tick: p.tick, length: p.length }))
+}
+
+/**
+ * @deprecated Use `extractMidi105Phrases` and `extractMidi106Phrases` separately.
+ * Kept for backward compatibility with scan-chart's own tests.
  */
 export function extractMidiVocalPhrases(trackEvents: MidiLyricEvent[]): { tick: number; length: number; noteNumber: number }[] {
 	return extractMidiNotePairs(trackEvents, n => n === 105 || n === 106)

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -20,6 +20,17 @@ const trackNames = [
 	'PART GUITAR COOP GHL',
 	'PART RHYTHM GHL',
 	'PART BASS GHL',
+	'PART KEYS GHL',
+	'PART REAL_GUITAR',
+	'PART REAL_GUITAR_22',
+	'PART REAL_BASS',
+	'PART REAL_BASS_22',
+	'PART REAL_KEYS_X',
+	'PART REAL_KEYS_H',
+	'PART REAL_KEYS_M',
+	'PART REAL_KEYS_E',
+	'PART ELITE_DRUMS',
+	'PART REAL_DRUMS_PS',
 	'PART VOCALS',
 	'HARM1',
 	'HARM2',
@@ -52,8 +63,28 @@ const instrumentNameMap: { [key in InstrumentTrackName]: Instrument } = {
 	'PART GUITAR COOP GHL': 'guitarcoopghl',
 	'PART RHYTHM GHL': 'rhythmghl',
 	'PART BASS GHL': 'bassghl',
+	'PART KEYS GHL': 'keysghl',
+	'PART REAL_GUITAR': 'proguitar',
+	'PART REAL_GUITAR_22': 'proguitar22',
+	'PART REAL_BASS': 'probass',
+	'PART REAL_BASS_22': 'probass22',
+	'PART REAL_KEYS_X': 'prokeys',
+	'PART REAL_KEYS_H': 'prokeys',
+	'PART REAL_KEYS_M': 'prokeys',
+	'PART REAL_KEYS_E': 'prokeys',
+	'PART ELITE_DRUMS': 'elitedrums',
+	'PART REAL_DRUMS_PS': 'drums',
 } as const
 /* eslint-enable @typescript-eslint/naming-convention */
+
+/** Pro Keys uses one MIDI track per difficulty instead of one track for all difficulties. */
+const proKeysDifficultyMap: { [key: string]: Difficulty } = {
+	'PART REAL_KEYS_X': 'expert',
+	'PART REAL_KEYS_H': 'hard',
+	'PART REAL_KEYS_M': 'medium',
+	'PART REAL_KEYS_E': 'easy',
+}
+
 
 const sysExDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 const discoFlipDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
@@ -106,7 +137,21 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 	// Sets event.deltaTime to the number of ticks since the start of the track
 	convertToAbsoluteTime(midiFile)
 
-	const tracks = getTracks(midiFile)
+	const allTracks = getTracks(midiFile)
+	const parseIssues: RawChartData['parseIssues'] = []
+
+	// YARG/Moonscraper behavior: PART DRUMS is canonical; PART REAL_DRUMS_PS is a
+	// fallback used only when PART DRUMS is absent. When both exist, drop the
+	// fallback entirely (matches YARG's TrackOverrides dictionary, where
+	// DRUMS_REAL_TRACK has overwrite=false so it's discarded once drums is loaded).
+	const hasCanonicalDrums = allTracks.some(t => t.trackName === 'PART DRUMS')
+	const hasFallbackDrums = allTracks.some(t => t.trackName === 'PART REAL_DRUMS_PS')
+	const tracks = hasCanonicalDrums && hasFallbackDrums
+		? allTracks.filter(t => t.trackName !== 'PART REAL_DRUMS_PS')
+		: allTracks
+	if (hasCanonicalDrums && hasFallbackDrums) {
+		parseIssues.push({ instrument: 'drums', difficulty: null, noteIssue: 'duplicateDrumsTrack' })
+	}
 
 	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3
 	const vocalTracks: { [part: string]: VocalTrackData } = {}
@@ -195,24 +240,35 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
-		parseIssues: eventsScan.parseIssues,
+		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
 				const instrument = instrumentNameMap[t.trackName as InstrumentTrackName]
 				const instrumentType = getInstrumentType(instrument)
 				// Single scan pass extracts note-shaped events AND the
-				// data-carrying ones (text, versus, animations).
-				const { eventEnds, textEvents, versusPhrases, animations } = scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				// data-carrying ones (text, versus, animations, pro-instrument rawNotes,
+				// Pro Keys range shifts).
+				const { eventEnds, textEvents, versusPhrases, animations, rawNotesByDifficulty, proKeysRangeShifts } =
+					scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				// Pro instruments (pro guitar/bass, pro keys, elite drums) don't use
+				// the difficulty-range noteOn dispatch, so their 'all'-difficulty
+				// modifiers need to be copied to every difficulty unconditionally.
+				const forceDistribute = storesRawNotes(instrumentType)
 				const trackDifficulties = _.chain(eventEnds)
-					.thru(eventEnds => distributeInstrumentEvents(eventEnds)) // Removes 'all' difficulty
+					.thru(eventEnds => distributeInstrumentEvents(eventEnds, forceDistribute)) // Removes 'all' difficulty
 					.thru(eventEnds => getTrackEvents(eventEnds)) // Connects note ends together
 					.thru(events => splitMidiModifierSustains(events, instrumentType))
 					.thru(events => fixLegacyGhStarPower(events, instrumentType, iniChartModifiers))
 					.thru(events => fixFlexLaneLds(events))
 					.value()
 
-				return difficulties.map(difficulty => {
+				// Pro Keys uses one MIDI track per difficulty; other instruments
+				// have all 4 difficulties on one track.
+				const fixedDifficulty = proKeysDifficultyMap[t.trackName as string]
+				const diffsToProcess = fixedDifficulty ? [fixedDifficulty] as Difficulty[] : difficulties
+
+				return diffsToProcess.map(difficulty => {
 					const result: RawChartData['trackData'][number] = {
 						instrument,
 						difficulty,
@@ -225,6 +281,8 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 						textEvents,
 						versusPhrases,
 						animations,
+						proKeysRangeShifts,
+						rawNotes: rawNotesByDifficulty[difficulty],
 					}
 
 					for (const event of trackDifficulties[difficulty]) {
@@ -255,7 +313,13 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				})
 			})
 			.flatMap()
-			.filter(track => track.trackEvents.length > 0)
+			.filter(track =>
+				track.trackEvents.length > 0
+				|| track.rawNotes.length > 0
+				|| track.starPowerSections.length > 0
+				|| track.soloSections.length > 0,
+			)
+			.thru(tracks => copyDownProKeysPhrases(tracks))
 			.value(),
 	}
 }
@@ -300,6 +364,11 @@ interface TrackScanResult {
 	textEvents: { tick: number; text: string }[]
 	versusPhrases: { tick: number; length: number; isPlayer2: boolean }[]
 	animations: { tick: number; length: number; noteNumber: number }[]
+	/** Per-difficulty raw MIDI notes, populated for instrument types that store
+	 *  raw notes (pro guitar/bass, pro keys, elite drums). Empty otherwise. */
+	rawNotesByDifficulty: { [key in Difficulty]: RawNote[] }
+	/** Pro Keys range shift markers (notes 0, 2, 4, 5, 7, 9). Empty for other instruments. */
+	proKeysRangeShifts: { tick: number; length: number; noteNumber: number }[]
 }
 
 /**
@@ -308,7 +377,8 @@ interface TrackScanResult {
  *     `distributeInstrumentEvents` / `getTrackEvents`)
  *   - data-carrying events that ride alongside the notes: `textEvents`,
  *     `versusPhrases` (notes 105/106), `animations` (notes 24-51 drums,
- *     40-59 fret)
+ *     40-59 fret), and for pro instruments: `rawNotesByDifficulty` and
+ *     `proKeysRangeShifts`
  *
  * Versus phrases and animations live in the same MIDI event stream as the
  * playable notes, so they're emitted from this single iteration.
@@ -335,6 +405,14 @@ function scanInstrumentTrack(
 	const animationFilter = instrumentType === instrumentTypes.drums
 		? (n: number) => n >= 24 && n <= 51
 		: (n: number) => n >= 40 && n <= 59
+	// Raw notes + pro keys range shifts (pro guitar/bass, pro keys, elite drums).
+	const collectRawNotes = storesRawNotes(instrumentType)
+	const fixedRawNoteDifficulty = proKeysDifficultyMap[trackName]
+	const rawStarts = new Map<string, { tick: number; noteNumber: number; velocity: number; channel: number }>() // keyed by noteNumber+channel
+	const rawNotesByDifficulty: { [key in Difficulty]: RawNote[] } = { expert: [], hard: [], medium: [], easy: [] }
+	const rangeShiftStarts = new Map<number, number>() // noteNumber → startTick
+	const proKeysRangeShifts: { tick: number; length: number; noteNumber: number }[] = []
+	const isProKeys = instrumentType === instrumentTypes.proKeys
 
 	for (const event of events) {
 		// SysEx event (tap modifier or open)
@@ -358,6 +436,52 @@ function scanInstrumentTrack(
 			}
 		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
 			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+
+			// Collect per-difficulty raw MIDI notes for pro guitar/bass, pro keys,
+			// and elite drums. These instruments store notes verbatim with
+			// velocity+channel (matching YARG.Core) rather than being dispatched
+			// through the difficulty-range noteOn logic below.
+			if (collectRawNotes) {
+				const key = `${event.noteNumber}:${event.channel}`
+				if (!isOff) {
+					if (!rawStarts.has(key)) {
+						rawStarts.set(key, { tick: event.deltaTime, noteNumber: event.noteNumber, velocity: event.velocity, channel: event.channel })
+					}
+				} else {
+					const start = rawStarts.get(key)
+					if (start) {
+						const diff = getRawNoteDifficulty(event.noteNumber, instrumentType, fixedRawNoteDifficulty)
+						if (diff) {
+							rawNotesByDifficulty[diff].push({
+								tick: start.tick,
+								length: event.deltaTime - start.tick,
+								noteNumber: start.noteNumber,
+								velocity: start.velocity,
+								channel: start.channel,
+							})
+						}
+						rawStarts.delete(key)
+					}
+				}
+			}
+
+			// Pro Keys range shift markers (notes 0, 2, 4, 5, 7, 9 — no overlap
+			// with Pro Keys playable notes 48-72, so exclusive).
+			if (isProKeys && (event.noteNumber === 0 || event.noteNumber === 2 || event.noteNumber === 4
+				|| event.noteNumber === 5 || event.noteNumber === 7 || event.noteNumber === 9)) {
+				if (!isOff) {
+					if (!rangeShiftStarts.has(event.noteNumber)) {
+						rangeShiftStarts.set(event.noteNumber, event.deltaTime)
+					}
+				} else {
+					const startTick = rangeShiftStarts.get(event.noteNumber)
+					if (startTick !== undefined) {
+						proKeysRangeShifts.push({ tick: startTick, length: event.deltaTime - startTick, noteNumber: event.noteNumber })
+						rangeShiftStarts.delete(event.noteNumber)
+					}
+				}
+				continue
+			}
 
 			// Collect versus phrase markers (notes 105/106). These don't overlap
 			// with any note-shaped events, so we don't fall through.
@@ -402,7 +526,7 @@ function scanInstrumentTrack(
 				: 'all'
 			if (difficulty === 'all') {
 				// Instrument-wide event (solo marker, star power, etc...) (applies to all difficulties)
-				const type = getInstrumentEventType(event.noteNumber)
+				const type = getInstrumentEventType(event.noteNumber, instrumentType)
 				if (type !== null) {
 					eventEnds[difficulty].push({
 						tick: event.deltaTime,
@@ -414,9 +538,10 @@ function scanInstrumentTrack(
 				}
 			} else {
 				const type =
-					(instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
+					instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
 					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(event.noteNumber, difficulty)
-					: get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)) ?? null
+					: instrumentType === instrumentTypes.fiveFret ? get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)
+					: null // New instrument types: per-difficulty notes not parsed yet
 				if (type !== null) {
 					eventEnds[difficulty].push({
 						tick: event.deltaTime,
@@ -468,24 +593,45 @@ function scanInstrumentTrack(
 
 	versusPhrases.sort((a, b) => a.tick - b.tick)
 	animations.sort((a, b) => a.tick - b.tick)
-	return { eventEnds, textEvents, versusPhrases, animations }
+	proKeysRangeShifts.sort((a, b) => a.tick - b.tick)
+	for (const diff of difficulties) {
+		rawNotesByDifficulty[diff].sort((a, b) => a.tick - b.tick || a.noteNumber - b.noteNumber)
+	}
+	return { eventEnds, textEvents, versusPhrases, animations, rawNotesByDifficulty, proKeysRangeShifts }
 }
 
 /** These apply to the entire instrument, not specific difficulties. */
-function getInstrumentEventType(note: number) {
+function getInstrumentEventType(note: number, instrumentType: InstrumentType) {
 	switch (note) {
 		case 103:
+			// Solo on standard instruments and elite drums. NOT solo on pro guitar/bass/keys (they use 115).
+			if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys) return null
 			return eventTypes.soloSection
+		case 115:
+			// Solo on pro guitar/bass and pro keys only
+			if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys) {
+				return eventTypes.soloSection
+			}
+			return null
 		case 104:
-			return eventTypes.forceTap
+			// forceTap on standard fret instruments only
+			if (instrumentType === instrumentTypes.fiveFret || instrumentType === instrumentTypes.sixFret) {
+				return eventTypes.forceTap
+			}
+			return null
 		case 109:
-			return eventTypes.forceFlam
+			// forceFlam on standard drums only
+			if (instrumentType === instrumentTypes.drums) return eventTypes.forceFlam
+			return null
 		case 110:
-			return eventTypes.yellowTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.yellowTomMarker
+			return null
 		case 111:
-			return eventTypes.blueTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.blueTomMarker
+			return null
 		case 112:
-			return eventTypes.greenTomMarker
+			if (instrumentType === instrumentTypes.drums) return eventTypes.greenTomMarker
+			return null
 		case 116:
 			return eventTypes.starPower
 		case 120:
@@ -584,10 +730,10 @@ function getDrumsNoteType(note: number, difficulty: Difficulty) {
  * enableChartDynamics is meant to apply to all charted difficulties.
  * Distributes all of these to each difficulty in the instrument.
  */
-function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] }) {
+function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] }, forceDistribute = false) {
 	for (const instrumentEvent of eventEnds.all) {
 		for (const difficulty of difficulties) {
-			if (eventEnds[difficulty].length === 0) {
+			if (!forceDistribute && eventEnds[difficulty].length === 0) {
 				continue // Skip adding modifiers to uncharted difficulties
 			}
 			eventEnds[difficulty].push(_.clone(instrumentEvent))
@@ -666,6 +812,10 @@ function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }
 function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent[] }, instrumentType: InstrumentType) {
 	let enableChartDynamics = false
 	const t = eventTypes
+	// New instrument types have no per-difficulty notes to modify; return as-is
+	if (instrumentType === instrumentTypes.proGuitar || instrumentType === instrumentTypes.proKeys || instrumentType === instrumentTypes.eliteDrums) {
+		return events
+	}
 	const modifierSustains: EventType[] =
 		instrumentType === instrumentTypes.drums ?
 			[t.forceFlam, t.yellowTomMarker, t.blueTomMarker, t.greenTomMarker]
@@ -824,6 +974,85 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	)
 
 	return events
+}
+
+export type RawNote = { tick: number; length: number; noteNumber: number; velocity: number; channel: number }
+
+/**
+ * Instruments that store per-difficulty raw MIDI notes (pro guitar/bass, pro keys,
+ * elite drums) instead of the standard difficulty-range noteOn dispatch.
+ */
+function storesRawNotes(instrumentType: InstrumentType): boolean {
+	return instrumentType === instrumentTypes.proGuitar
+		|| instrumentType === instrumentTypes.proKeys
+		|| instrumentType === instrumentTypes.eliteDrums
+}
+
+/**
+ * Determine which difficulty a raw MIDI note belongs to. Pro guitar/bass uses
+ * per-difficulty note ranges; pro keys has one MIDI track per difficulty; elite
+ * drums uses per-difficulty offsets.
+ */
+function getRawNoteDifficulty(
+	noteNumber: number,
+	instrumentType: InstrumentType,
+	fixedDifficulty?: Difficulty,
+): Difficulty | null {
+	if (instrumentType === instrumentTypes.proGuitar) {
+		// Pro Guitar/Bass: 6 strings + per-difficulty modifiers
+		// Easy=24-34, Medium=48-58, Hard=72-82, Expert=96-108
+		if (noteNumber >= 24 && noteNumber <= 34) return 'easy'
+		if (noteNumber >= 48 && noteNumber <= 58) return 'medium'
+		if (noteNumber >= 72 && noteNumber <= 82) return 'hard'
+		if (noteNumber >= 96 && noteNumber <= 108) return 'expert'
+		// Root note markers (4-18) apply to all difficulties — store on expert
+		if (noteNumber >= 4 && noteNumber <= 18) return 'expert'
+		return null
+	}
+
+	if (instrumentType === instrumentTypes.proKeys) {
+		// Pro Keys: notes 48-72 (25 keys). Each track is one difficulty.
+		if (noteNumber >= 48 && noteNumber <= 72) return fixedDifficulty ?? 'expert'
+		return null
+	}
+
+	if (instrumentType === instrumentTypes.eliteDrums) {
+		// Elite Drums: base offsets Easy=2, Medium=26, Hard=50, Expert=74
+		// 10 pads (offset -2 to +8) + modifiers (offset +13, +14, +16)
+		if (noteNumber >= 0 && noteNumber <= 18) return 'easy'
+		if (noteNumber >= 24 && noteNumber <= 42) return 'medium'
+		if (noteNumber >= 48 && noteNumber <= 66) return 'hard'
+		if (noteNumber >= 72 && noteNumber <= 90) return 'expert'
+		return null
+	}
+
+	return null
+}
+
+
+/**
+ * YARG copies star power and solo sections from the Pro Keys expert track to all other
+ * Pro Keys difficulties (each Pro Keys difficulty is a separate MIDI track, but star power
+ * and solo are only charted on the expert track).
+ */
+function copyDownProKeysPhrases(tracks: RawChartData['trackData']): RawChartData['trackData'] {
+	const expertProKeys = tracks.find(t => t.instrument === 'prokeys' && t.difficulty === 'expert')
+	if (!expertProKeys) return tracks
+
+	for (const track of tracks) {
+		if (track.instrument !== 'prokeys' || track.difficulty === 'expert') continue
+		if (track.starPowerSections.length === 0 && expertProKeys.starPowerSections.length > 0) {
+			track.starPowerSections = expertProKeys.starPowerSections.map(p => ({ ...p }))
+		}
+		if (track.soloSections.length === 0 && expertProKeys.soloSections.length > 0) {
+			track.soloSections = expertProKeys.soloSections.map(p => ({ ...p }))
+		}
+		// Range shifts are charted per-difficulty, but if missing, copy from expert
+		if (track.proKeysRangeShifts.length === 0 && expertProKeys.proKeysRangeShifts.length > 0) {
+			track.proKeysRangeShifts = expertProKeys.proKeysRangeShifts.map(p => ({ ...p }))
+		}
+	}
+	return tracks
 }
 
 /**

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -263,6 +263,9 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 					.thru(events => fixFlexLaneLds(events))
 					.value()
 
+				// Typed HandMap / StrumMap / CharacterState text events (same across difficulties).
+				const { handMaps, strumMaps, characterStates } = extractTypedTextEvents(t.trackEvents)
+
 				// Pro Keys uses one MIDI track per difficulty; other instruments
 				// have all 4 difficulties on one track.
 				const fixedDifficulty = proKeysDifficultyMap[t.trackName as string]
@@ -275,10 +278,14 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 						starPowerSections: [],
 						rejectedStarPowerSections: [],
 						soloSections: [],
+						glissandoSections: [],
 						flexLanes: [],
 						drumFreestyleSections: [],
 						trackEvents: [],
 						textEvents,
+						handMaps,
+						strumMaps,
+						characterStates,
 						versusPhrases,
 						animations,
 						proKeysRangeShifts,
@@ -292,6 +299,8 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 							result.rejectedStarPowerSections.push(event)
 						} else if (event.type === eventTypes.soloSection) {
 							result.soloSections.push(event)
+						} else if (event.type === eventTypes.glissando) {
+							result.glissandoSections.push({ tick: event.tick, length: event.length })
 						} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
 							result.flexLanes.push({
 								tick: event.tick,
@@ -647,7 +656,8 @@ function getInstrumentEventType(note: number, instrumentType: InstrumentType) {
 		// case 124:
 		// 	return eventTypes.freestyleSection5
 		case 126:
-			return eventTypes.flexLaneSingle
+			// Pro Keys: glissando. All others: tremolo/single roll lane.
+			return instrumentType === instrumentTypes.proKeys ? eventTypes.glissando : eventTypes.flexLaneSingle
 		case 127:
 			return eventTypes.flexLaneDouble
 		default:
@@ -1029,6 +1039,62 @@ function getRawNoteDifficulty(
 	return null
 }
 
+const handMapLookup: { [key: string]: RawChartData['trackData'][number]['handMaps'][number]['type'] } = {
+	'HandMap_Default': 'default', 'HandMap_NoChords': 'noChords', 'HandMap_AllChords': 'allChords',
+	'HandMap_AllBend': 'allBend', 'HandMap_Solo': 'solo', 'HandMap_DropD': 'dropD',
+	'HandMap_DropD2': 'dropD2', 'HandMap_Chord_C': 'chordC', 'HandMap_Chord_D': 'chordD',
+	'HandMap_Chord_A': 'chordA',
+}
+const strumMapLookup: { [key: string]: RawChartData['trackData'][number]['strumMaps'][number]['type'] } = {
+	'StrumMap_Default': 'default', 'StrumMap_Pick': 'pick', 'StrumMap_SlapBass': 'slapBass',
+}
+const characterStateLookup: { [key: string]: RawChartData['trackData'][number]['characterStates'][number]['type'] } = {
+	'idle': 'idle', 'idle_intense': 'idleIntense', 'idle_realtime': 'idleRealtime',
+	'play': 'play', 'play_solo': 'playSolo', 'intense': 'intense', 'mellow': 'mellow',
+}
+
+/**
+ * Extract HandMap, StrumMap, and CharacterState events from text events on instrument tracks.
+ * These are text events that YARG interprets into typed animation objects.
+ * YARG strips brackets before matching, so we normalize here.
+ */
+function extractTypedTextEvents(events: MidiEvent[]) {
+	const handMaps: RawChartData['trackData'][number]['handMaps'] = []
+	const strumMaps: RawChartData['trackData'][number]['strumMaps'] = []
+	const characterStates: RawChartData['trackData'][number]['characterStates'] = []
+
+	for (const event of events) {
+		if (!isTextLikeEvent(event)) continue
+		let text = event.text
+		// YARG's NormalizeTextEvent strips brackets
+		if (text.startsWith('[') && text.endsWith(']')) text = text.slice(1, -1)
+		text = text.trim()
+
+		// HandMap: "map HandMap_*"
+		const handMapMatch = /^map (HandMap_\w+)$/.exec(text)
+		if (handMapMatch) {
+			const type = handMapLookup[handMapMatch[1]]
+			if (type) handMaps.push({ tick: event.deltaTime, type })
+			continue
+		}
+
+		// StrumMap: "map StrumMap_*"
+		const strumMapMatch = /^map (StrumMap_\w+)$/.exec(text)
+		if (strumMapMatch) {
+			const type = strumMapLookup[strumMapMatch[1]]
+			if (type) strumMaps.push({ tick: event.deltaTime, type })
+			continue
+		}
+
+		// CharacterState: bare text matching known states
+		const charState = characterStateLookup[text]
+		if (charState) {
+			characterStates.push({ tick: event.deltaTime, type: charState })
+		}
+	}
+
+	return { handMaps, strumMaps, characterStates }
+}
 
 /**
  * YARG copies star power and solo sections from the Pro Keys expert track to all other
@@ -1068,8 +1134,10 @@ interface EventsScanResult {
 	sections: { tick: number; name: string }[]
 	endEvents: { tick: number }[]
 	codaEvents: { tick: number }[]
-	/** All remaining text-like events not recognized as sections/endEvents/coda/lyrics/phrases.
-	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocals path. */
+	/** All remaining text-like events not recognized as sections/endEvents/lyrics/phrases.
+	 *  Coda events are included here as well (for consumer visibility) in addition to
+	 *  codaEvents. Lyrics and phrase_start/phrase_end are extracted separately by the
+	 *  vocals path. */
 	unrecognizedEvents: { tick: number; text: string }[]
 	/** Issues raised while classifying EVENTS track text events (e.g. stray lyric/phrase
 	 *  events that belong on PART VOCALS, not EVENTS). */
@@ -1114,6 +1182,9 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 		}
 		if (/^\s*\[?coda\]?\s*$/.test(text)) {
 			result.codaEvents.push({ tick })
+			// Coda is also exposed in unrecognizedEvents for consumer visibility
+			// (matching YARG/MoonSong behavior where coda appears in globalEvents).
+			result.unrecognizedEvents.push({ tick, text })
 			continue
 		}
 		// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
@@ -1133,4 +1204,3 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 	}
 	return result
 }
-

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -3,11 +3,23 @@ import { MidiData, MidiEvent, MidiSetTempoEvent, MidiTextEvent, MidiTimeSignatur
 
 import { difficulties, Difficulty, getInstrumentType, Instrument, InstrumentType, instrumentTypes } from 'src/interfaces'
 import { EventType, eventTypes, IniChartModifiers, RawChartData, VenueEvent, VocalTrackData } from './note-parsing-interfaces'
-import { extractMidiLyrics, extractMidiVocalPhrases, extractMidiVocalNotes, extractMidiVocalStarPower, extractMidiRangeShifts, extractMidiLyricShifts } from './lyric-parser'
+import { extractMidiLyrics, extractMidi105Phrases, extractMidi106Phrases, extractMidiVocalNotes, extractMidiVocalStarPower, extractMidiRangeShifts, extractMidiLyricShifts, extractMidiVocalTextEvents } from './lyric-parser'
+
+// Union two phrase lists, dedup by tick (keep longest length), sort by tick.
+function mergePhraseLists(a: { tick: number; length: number }[], b: { tick: number; length: number }[]): { tick: number; length: number }[] {
+	const byTick = new Map<number, number>()
+	for (const p of [...a, ...b]) {
+		const existing = byTick.get(p.tick)
+		if (existing === undefined || p.length > existing) byTick.set(p.tick, p.length)
+	}
+	return [...byTick.entries()]
+		.sort((x, y) => x[0] - y[0])
+		.map(([tick, length]) => ({ tick, length }))
+}
 
 type TrackName = (typeof trackNames)[number]
 type VocalTrackName = 'PART VOCALS' | 'HARM1' | 'HARM2' | 'HARM3' | 'PART HARM1' | 'PART HARM2' | 'PART HARM3'
-type InstrumentTrackName = Exclude<TrackName, VocalTrackName | 'EVENTS' | 'VENUE'>
+type InstrumentTrackName = Exclude<TrackName, VocalTrackName | 'EVENTS' | 'VENUE' | 'BEAT'>
 const trackNames = [
 	'T1 GEMS',
 	'PART GUITAR',
@@ -32,6 +44,7 @@ const trackNames = [
 	'PART ELITE_DRUMS',
 	'PART REAL_DRUMS_PS',
 	'VENUE',
+	'BEAT',
 	'PART VOCALS',
 	'HARM1',
 	'HARM2',
@@ -101,10 +114,35 @@ interface TrackEventEnd {
 	channel: number
 	// Necessary because .mid stores track events as separate start and end events
 	isStart: boolean
+	/**
+	 * Internal marker for Phase Shift SysEx-sourced forceTap events. YARG.Core
+	 * treats SysEx-based taps as INCLUSIVE-end sustains (Phase Shift / Clone Hero
+	 * behavior) while note-104-based taps are EXCLUSIVE-end (like all other
+	 * note-based modifiers). scan-chart can't otherwise distinguish the two.
+	 */
+	_fromSysEx?: boolean
+	/**
+	 * Insertion index in the original MIDI file, used for stable tiebreaking
+	 * when multiple events land on the same tick. YARG.Core processes modifier
+	 * closures in file order, so the relative position of noteOff events at
+	 * the same tick determines which force modifier wins a conflict.
+	 */
+	_seq?: number
 }
 
 // Necessary because .mid stores some additional modifiers and information using velocity
-type MidiTrackEvent = RawChartData['trackData'][number]['trackEvents'][number] & { velocity: number; channel: number }
+type MidiTrackEvent = RawChartData['trackData'][number]['trackEvents'][number] & {
+	velocity: number
+	channel: number
+	_fromSysEx?: boolean
+	/**
+	 * Sequence number (MIDI file order) of the END event that closed this sustain.
+	 * Used by resolveFretModifiers to match YARG's "last closure wins" behavior:
+	 * when multiple force modifiers cover a note, pick the one with the largest
+	 * `_endSeq`, matching YARG's MidReader forcingProcessList iteration order.
+	 */
+	_endSeq?: number
+}
 
 /**
  * Parses `buffer` as a chart in the .mid format. Returns all the note data in `RawChartData`, but any
@@ -154,40 +192,63 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		parseIssues.push({ instrument: 'drums', difficulty: null, noteIssue: 'duplicateDrumsTrack' })
 	}
 
-	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3
+	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3.
+	// Separate note 105 (scoring phrases) from note 106 (static lyric / player-2
+	// display phrases) at extraction time. This lets the writer round-trip HARM2/HARM3
+	// without any pre-CopyDown stashing: HARM2/HARM3 emit staticLyricPhrases as
+	// note 106 on their own track, HARM1 emits vocalPhrases as note 105, and CopyDown
+	// on re-parse re-copies HARM1's vocalPhrases to HARM2/HARM3 — identical result.
 	const vocalTracks: { [part: string]: VocalTrackData } = {}
 	for (const track of tracks) {
 		const partName = vocalTrackNameMap[track.trackName as VocalTrackName]
 		if (partName && !vocalTracks[partName]) {
 			const events = track.trackEvents
+			// YARG treats BOTH note 105 (LYRICS_PHRASE_1) and note 106
+			// (LYRICS_PHRASE_2) as creating a `Vocals_StaticLyricPhrase` in HARM2/
+			// HARM3's specialPhrases (plus `Vocals_ScoringPhrase` which CopyDown
+			// later replaces from HARM1). Match that by unioning both sets for
+			// harmony parts. For solo vocals and HARM1, the static-lyric view is
+			// simply a duplicate of the note-phrase (scoring) list per YARG's
+			// MoonSongLoader.Vocals.cs.
+			const phrases105 = extractMidi105Phrases(events)
+			const phrases106 = extractMidi106Phrases(events)
+			const isHarmonyBacking = partName === 'harmony2' || partName === 'harmony3'
 			vocalTracks[partName] = {
 				lyrics: extractMidiLyrics(events),
-				vocalPhrases: extractMidiVocalPhrases(events),
+				vocalPhrases: phrases105,
 				notes: extractMidiVocalNotes(events),
 				starPowerSections: extractMidiVocalStarPower(events),
 				rangeShifts: extractMidiRangeShifts(events),
 				lyricShifts: extractMidiLyricShifts(events),
-				staticLyricPhrases: [],
+				staticLyricPhrases: isHarmonyBacking
+					? mergePhraseLists(phrases105, phrases106)
+					: phrases106,
+				// Raw text events on the vocal track (stance, facial anim, etc.)
+				// that YARG preserves as MoonText events. Required for round-trip
+				// of vocal tracks that only have stance markers (no notes/lyrics).
+				textEvents: extractMidiVocalTextEvents(events),
 			}
 		}
 	}
 
 	// YARG CopyDownPhrases: HARM2/HARM3 get scoring phrases AND star power from HARM1.
-	// HARM2 keeps its own note-105 phrases as staticLyricPhrases (for lyric display),
-	// then replaces vocalPhrases (scoring) and starPowerSections with HARM1's.
-	// HARM3 clones HARM2's staticLyricPhrases and also gets HARM1's scoring/starpower.
+	// This only touches vocalPhrases/starPowerSections — staticLyricPhrases are
+	// extracted directly from note 106 on HARM2/HARM3 and are NOT touched here.
+	// CopyDown is idempotent (re-parse → re-CopyDown produces the same result).
 	if (vocalTracks.harmony1) {
 		const harm1Phrases = vocalTracks.harmony1.vocalPhrases
 		const harm1StarPower = vocalTracks.harmony1.starPowerSections
 		if (vocalTracks.harmony2) {
-			vocalTracks.harmony2.staticLyricPhrases = vocalTracks.harmony2.vocalPhrases.map(p => ({ tick: p.tick, length: p.length }))
 			vocalTracks.harmony2.vocalPhrases = harm1Phrases.map(p => ({ ...p }))
 			vocalTracks.harmony2.starPowerSections = harm1StarPower.map(p => ({ ...p }))
 		}
 		if (vocalTracks.harmony3) {
-			vocalTracks.harmony3.staticLyricPhrases = (vocalTracks.harmony2?.staticLyricPhrases ?? []).map(p => ({ ...p }))
 			vocalTracks.harmony3.vocalPhrases = harm1Phrases.map(p => ({ ...p }))
 			vocalTracks.harmony3.starPowerSections = harm1StarPower.map(p => ({ ...p }))
+			// HARM3 gets HARM2's staticLyricPhrases (matching YARG's CopyDownPhrases)
+			if (vocalTracks.harmony2) {
+				vocalTracks.harmony3.staticLyricPhrases = vocalTracks.harmony2.staticLyricPhrases.map(p => ({ ...p }))
+			}
 		}
 	}
 
@@ -241,8 +302,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
-		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 		venue: extractVenueEvents(tracks),
+		beatTrack: extractBeatTrack(tracks),
+		// trackData is evaluated before parseIssues (below) because the per-track
+		// pairing pushes orphan-note issues into `parseIssues` during evaluation.
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -257,9 +320,15 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				// the difficulty-range noteOn dispatch, so their 'all'-difficulty
 				// modifiers need to be copied to every difficulty unconditionally.
 				const forceDistribute = storesRawNotes(instrumentType)
-				const trackDifficulties = _.chain(eventEnds)
-					.thru(eventEnds => distributeInstrumentEvents(eventEnds, forceDistribute)) // Removes 'all' difficulty
-					.thru(eventEnds => getTrackEvents(eventEnds)) // Connects note ends together
+				const distributed = distributeInstrumentEvents(eventEnds, forceDistribute) // Removes 'all' difficulty
+				const { trackEvents: pairedEvents, orphans } = getTrackEvents(distributed) // Connects note ends together
+				if (orphans.starts > 0) {
+					parseIssues.push({ instrument, difficulty: null, noteIssue: 'orphanedNoteStart' })
+				}
+				if (orphans.ends > 0) {
+					parseIssues.push({ instrument, difficulty: null, noteIssue: 'orphanedNoteEnd' })
+				}
+				const trackDifficulties = _.chain(pairedEvents)
 					.thru(events => splitMidiModifierSustains(events, instrumentType))
 					.thru(events => fixLegacyGhStarPower(events, instrumentType, iniChartModifiers))
 					.thru(events => fixFlexLaneLds(events))
@@ -293,6 +362,14 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 						proKeysRangeShifts,
 						rawNotes: rawNotesByDifficulty[difficulty],
 					}
+					// Attach source track name (for cases like PART DRUMS + PART REAL_DRUMS_PS
+					// both mapping to 'drums', or duplicate MIDI tracks with the same name)
+					Object.defineProperty(result, '_sourceTrackName', {
+						value: t.trackName,
+						enumerable: false,
+						writable: true,
+						configurable: true,
+					})
 
 					for (const event of trackDifficulties[difficulty]) {
 						if (event.type === eventTypes.starPower) {
@@ -324,14 +401,24 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				})
 			})
 			.flatMap()
-			.filter(track =>
-				track.trackEvents.length > 0
-				|| track.rawNotes.length > 0
-				|| track.starPowerSections.length > 0
-				|| track.soloSections.length > 0,
-			)
+			.filter(track => {
+				// A track must have "real" content — actual notes or scorable sections.
+				// Tracks with only global modifier events (e.g. [ENABLE_CHART_DYNAMICS])
+				// and no actual notes should be filtered out so that round-trip behavior
+				// is stable (the writer doesn't need to emit placeholder text events).
+				const hasRealTrackEvents = track.trackEvents.some(e =>
+					e.type !== eventTypes.enableChartDynamics,
+				)
+				return hasRealTrackEvents
+					|| track.rawNotes.length > 0
+					|| track.starPowerSections.length > 0
+					|| track.soloSections.length > 0
+			})
 			.thru(tracks => copyDownProKeysPhrases(tracks))
 			.value(),
+		// Evaluated AFTER trackData so orphan-note issues pushed during per-track
+		// pairing are included.
+		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 	}
 }
 
@@ -345,21 +432,63 @@ function convertToAbsoluteTime(midiData: MidiData) {
 	}
 }
 
+/**
+ * Parse a MIDI text event as a section event, matching YARG's
+ * TextEvents.NormalizeTextEvent → TryParseSectionEvent pipeline exactly.
+ * Returns the section name, or null if the event isn't a section event.
+ */
+function parseMidiSectionEventText(rawText: string): string | null {
+	// NormalizeTextEvent: if there's both `[` and `]`, take content between
+	// the FIRST `[` and FIRST `]` (not a balanced pair!). Otherwise trim.
+	let text = rawText
+	const openIdx = text.indexOf('[')
+	const closeIdx = text.indexOf(']')
+	if (openIdx >= 0 && closeIdx >= 0 && openIdx <= closeIdx) {
+		text = text.slice(openIdx + 1, closeIdx)
+	}
+	text = text.trim()
+
+	// TryParseSectionEvent: strip "section" or "prc" prefix
+	let name: string
+	if (text.startsWith('section')) {
+		name = text.slice('section'.length)
+	} else if (text.startsWith('prc')) {
+		name = text.slice('prc'.length)
+	} else {
+		return null
+	}
+
+	// TrimStart('_').Trim()
+	while (name.length > 0 && name[0] === '_') name = name.slice(1)
+	name = name.trim()
+
+	if (name.length === 0) return null
+	return name
+}
+
 function getTracks(midiData: MidiData) {
 	const tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[] = []
 
 	for (const track of midiData.tracks) {
+		// Match YARG.Core's MidiExtensions.GetTrackName: return the FIRST
+		// `SequenceTrackName` event (FF 03) seen at tick 0, even if it
+		// doesn't match any recognized instrument track. The early `break`
+		// below ensures we don't continue scanning for a "better" name.
+		// Some charts (e.g. "Culture Killer - Blindfolded Death") have a
+		// bogus leading trackname like `[ENHANCED_OPENS]` followed by the
+		// real `PART BASS` — YARG honors the first and skips the track.
 		let trackName: string | null = null
 		for (const event of track) {
 			if (event.deltaTime !== 0) {
 				break
 			}
-			if (event.type === 'trackName' && trackNames.includes(event.text as TrackName)) {
+			if (event.type === 'trackName') {
 				trackName = event.text
+				break
 			}
 		}
 
-		if (trackName !== null) {
+		if (trackName !== null && trackNames.includes(trackName as TrackName)) {
 			tracks.push({
 				trackName: trackName as TrackName,
 				trackEvents: track,
@@ -424,6 +553,10 @@ function scanInstrumentTrack(
 	const rangeShiftStarts = new Map<number, number>() // noteNumber → startTick
 	const proKeysRangeShifts: { tick: number; length: number; noteNumber: number }[] = []
 	const isProKeys = instrumentType === instrumentTypes.proKeys
+	// Monotonically increasing counter used to tag each event with its MIDI
+	// file position. We use this for stable tiebreaks in force-modifier
+	// conflict resolution (matching YARG's forcingProcessList order).
+	let seq = 0
 
 	for (const event of events) {
 		// SysEx event (tap modifier or open)
@@ -442,6 +575,11 @@ function scanInstrumentTrack(
 						channel: 1,
 						velocity: 127,
 						isStart: event.data[6] === 0x01,
+						// Mark SysEx-sourced taps so splitMidiModifierSustains can
+						// treat them with inclusive-end (matching YARG's Phase Shift
+						// SysEx handling, which skips the endTick decrement).
+						_fromSysEx: type === eventTypes.forceTap,
+						_seq: seq++,
 					})
 				}
 			}
@@ -545,6 +683,7 @@ function scanInstrumentTrack(
 						velocity: event.velocity,
 						channel: event.channel,
 						isStart: event.type === 'noteOn',
+						_seq: seq++,
 					})
 				}
 			} else {
@@ -560,6 +699,7 @@ function scanInstrumentTrack(
 						velocity: event.velocity,
 						channel: event.channel,
 						isStart: event.type === 'noteOn',
+						_seq: seq++,
 					})
 				}
 			}
@@ -762,9 +902,17 @@ function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'al
 
 /**
  * Connects together start and end events to determine event lengths.
+ *
+ * Returns `trackEvents` plus an `orphans` summary — unpaired noteOn starts
+ * (dropped at the end) and unpaired noteOff ends (dropped when no matching
+ * start is found). The caller surfaces these as chart issues.
  */
-function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }) {
+function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }): {
+	trackEvents: { [key in Difficulty]: MidiTrackEvent[] }
+	orphans: { starts: number; ends: number }
+} {
 	const trackEvents: { [key in Difficulty]: MidiTrackEvent[] } = { expert: [], hard: [], medium: [], easy: [] }
+	let orphanEnds = 0
 
 	for (const difficulty of difficulties) {
 		const partialTrackEventsMap = _.chain(eventTypes)
@@ -782,25 +930,44 @@ function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }
 					type: trackEventEnd.type,
 					velocity: trackEventEnd.velocity,
 					channel: trackEventEnd.channel,
+					_fromSysEx: trackEventEnd._fromSysEx,
 				}
 				partialTrackEvents.push(partialTrackEvent)
 				trackEvents[difficulty].push(partialTrackEvent)
-			} else if (partialTrackEvents.length) {
+			} else {
+				// Pair end events with the closest previous (most recent) matching
+				// start — LIFO ordering per the BTrack spec: "Each end event is
+				// paired with the closest previous start event."
 				let partialTrackEventIndex = partialTrackEvents.length - 1
 				while (partialTrackEventIndex >= 0 && partialTrackEvents[partialTrackEventIndex].channel !== trackEventEnd.channel) {
-					partialTrackEventIndex-- // Find the most recent partial event on the same channel
+					partialTrackEventIndex--
 				}
 				if (partialTrackEventIndex >= 0) {
 					const partialTrackEvent = _.pullAt(partialTrackEvents, partialTrackEventIndex)[0]
 					partialTrackEvent.length = trackEventEnd.tick - partialTrackEvent.tick
+					// Tag the paired event with the MIDI file position of the
+					// END event that closed it — resolveFretModifiers uses this
+					// to match YARG's "last closure wins" ordering for overlapping
+					// force modifiers.
+					partialTrackEvent._endSeq = trackEventEnd._seq
+				} else {
+					// No matching start event for this end — spec says drop it.
+					orphanEnds++
 				}
 			}
 		}
+	}
 
+	// Count unpaired starts (still length === -1) before dropping them.
+	let orphanStarts = 0
+	for (const difficulty of difficulties) {
+		for (const ev of trackEvents[difficulty]) {
+			if (ev.length === -1) orphanStarts++
+		}
 		_.remove(trackEvents[difficulty], e => e.length === -1) // Remove all remaining partial events
 	}
 
-	return trackEvents
+	return { trackEvents, orphans: { starts: orphanStarts, ends: orphanEnds } }
 }
 
 /**
@@ -854,7 +1021,14 @@ function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent
 				continue
 			}
 
-			_.remove(activeModifiers, m => (m.length === 0 ? m.tick + m.length < event.tick : m.tick + m.length <= event.tick))
+			_.remove(activeModifiers, m => {
+				const end = m.tick + m.length
+				// Most modifier sustains exclude their last tick, matching YARG.Core's
+				// `if (endTick > startTick) --endTick` in ProcessNoteOnEventAsGuitarForcedType.
+				// SysEx-sourced forceTap is the exception: YARG's
+				if (m.length === 0) return end < event.tick
+				return end <= event.tick
+			})
 
 			if (modifierSustains.includes(event.type)) {
 				activeModifiers.push(event)
@@ -873,6 +1047,10 @@ function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent
 							type: activeModifier.type,
 							velocity: activeModifier.velocity,
 							channel: activeModifier.channel,
+							// Propagate the original sustain's end-event file position
+							// so resolveFretModifiers can use it to pick the "winning"
+							// modifier when multiple overlap on the same note.
+							_endSeq: activeModifier._endSeq,
 						}
 						latestInsertedModifiers[activeModifier.type] = newInsertedModifier
 						newEvents[difficulty].push(newInsertedModifier)
@@ -1095,6 +1273,14 @@ function extractTypedTextEvents(events: MidiEvent[]) {
 		}
 	}
 
+	// Deterministic ordering for same-tick events so round-trip is stable
+	// regardless of whether the original file stored them as 'text' vs
+	// 'lyrics' meta events (the writer re-serializes characterStates as
+	// lyrics, so push-order from the original file isn't preserved).
+	handMaps.sort((a, b) => a.tick - b.tick || a.type.localeCompare(b.type))
+	strumMaps.sort((a, b) => a.tick - b.tick || a.type.localeCompare(b.type))
+	characterStates.sort((a, b) => a.tick - b.tick || a.type.localeCompare(b.type))
+
 	return { handMaps, strumMaps, characterStates }
 }
 
@@ -1165,45 +1351,60 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 		unrecognizedEvents: [],
 		parseIssues: [],
 	}
-	const eventsTrack = tracks.find(t => t.trackName === 'EVENTS')
-	if (!eventsTrack) return result
+	// YARG iterates ALL chunks with trackName === 'EVENTS' in file order,
+	// accumulating into one MoonSong. Merge events from every EVENTS track
+	// before classifying. Also skip the first event of each track (YARG's
+	// `for (int i = 1; ...)` loop, which drops any event before the trackName).
+	const eventsTracks = tracks.filter(t => t.trackName === 'EVENTS')
+	if (eventsTracks.length === 0) return result
 
-	for (const event of eventsTrack.trackEvents) {
-		if (!isTextLikeEvent(event)) continue
-		const text = event.text
-		const tick = event.deltaTime
+	for (const eventsTrack of eventsTracks) {
+		const evs = eventsTrack.trackEvents
+		for (let i = 1; i < evs.length; i++) {
+			const event = evs[i]
+			if (!isTextLikeEvent(event)) continue
+			const text = event.text
+			const tick = event.deltaTime
 
-		const sectionMatch = /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.exec(text)
-		if (sectionMatch) {
-			result.sections.push({ tick, name: sectionMatch[1] })
-			continue
-		}
-		if (/^\[?end\]?$/.test(text)) {
-			result.endEvents.push({ tick })
-			continue
-		}
-		if (/^\s*\[?coda\]?\s*$/.test(text)) {
-			result.codaEvents.push({ tick })
-			// Coda is also exposed in unrecognizedEvents for consumer visibility
-			// (matching YARG/MoonSong behavior where coda appears in globalEvents).
+			// Sections use YARG-compatible normalization (matches parseMidiSectionEventText:
+			// content between FIRST `[` and FIRST `]`, then strip 'section' / 'prc' prefix).
+			const sectionName = parseMidiSectionEventText(text)
+			if (sectionName !== null) {
+				result.sections.push({ tick, name: sectionName })
+				continue
+			}
+			if (/^\[?end\]?$/.test(text)) {
+				result.endEvents.push({ tick })
+				continue
+			}
+			if (/^\s*\[?coda\]?\s*$/.test(text)) {
+				result.codaEvents.push({ tick })
+				// Coda is also exposed in unrecognizedEvents for consumer visibility
+				// (matching YARG/MoonSong behavior where coda appears in globalEvents).
+				result.unrecognizedEvents.push({ tick, text })
+				continue
+			}
+			// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
+			// the EVENTS track. Game engines silently drop them when they show up
+			// here. Record a parse issue so consumers can surface the misplacement,
+			// then fall through to unrecognizedEvents so the value round-trips back
+			// out — users can move it to PART VOCALS manually.
+			if (/^\[?\s*lyric[ \t]/.test(text)) {
+				result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
+			} else if (/^\[?phrase_start\]?$/.test(text)) {
+				result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
+			} else if (/^\[?phrase_end\]?$/.test(text)) {
+				result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
+			}
+
 			result.unrecognizedEvents.push({ tick, text })
-			continue
 		}
-		// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
-		// the EVENTS track. Game engines silently drop them when they show up
-		// here. Record a parse issue so consumers can surface the misplacement,
-		// then fall through to unrecognizedEvents so the value round-trips back
-		// out — users can move it to PART VOCALS manually.
-		if (/^\[?\s*lyric[ \t]/.test(text)) {
-			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
-		} else if (/^\[?phrase_start\]?$/.test(text)) {
-			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
-		} else if (/^\[?phrase_end\]?$/.test(text)) {
-			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
-		}
-
-		result.unrecognizedEvents.push({ tick, text })
 	}
+	// Sort sections by (tick, name) and unrecognizedEvents by (tick, text) so
+	// multi-EVENTS-track charts produce the same ordering as YARG's
+	// MoonText.InsertionCompareTo sorted inserts.
+	result.sections.sort((a, b) => a.tick - b.tick || a.name.localeCompare(b.name))
+	result.unrecognizedEvents.sort((a, b) => a.tick - b.tick || a.text.localeCompare(b.text))
 	return result
 }
 
@@ -1351,51 +1552,112 @@ function extractVenueEvents(tracks: { trackName: TrackName; trackEvents: MidiEve
 	if (!venueTrack) return []
 
 	const events: VenueEvent[] = []
+	// Match YARG's ReadVenueEvents: note-based events are only emitted when
+	// a matching noteOff arrives (`new MoonVenue(type, text, startTick,
+	// endTick - startTick)`). Unpaired noteOns are silently dropped. Track
+	// unpaired noteOns in a queue keyed by note number — when a noteOff
+	// arrives for the same note, pop the earliest matching noteOn and emit
+	// a venue event with the computed length.
+	const unpairedNotes: { noteNumber: number; tick: number }[] = []
 
+	// Match YARG's ReadVenueEvents: skip the FIRST event regardless of type
+	// (YARG iterates `for (int i = 1; ...)` and assumes the first event is
+	// the track name). Some charts have a spurious text event at index 0
+	// BEFORE the real trackName event — we must skip it to match YARG.
+	let skipFirst = true
 	for (const event of venueTrack.trackEvents) {
-		// Note-based events
-		if (event.type === 'noteOn' && (event as { velocity: number }).velocity > 0) {
+		if (skipFirst) {
+			skipFirst = false
+			continue
+		}
+		// Note events: queue noteOns, emit on noteOff.
+		const isNoteOn = event.type === 'noteOn' && (event as { velocity: number }).velocity > 0
+		const isNoteOff = event.type === 'noteOff' || (event.type === 'noteOn' && (event as { velocity: number }).velocity === 0)
+		if (isNoteOn) {
 			const noteNumber = (event as { noteNumber: number }).noteNumber
-			const template = venueNoteLookup[noteNumber]
-			if (template) {
-				events.push({ tick: event.deltaTime, type: template.type, name: template.name })
+			// Duplicate noteOn: YARG logs a debug message but still adds
+			// the new note to the queue. We do the same.
+			unpairedNotes.push({ noteNumber, tick: event.deltaTime })
+			continue
+		}
+		if (isNoteOff) {
+			const noteNumber = (event as { noteNumber: number }).noteNumber
+			// Find the earliest unpaired noteOn with the same note number.
+			const idx = unpairedNotes.findIndex(n => n.noteNumber === noteNumber)
+			if (idx >= 0) {
+				const start = unpairedNotes[idx]
+				unpairedNotes.splice(idx, 1)
+				const template = venueNoteLookup[noteNumber]
+				if (template) {
+					events.push({
+						tick: start.tick,
+						type: template.type,
+						name: template.name,
+						length: event.deltaTime - start.tick,
+					})
+				}
 			}
+			continue
 		}
 
 		// Text-based events
 		if (isTextLikeEvent(event)) {
 			let text = event.text
-			if (text.startsWith('[') && text.endsWith(']')) text = text.slice(1, -1)
+			// YARG's NormalizeTextEvent: if the text contains `[` and `]`,
+			// return the content between them (trimmed). Otherwise return
+			// the trimmed text. The brackets don't have to wrap the entire
+			// string — "[verse] " (trailing space) yields "verse".
+			const openIdx = text.indexOf('[')
+			const closeIdx = text.indexOf(']')
+			if (openIdx >= 0 && closeIdx >= 0 && openIdx <= closeIdx) {
+				text = text.slice(openIdx + 1, closeIdx)
+			}
 			text = text.trim()
 
 			// Lighting: "lighting (TYPE)"
+			// YARG falls back to "default" for any lighting type not in its
+			// conversion lookup (including `default` and empty string).
 			const lightingMatch = /^lighting\s+\((.*)\)$/.exec(text)
 			if (lightingMatch) {
-				const name = venueLightingLookup[lightingMatch[1]]
-				if (name) events.push({ tick: event.deltaTime, type: 'lighting', name })
+				const name = venueLightingLookup[lightingMatch[1]] ?? 'default'
+				events.push({ tick: event.deltaTime, type: 'lighting', name })
 				continue
 			}
 
-			// Post-processing: "*.pp"
+			// Post-processing: "*.pp". YARG's lookup falls through to the
+			// Unknown-type bucket for any `.pp` text not in its conversion
+			// lookup, so we match that by letting unrecognized `.pp` values
+			// fall through to the unknown-text handler at the end.
 			if (text.endsWith('.pp')) {
 				const name = venuePostProcessingLookup[text]
-				if (name) events.push({ tick: event.deltaTime, type: 'postProcessing', name })
-				continue
+				if (name) {
+					events.push({ tick: event.deltaTime, type: 'postProcessing', name })
+					continue
+				}
+				// Unknown .pp: fall through to the Unknown handler below.
 			}
 
-			// Directed camera cuts: "directed_*"
-			const directedMatch = /^(directed_\w+)$/.exec(text)
+			// Directed camera cuts: "directed_*". YARG's regex `(directed_\w+)`
+			// has no anchors — it matches the FIRST occurrence of a directed_*
+			// token anywhere in the text (e.g. "do_directed_cut directed_bass"
+			// matches `directed_cut` first). Any directed_* token not in the
+			// lookup falls back to "default" in YARG. For unrecognized values
+			// we store the full bracket-stripped text as `name` so the writer
+			// can re-emit it verbatim for round-trip fidelity.
+			const directedMatch = /(directed_\w+)/.exec(text)
 			if (directedMatch) {
-				const name = venueDirectedCutLookup[directedMatch[1]]
-				if (name) events.push({ tick: event.deltaTime, type: 'cameraCut', name })
+				const name = venueDirectedCutLookup[directedMatch[1]] ?? text
+				events.push({ tick: event.deltaTime, type: 'cameraCut', name })
 				continue
 			}
 
-			// Coop camera cuts: "coop_*_*"
+			// Coop camera cuts: "coop_*_*". YARG's regex captures the tail
+			// after `coop_` and falls back to "default" for unknown values.
+			// For unrecognized values we store the full text as `name`.
 			const coopMatch = /^coop_(\w+_\w+)$/.exec(text)
 			if (coopMatch) {
-				const name = venueCoopCutLookup[coopMatch[1]]
-				if (name) events.push({ tick: event.deltaTime, type: 'cameraCut', name })
+				const name = venueCoopCutLookup[coopMatch[1]] ?? text
+				events.push({ tick: event.deltaTime, type: 'cameraCut', name })
 				continue
 			}
 
@@ -1403,11 +1665,59 @@ function extractVenueEvents(tracks: { trackName: TrackName; trackEvents: MidiEve
 			const standalone = venueStandaloneTextLookup[text]
 			if (standalone) {
 				events.push({ tick: event.deltaTime, type: standalone.type, name: standalone.name })
+				continue
 			}
+
+			// Unknown text event — YARG preserves these as `Unknown`-typed
+			// MoonVenue events. The name stores the full bracket-stripped text
+			// so the writer can re-emit it verbatim.
+			events.push({ tick: event.deltaTime, type: 'unknown', name: text })
 		}
 	}
 
 	events.sort((a, b) => a.tick - b.tick)
 	return events
+}
+
+/**
+ * Extract BEAT-track events. Matches YARG.Core's `ReadSongBeats`:
+ * - skip the first event (track name)
+ * - MIDI note 12 = measure beat (BeatlineType.Measure)
+ * - MIDI note 13 = strong beat (BeatlineType.Strong)
+ * - MIDI note 14 = weak beat (BeatlineType.Weak)
+ */
+function extractBeatTrack(
+	tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[],
+): { tick: number; type: 'measure' | 'strong' | 'weak' }[] | undefined {
+	const beatTrack = tracks.find(t => t.trackName === 'BEAT')
+	if (!beatTrack) return undefined
+
+	const out: { tick: number; type: 'measure' | 'strong' | 'weak' }[] = []
+	let skipFirst = true
+	for (const event of beatTrack.trackEvents) {
+		// YARG skips the first event (the track name) before parsing beat notes.
+		if (skipFirst) {
+			skipFirst = false
+			continue
+		}
+		if (event.type !== 'noteOn' || (event as { velocity: number }).velocity === 0) continue
+		const noteNumber = (event as { noteNumber: number }).noteNumber
+		let type: 'measure' | 'strong' | 'weak' | null = null
+		if (noteNumber === 12) type = 'measure'
+		else if (noteNumber === 13) type = 'strong'
+		else if (noteNumber === 14) type = 'weak'
+		if (type === null) continue
+		out.push({ tick: event.deltaTime, type })
+	}
+	// Sort beat notes by tick so output is deterministic regardless of file
+	// order. Some charts (e.g. "Old Man's Child - Black Seeds on Virgin Soil")
+	// store BEAT notes out of order, which causes setEventMsTimes to compute
+	// wrong msTimes via its forward-only rolling tempo index when a tempo
+	// change coincides with one of the beat positions.
+	out.sort((a, b) => a.tick - b.tick)
+	// Treat an empty BEAT track the same as a missing one — round-trip
+	// consumers don't write empty BEAT tracks, so returning `[]` would
+	// break the round-trip diff. Example: "Creed - Torn".
+	return out.length > 0 ? out : undefined
 }
 

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -2,12 +2,12 @@ import * as _ from 'lodash'
 import { MidiData, MidiEvent, MidiSetTempoEvent, MidiTextEvent, MidiTimeSignatureEvent, parseMidi } from 'midi-file'
 
 import { difficulties, Difficulty, getInstrumentType, Instrument, InstrumentType, instrumentTypes } from 'src/interfaces'
-import { EventType, eventTypes, IniChartModifiers, RawChartData, VocalTrackData } from './note-parsing-interfaces'
+import { EventType, eventTypes, IniChartModifiers, RawChartData, VenueEvent, VocalTrackData } from './note-parsing-interfaces'
 import { extractMidiLyrics, extractMidiVocalPhrases, extractMidiVocalNotes, extractMidiVocalStarPower, extractMidiRangeShifts, extractMidiLyricShifts } from './lyric-parser'
 
 type TrackName = (typeof trackNames)[number]
 type VocalTrackName = 'PART VOCALS' | 'HARM1' | 'HARM2' | 'HARM3' | 'PART HARM1' | 'PART HARM2' | 'PART HARM3'
-type InstrumentTrackName = Exclude<TrackName, VocalTrackName | 'EVENTS'>
+type InstrumentTrackName = Exclude<TrackName, VocalTrackName | 'EVENTS' | 'VENUE'>
 const trackNames = [
 	'T1 GEMS',
 	'PART GUITAR',
@@ -31,6 +31,7 @@ const trackNames = [
 	'PART REAL_KEYS_E',
 	'PART ELITE_DRUMS',
 	'PART REAL_DRUMS_PS',
+	'VENUE',
 	'PART VOCALS',
 	'HARM1',
 	'HARM2',
@@ -241,6 +242,7 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
+		venue: extractVenueEvents(tracks),
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -1204,3 +1206,208 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 	}
 	return result
 }
+
+// ---------------------------------------------------------------------------
+// VENUE track parsing
+// ---------------------------------------------------------------------------
+
+/** VENUE MIDI note → event. */
+const venueNoteLookup: { [note: number]: VenueEvent | undefined } = {
+	// Post-processing (96-110)
+	96: { tick: 0, type: 'postProcessing', name: 'default' },
+	97: { tick: 0, type: 'postProcessing', name: 'polarized_black_white' },
+	98: { tick: 0, type: 'postProcessing', name: 'grainy_film' },
+	99: { tick: 0, type: 'postProcessing', name: 'sepiatone' },
+	100: { tick: 0, type: 'postProcessing', name: 'silvertone' },
+	101: { tick: 0, type: 'postProcessing', name: 'photonegative' },
+	102: { tick: 0, type: 'postProcessing', name: 'choppy_black_white' },
+	103: { tick: 0, type: 'postProcessing', name: 'bloom' },
+	104: { tick: 0, type: 'postProcessing', name: 'desaturated_red' },
+	105: { tick: 0, type: 'postProcessing', name: 'mirror' },
+	106: { tick: 0, type: 'postProcessing', name: 'scanlines_blue' },
+	107: { tick: 0, type: 'postProcessing', name: 'scanlines' },
+	108: { tick: 0, type: 'postProcessing', name: 'scanlines_black_white' },
+	109: { tick: 0, type: 'postProcessing', name: 'scanlines_security' },
+	110: { tick: 0, type: 'postProcessing', name: 'trails_long' },
+	// Singalong (85-87)
+	85: { tick: 0, type: 'singalong', name: 'bass' },
+	86: { tick: 0, type: 'singalong', name: 'drums' },
+	87: { tick: 0, type: 'singalong', name: 'guitar' },
+	// Camera cut constraints (70-73)
+	70: { tick: 0, type: 'cameraCutConstraint', name: 'no_behind' },
+	71: { tick: 0, type: 'cameraCutConstraint', name: 'only_far' },
+	72: { tick: 0, type: 'cameraCutConstraint', name: 'only_close' },
+	73: { tick: 0, type: 'cameraCutConstraint', name: 'no_close' },
+	// Camera cuts (60-64)
+	60: { tick: 0, type: 'cameraCut', name: 'random' },
+	61: { tick: 0, type: 'cameraCut', name: 'directed_bass' },
+	62: { tick: 0, type: 'cameraCut', name: 'directed_drums' },
+	63: { tick: 0, type: 'cameraCut', name: 'directed_guitar' },
+	64: { tick: 0, type: 'cameraCut', name: 'directed_vocals' },
+	// Lighting keyframes (48-50)
+	48: { tick: 0, type: 'lighting', name: 'next' },
+	49: { tick: 0, type: 'lighting', name: 'previous' },
+	50: { tick: 0, type: 'lighting', name: 'first' },
+	// Spotlights (37-41)
+	37: { tick: 0, type: 'spotlight', name: 'bass' },
+	38: { tick: 0, type: 'spotlight', name: 'drums' },
+	39: { tick: 0, type: 'spotlight', name: 'guitar' },
+	40: { tick: 0, type: 'spotlight', name: 'vocals' },
+	41: { tick: 0, type: 'spotlight', name: 'keys' },
+}
+
+/** VENUE text events: lighting presets via "lighting (TYPE)". */
+const venueLightingLookup: { [key: string]: string } = {
+	'': 'default', 'chorus': 'chorus', 'dischord': 'dischord',
+	'manual_cool': 'cool_manual', 'manual_warm': 'warm_manual', 'stomp': 'stomp',
+	'verse': 'verse', 'blackout_fast': 'blackout_fast', 'blackout_slow': 'blackout_slow',
+	'blackout_spot': 'blackout_spotlight', 'bre': 'big_rock_ending',
+	'flare_fast': 'flare_fast', 'flare_slow': 'flare_slow', 'frenzy': 'frenzy',
+	'harmony': 'harmony', 'intro': 'intro', 'loop_cool': 'cool_automatic',
+	'loop_warm': 'warm_automatic', 'searchlights': 'searchlights',
+	'silhouettes': 'silhouettes', 'silhouettes_spot': 'silhouettes_spotlight',
+	'strobe_fast': 'strobe_fast', 'strobe_slow': 'strobe_slow', 'sweep': 'sweep',
+}
+
+/** VENUE text events: post-processing effects via "[xxx.pp]". */
+const venuePostProcessingLookup: { [key: string]: string } = {
+	'bloom.pp': 'bloom', 'bright.pp': 'bright', 'clean_trails.pp': 'trails',
+	'contrast_a.pp': 'polarized_black_white', 'desat_blue.pp': 'desaturated_blue',
+	'desat_posterize_trails.pp': 'trails_desaturated', 'film_contrast.pp': 'contrast',
+	'film_b+w.pp': 'black_white', 'film_sepia_ink.pp': 'sepiatone',
+	'film_silvertone.pp': 'silvertone', 'film_contrast_red.pp': 'contrast_red',
+	'film_contrast_green.pp': 'contrast_green', 'film_contrast_blue.pp': 'contrast_blue',
+	'film_16mm.pp': 'grainy_film', 'film_blue_filter.pp': 'scanlines_blue',
+	'flicker_trails.pp': 'trails_flickery', 'horror_movie_special.pp': 'photonegative_red_black',
+	'photocopy.pp': 'choppy_black_white', 'photo_negative.pp': 'photonegative',
+	'posterize.pp': 'posterize', 'ProFilm_a.pp': 'default', 'ProFilm_b.pp': 'desaturated_red',
+	'ProFilm_mirror_a.pp': 'mirror', 'ProFilm_psychedelic_blue_red.pp': 'polarized_red_blue',
+	'shitty_tv.pp': 'grainy_chromatic_abberation', 'space_woosh.pp': 'trails_spacey',
+	'video_a.pp': 'scanlines', 'video_bw.pp': 'scanlines_black_white',
+	'video_security.pp': 'scanlines_security', 'video_trails.pp': 'trails_long',
+}
+
+/** VENUE text events: directed camera cuts via "[directed_*]". */
+const venueDirectedCutLookup: { [key: string]: string } = {
+	'directed_guitar': 'directed_guitar', 'directed_bass': 'directed_bass',
+	'directed_drums': 'directed_drums', 'directed_vocals': 'directed_vocals',
+	'directed_stagedive': 'directed_stagedive', 'directed_crowdsurf': 'directed_crowdsurf',
+	'directed_all': 'directed_all', 'directed_bre': 'directed_bre',
+	'directed_brej': 'directed_brej', 'directed_guitar_cam': 'directed_guitar_cam',
+	'directed_bass_cam': 'directed_bass_cam', 'directed_drums_kd': 'directed_drums_kd',
+	'directed_drums_lt': 'directed_drums_lt', 'directed_drums_np': 'directed_drums_np',
+	'directed_crowd_g': 'directed_crowd_g', 'directed_crowd_b': 'directed_crowd_b',
+	'directed_crowd_pnt': 'directed_crowd_pnt', 'directed_duo_drums': 'directed_duo_drums',
+	'directed_guitar_cls': 'directed_guitar_cls', 'directed_bass_cls': 'directed_bass_cls',
+	'directed_vocals_cam': 'directed_vocals_cam', 'directed_vocals_cls': 'directed_vocals_cls',
+	'directed_all_cam': 'directed_all_cam', 'directed_all_lt': 'directed_all_lt',
+	'directed_all_yeah': 'directed_all_yeah', 'directed_guitar_np': 'directed_guitar_np',
+	'directed_bass_np': 'directed_bass_np', 'directed_vocals_np': 'directed_vocals_np',
+	'directed_drums_pnt': 'directed_drums_pnt',
+}
+
+/** VENUE text events: RBN2 coop camera cuts via "[coop_*_*]". */
+const venueCoopCutLookup: { [key: string]: string } = {
+	'all_behind': 'all_behind', 'all_far': 'all_far', 'all_near': 'all_near',
+	'front_behind': 'front_behind', 'front_near': 'front_near',
+	'd_behind': 'd_behind', 'd_near': 'd_near',
+	'v_behind': 'v_behind', 'v_near': 'v_near',
+	'b_behind': 'b_behind', 'b_near': 'b_near',
+	'g_behind': 'g_behind', 'g_near': 'g_near',
+	'k_behind': 'k_behind', 'k_near': 'k_near',
+	'd_closeup_hand': 'd_closeup_hand', 'd_closeup_head': 'd_closeup_head',
+	'v_closeup': 'v_closeup',
+	'b_closeup_hand': 'b_closeup_hand', 'b_closeup_head': 'b_closeup_head',
+	'g_closeup_hand': 'g_closeup_hand', 'g_closeup_head': 'g_closeup_head',
+	'k_closeup_hand': 'k_closeup_hand', 'k_closeup_head': 'k_closeup_head',
+	'dv_near': 'dv_near', 'bd_near': 'bd_near', 'dg_near': 'dg_near',
+	'bv_behind': 'bv_behind', 'bv_near': 'bv_near',
+	'gv_behind': 'gv_behind', 'gv_near': 'gv_near',
+	'kv_behind': 'kv_behind', 'kv_near': 'kv_near',
+	'bg_behind': 'bg_behind', 'bg_near': 'bg_near',
+	'bk_behind': 'bk_behind', 'bk_near': 'bk_near',
+	'gk_behind': 'gk_behind', 'gk_near': 'gk_near',
+}
+
+/** Standalone venue text events (direct text → event mapping). */
+const venueStandaloneTextLookup: { [key: string]: VenueEvent | undefined } = {
+	'first': { tick: 0, type: 'lighting', name: 'first' },
+	'next': { tick: 0, type: 'lighting', name: 'next' },
+	'prev': { tick: 0, type: 'lighting', name: 'previous' },
+	'verse': { tick: 0, type: 'lighting', name: 'verse' },
+	'chorus': { tick: 0, type: 'lighting', name: 'chorus' },
+	'bonusfx': { tick: 0, type: 'stageEffect', name: 'bonus_fx' },
+	'bonusfx_optional': { tick: 0, type: 'stageEffect', name: 'optional bonus_fx' },
+	'FogOn': { tick: 0, type: 'stageEffect', name: 'fog_on' },
+	'FogOff': { tick: 0, type: 'stageEffect', name: 'fog_off' },
+}
+
+/**
+ * Extract all venue events from the VENUE MIDI track.
+ * Handles both note-based events and text-based events.
+ */
+function extractVenueEvents(tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[]): VenueEvent[] {
+	const venueTrack = tracks.find(t => t.trackName === 'VENUE')
+	if (!venueTrack) return []
+
+	const events: VenueEvent[] = []
+
+	for (const event of venueTrack.trackEvents) {
+		// Note-based events
+		if (event.type === 'noteOn' && (event as { velocity: number }).velocity > 0) {
+			const noteNumber = (event as { noteNumber: number }).noteNumber
+			const template = venueNoteLookup[noteNumber]
+			if (template) {
+				events.push({ tick: event.deltaTime, type: template.type, name: template.name })
+			}
+		}
+
+		// Text-based events
+		if (isTextLikeEvent(event)) {
+			let text = event.text
+			if (text.startsWith('[') && text.endsWith(']')) text = text.slice(1, -1)
+			text = text.trim()
+
+			// Lighting: "lighting (TYPE)"
+			const lightingMatch = /^lighting\s+\((.*)\)$/.exec(text)
+			if (lightingMatch) {
+				const name = venueLightingLookup[lightingMatch[1]]
+				if (name) events.push({ tick: event.deltaTime, type: 'lighting', name })
+				continue
+			}
+
+			// Post-processing: "*.pp"
+			if (text.endsWith('.pp')) {
+				const name = venuePostProcessingLookup[text]
+				if (name) events.push({ tick: event.deltaTime, type: 'postProcessing', name })
+				continue
+			}
+
+			// Directed camera cuts: "directed_*"
+			const directedMatch = /^(directed_\w+)$/.exec(text)
+			if (directedMatch) {
+				const name = venueDirectedCutLookup[directedMatch[1]]
+				if (name) events.push({ tick: event.deltaTime, type: 'cameraCut', name })
+				continue
+			}
+
+			// Coop camera cuts: "coop_*_*"
+			const coopMatch = /^coop_(\w+_\w+)$/.exec(text)
+			if (coopMatch) {
+				const name = venueCoopCutLookup[coopMatch[1]]
+				if (name) events.push({ tick: event.deltaTime, type: 'cameraCut', name })
+				continue
+			}
+
+			// Standalone text events
+			const standalone = venueStandaloneTextLookup[text]
+			if (standalone) {
+				events.push({ tick: event.deltaTime, type: standalone.type, name: standalone.name })
+			}
+		}
+	}
+
+	events.sort((a, b) => a.tick - b.tick)
+	return events
+}
+

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -145,11 +145,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		}
 	}
 
-	const codaEvents =
-		tracks
-			.find(t => t.trackName === 'EVENTS')
-			?.trackEvents.filter(e => e.type === 'text' && (e.text.trim() === 'coda' || e.text.trim() === '[coda]')) ?? []
-	const firstCodaTick = codaEvents[0] ? codaEvents[0].deltaTime : null
+	// Classify each text-like event on the EVENTS track into one of:
+	// sections, endEvents, codaEvents, or unrecognizedEvents (the remainder).
+	const eventsScan = scanEventsTrack(tracks)
+	const firstCodaTick = eventsScan.codaEvents[0]?.tick ?? null
 
 	return {
 		chartTicksPerBeat: midiFile.header.ticksPerBeat,
@@ -193,24 +192,10 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				}
 			})
 			.value(),
-		sections: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-				name: e.text.match(/^\[?(?:section|prc)[ _]([^\]]*)\]?$/)![1],
-			}))
-			.value(),
-		endEvents: _.chain(tracks)
-			.find(t => t.trackName === 'EVENTS')
-			.get('trackEvents')
-			.filter((e): e is MidiTextEvent => e.type === 'text' && /^\[?end\]?$/.test(e.text))
-			.map(e => ({
-				tick: e.deltaTime,
-			}))
-			.value(),
-		parseIssues: [],
+		sections: eventsScan.sections,
+		endEvents: eventsScan.endEvents,
+		unrecognizedEvents: eventsScan.unrecognizedEvents,
+		parseIssues: eventsScan.parseIssues,
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -839,5 +824,84 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	)
 
 	return events
+}
+
+/**
+ * YARG/MoonSong reads text-like events from multiple MIDI meta event types:
+ * text (FF 01), lyrics (FF 05), marker (FF 06), cuePoint (FF 07).
+ * trackName (FF 03) and instrumentName (FF 04) are excluded.
+ */
+function isTextLikeEvent(event: MidiEvent): event is MidiTextEvent {
+	return event.type === 'text' || event.type === 'lyrics' || event.type === 'marker' || event.type === 'cuePoint'
+}
+
+interface EventsScanResult {
+	sections: { tick: number; name: string }[]
+	endEvents: { tick: number }[]
+	codaEvents: { tick: number }[]
+	/** All remaining text-like events not recognized as sections/endEvents/coda/lyrics/phrases.
+	 *  Lyrics and phrase_start/phrase_end are extracted separately by the vocals path. */
+	unrecognizedEvents: { tick: number; text: string }[]
+	/** Issues raised while classifying EVENTS track text events (e.g. stray lyric/phrase
+	 *  events that belong on PART VOCALS, not EVENTS). */
+	parseIssues: RawChartData['parseIssues']
+}
+
+/**
+ * Single-pass scan of the EVENTS track that classifies each text-like event
+ * into one of {section, endEvent, coda, lyric, phrase, unrecognized}. Lyrics
+ * and phrase_start/phrase_end are consumed by the vocal parsing path — we
+ * don't re-emit them here. Everything else that matches a recognized pattern
+ * goes into its typed array; all remaining text-like events fall through to
+ * `unrecognizedEvents`.
+ *
+ * Reads from all text-like event types (text, lyrics, marker, cuePoint),
+ * matching YARG.Core's MoonText behavior.
+ */
+function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[]): EventsScanResult {
+	const result: EventsScanResult = {
+		sections: [],
+		endEvents: [],
+		codaEvents: [],
+		unrecognizedEvents: [],
+		parseIssues: [],
+	}
+	const eventsTrack = tracks.find(t => t.trackName === 'EVENTS')
+	if (!eventsTrack) return result
+
+	for (const event of eventsTrack.trackEvents) {
+		if (!isTextLikeEvent(event)) continue
+		const text = event.text
+		const tick = event.deltaTime
+
+		const sectionMatch = /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.exec(text)
+		if (sectionMatch) {
+			result.sections.push({ tick, name: sectionMatch[1] })
+			continue
+		}
+		if (/^\[?end\]?$/.test(text)) {
+			result.endEvents.push({ tick })
+			continue
+		}
+		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+			result.codaEvents.push({ tick })
+			continue
+		}
+		// Lyrics and phrase markers belong on PART VOCALS in .mid charts, not on
+		// the EVENTS track. Game engines silently drop them when they show up
+		// here. Record a parse issue so consumers can surface the misplacement,
+		// then fall through to unrecognizedEvents so the value round-trips back
+		// out — users can move it to PART VOCALS manually.
+		if (/^\[?\s*lyric[ \t]/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
+		} else if (/^\[?phrase_start\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
+		} else if (/^\[?phrase_end\]?$/.test(text)) {
+			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
+		}
+
+		result.unrecognizedEvents.push({ tick, text })
+	}
+	return result
 }
 

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -159,6 +159,34 @@ export interface RawChartData {
 			/** The MIDI note number identifying the animation */
 			noteNumber: number
 		}[]
+		/**
+		 * Pro Keys range shift markers (MIDI notes 0/2/4/5/7/9). Each shift
+		 * changes which 10-key portion of the 25-key range is visible.
+		 * Only present on prokeys instrument tracks.
+		 */
+		proKeysRangeShifts: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** The MIDI note number: 0=C1-E2, 2=D1-F2, 4=E1-G2, 5=F1-A2, 7=G1-B2, 9=A1-C3 */
+			noteNumber: number
+		}[]
+		/**
+		 * Raw MIDI note data for instruments whose note format is not yet fully parsed
+		 * into NoteEvent (pro guitar/bass, pro keys, elite drums). Contains all per-difficulty
+		 * noteOn/noteOff pairs with full MIDI properties for roundtrip writing.
+		 */
+		rawNotes: {
+			tick: number
+			/** Number of ticks */
+			length: number
+			/** The MIDI note number (instrument-type-specific meaning) */
+			noteNumber: number
+			/** MIDI velocity (pro guitar: fret + 100; elite drums: 1=ghost, 127=accent) */
+			velocity: number
+			/** MIDI channel (pro guitar: 0=normal, 1=ghost, 2=bend, 3=muted, 4=tapped, 5=harmonics, 6=pinch harmonics) */
+			channel: number
+		}[]
 	}[]
 }
 

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -93,6 +93,25 @@ export interface RawChartData {
 	parseIssues: Omit<NotesData['chartIssues'][number], 'description'>[]
 	/** VENUE track events: lighting, camera, post-processing, spotlights, singalongs, stage effects. */
 	venue: VenueEvent[]
+	/**
+	 * BEAT track events (MIDI-only). YARG.Core reads this track via
+	 * `ReadSongBeats` and uses it to populate `SyncTrack.Beatlines` — which
+	 * drives the auto-generated drum activation-phrase placement (and other
+	 * measure-aware logic). If we drop the BEAT track on round-trip, YARG
+	 * falls back to time-signature-derived beatlines, which may produce
+	 * different activator positions on charts whose BEAT track disagrees
+	 * with the naive derivation (e.g. "Genghis Tron - Things Don't Look Good"
+	 * and ~80% of the MIDI corpus).
+	 *
+	 * We capture beat events verbatim for round-trip fidelity. `type` matches
+	 * YARG's `BeatlineType`: measure = strong first-beat-of-measure
+	 * (MIDI note 12), strong = downbeat within measure (MIDI note 13),
+	 * weak = subdivision (MIDI note 14).
+	 */
+	beatTrack?: {
+		tick: number
+		type: 'measure' | 'strong' | 'weak'
+	}[]
 	trackData: {
 		instrument: Instrument
 		difficulty: Difficulty
@@ -135,6 +154,13 @@ export interface RawChartData {
 			 */
 			length: number
 			type: EventType
+			/**
+			 * .mid only: MIDI-file-order sequence number of the END (noteOff) event
+			 * that closed this sustain. Used by `resolveFretModifiers` to match
+			 * YARG.Core's "last closure wins" ordering when multiple force
+			 * modifiers overlap the same note.
+			 */
+			_endSeq?: number
 		}[]
 		/** Per-track text events (FF 01 text on MIDI instrument tracks, E events in .chart).
 		 * Does not include events already consumed by other fields (disco flip, ENHANCED_OPENS, etc.). */
@@ -236,7 +262,6 @@ export interface VocalTrackData {
 	vocalPhrases: {
 		tick: number
 		length: number
-		noteNumber?: number
 	}[]
 	notes: import('./lyric-parser').VocalNote[]
 	starPowerSections: {
@@ -251,19 +276,46 @@ export interface VocalTrackData {
 		tick: number
 		length: number
 	}[]
-	/** HARM2/3 static lyric phrase boundaries (distinct from scoring phrases). */
+	/** HARM2/3 static lyric phrase boundaries (from note 106 — distinct from
+	 * scoring phrases which are note 105). On HARM1 this is typically empty. */
 	staticLyricPhrases: {
 		tick: number
 		length: number
 	}[]
+	/**
+	 * Raw text events on the vocal track (stance markers, Band_PlayFacialAnim, etc.).
+	 * YARG.Core parses these into the VocalsPart.TextEvents list, which is what
+	 * makes an otherwise-empty vocal track "non-empty" (and therefore visible to
+	 * ChartDump / UI). Storing them here lets the writer round-trip vocals-only
+	 * tracks that have no lyrics/notes/phrases but still have stance markers.
+	 * Does NOT include lyric events (which live in `lyrics`) or events scan-chart
+	 * consumes internally (`ENHANCED_OPENS`, `[mix N drumsM]`, `[range_shift ...]`).
+	 */
+	textEvents: {
+		tick: number
+		text: string
+	}[]
 }
 
-export type VenueEventType = 'lighting' | 'postProcessing' | 'cameraCut' | 'cameraCutConstraint' | 'spotlight' | 'singalong' | 'stageEffect'
+export type VenueEventType = 'lighting' | 'postProcessing' | 'cameraCut' | 'cameraCutConstraint' | 'spotlight' | 'singalong' | 'stageEffect' | 'unknown'
 export interface VenueEvent {
 	tick: number
 	type: VenueEventType
-	/** Semantic name of the event (e.g. 'verse', 'bloom', 'directed_guitar', 'bass') */
+	/**
+	 * Name of the event. For recognized events this is a canonical name
+	 * (e.g. 'verse', 'bloom', 'directed_guitar', 'all_behind'). For
+	 * unrecognized directed or coop or unknown events, this is the full
+	 * bracket-stripped text from the source MIDI, preserved verbatim so
+	 * the writer can re-emit it for round-trip fidelity.
+	 */
 	name: string
+	/**
+	 * Length in ticks for "held" venue events. Spotlights and singalongs are
+	 * typically authored as multi-tick noteOn/noteOff pairs whose duration YARG
+	 * uses for rendering. Text-based events and instantaneous note events leave
+	 * this undefined (treated as 0).
+	 */
+	length?: number
 }
 
 export type EventType = ObjectValues<typeof eventTypes>
@@ -376,6 +428,12 @@ export const noteTypes = {
 	yellowDrum: 15,
 	blueDrum: 16,
 	greenDrum: 17,
+	/**
+	 * 5-lane-only orange pad (4th lane in 5-lane drums, MIDI note 100 when
+	 * `five_lane_drums = true`). In 4-lane / 4-lane-pro, MIDI 100 stays as
+	 * `greenDrum` (the 4th lane).
+	 */
+	orangeDrum: 18,
 } as const
 
 /** Note: specific values here are standardized; they are constants used in the track hash calculation. */
@@ -414,9 +472,10 @@ export const lyricFlags = {
 export interface NormalizedLyricEvent {
 	tick: number
 	msTime: number
-	/** Flag symbols stripped, '=' → '-'. '_' and '§' kept as-is (consumer decides display). */
+	/** Original text from the source file, including markup symbols (#, ^, +, =, $, etc.).
+	 * Consumers should use `flags` for semantic interpretation, not parse `text` directly. */
 	text: string
-	/** Bitmask of `lyricFlags`. */
+	/** Bitmask of `lyricFlags`, derived from markup symbols in text. */
 	flags: number
 }
 
@@ -425,7 +484,9 @@ export interface NormalizedVocalNote {
 	msTime: number
 	length: number
 	msLength: number
-	/** MIDI pitch 36-84 for pitched, -1 for unpitched/percussion. */
+	/** MIDI pitch 36-84 for pitched, -1 for percussion. NonPitched notes
+	 * (lyric flags #/^/*) keep their original MIDI pitch — check the
+	 * associated lyric's nonPitched flag for semantic meaning. */
 	pitch: number
 	/** percussionHidden (note 97) is excluded from normalized output. */
 	type: 'pitched' | 'percussion'
@@ -438,17 +499,36 @@ export interface NormalizedVocalPhrase {
 	msLength: number
 	/** True if first note is percussion (YARG behavior — mixing types in one phrase is invalid data). */
 	isPercussion: boolean
+	/** Versus player (PART VOCALS only). 1 = player 1 (note 105), 2 = player 2 (note 106). */
+	player?: 1 | 2
 	notes: NormalizedVocalNote[]
 	lyrics: NormalizedLyricEvent[]
 }
 
 export interface NormalizedVocalPart {
-	/** Scoring phrases (from note 105). Notes and lyrics grouped into their containing phrase. */
+	/** Phrases with notes and lyrics grouped. Built from the union of note 105
+	 * and note 106 phrase boundaries. Notes outside all phrases are dropped. */
 	notePhrases: NormalizedVocalPhrase[]
-	/** Static lyric display phrases (from note 106 on HARM2/3, copy of notePhrases on vocals/HARM1). */
+	/** Static lyric display phrases (from note 106 on HARM2/3, copy of
+	 * notePhrases on vocals/HARM1). */
 	staticLyricPhrases: NormalizedVocalPhrase[]
 	/** Star power sections — separate array, not per-phrase. */
 	starPowerSections: { tick: number; msTime: number; length: number; msLength: number }[]
+	/**
+	 * Per-part range shift markers (MIDI note 0 on this part's track).
+	 * YARG computes rangeShifts from these markers. PART VOCALS and HARM1 often
+	 * have distinct marker sets — must be stored per-part for lossless round-trip.
+	 */
+	rangeShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+	/** Per-part lyric shift markers (MIDI note 1 on this part's track). */
+	lyricShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+	/**
+	 * Raw text events on the vocal track (stance, facial anim, etc.). Required
+	 * so that vocal tracks with only text events (no notes/lyrics/phrases)
+	 * round-trip — YARG considers a VocalsPart non-empty iff it has phrases or
+	 * text events, so dropping them causes ChartDump to hide the track.
+	 */
+	textEvents: { tick: number; msTime: number; text: string }[]
 }
 
 /** Top-level normalized vocal track. */

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -158,12 +158,35 @@ export interface RawChartData {
 			length: number
 			/** The MIDI note number identifying the animation */
 			noteNumber: number
+			/** Semantic name (set by notes-parser): e.g. 'leftHandPosition5', 'kick', 'snareLHHard' */
+			name?: string
 		}[]
 		/**
 		 * Pro Keys range shift markers (MIDI notes 0/2/4/5/7/9). Each shift
 		 * changes which 10-key portion of the 25-key range is visible.
 		 * Only present on prokeys instrument tracks.
 		 */
+		/** Typed hand map events parsed from text events matching 'map HandMap_*'. */
+		handMaps: {
+			tick: number
+			type: 'default' | 'noChords' | 'allChords' | 'allBend' | 'solo' | 'dropD' | 'dropD2' | 'chordC' | 'chordD' | 'chordA'
+		}[]
+		/** Typed strum map events parsed from text events matching 'map StrumMap_*'. */
+		strumMaps: {
+			tick: number
+			type: 'default' | 'pick' | 'slapBass'
+		}[]
+		/** Typed character state events parsed from text events ([idle], [play], etc.). */
+		characterStates: {
+			tick: number
+			type: 'idle' | 'idleIntense' | 'idleRealtime' | 'play' | 'playSolo' | 'intense' | 'mellow'
+		}[]
+		/** Pro Keys glissando markers (MIDI note 126 on pro keys tracks). */
+		glissandoSections: {
+			tick: number
+			/** Number of ticks */
+			length: number
+		}[]
 		proKeysRangeShifts: {
 			tick: number
 			/** Number of ticks */
@@ -172,20 +195,32 @@ export interface RawChartData {
 			noteNumber: number
 		}[]
 		/**
-		 * Raw MIDI note data for instruments whose note format is not yet fully parsed
-		 * into NoteEvent (pro guitar/bass, pro keys, elite drums). Contains all per-difficulty
-		 * noteOn/noteOff pairs with full MIDI properties for roundtrip writing.
+		 * Raw MIDI note data for new instruments (pro guitar/bass, pro keys, elite drums).
+		 * Contains per-difficulty noteOn/noteOff pairs with MIDI properties + semantic labels.
 		 */
 		rawNotes: {
 			tick: number
 			/** Number of ticks */
 			length: number
-			/** The MIDI note number (instrument-type-specific meaning) */
+			/** The MIDI note number */
 			noteNumber: number
-			/** MIDI velocity (pro guitar: fret + 100; elite drums: 1=ghost, 127=accent) */
+			/** MIDI velocity */
 			velocity: number
-			/** MIDI channel (pro guitar: 0=normal, 1=ghost, 2=bend, 3=muted, 4=tapped, 5=harmonics, 6=pinch harmonics) */
+			/** MIDI channel */
 			channel: number
+
+			// ── Semantic labels (set by notes-parser based on instrument type) ──
+
+			/** Pro Guitar/Bass: string index (0=low E, 1=A, 2=D, 3=G, 4=B, 5=high E) */
+			string?: number
+			/** Pro Guitar/Bass: fret number (0=open, 1-17 or 1-22) */
+			fret?: number
+			/** Pro Guitar/Bass: note modifier derived from MIDI channel */
+			noteModifier?: 'normal' | 'ghost' | 'bend' | 'muted' | 'tapped' | 'harmonics' | 'pinchHarmonics'
+			/** Pro Keys: key index (0-24, where 0=C1, 24=C3) */
+			key?: number
+			/** Elite Drums: pad name derived from noteNumber offset */
+			pad?: 'hatPedal' | 'kick' | 'snare' | 'hiHat' | 'leftCrash' | 'tom1' | 'tom2' | 'tom3' | 'ride' | 'rightCrash'
 		}[]
 	}[]
 }
@@ -288,6 +323,9 @@ export const eventTypes = {
 
 	// Toggle
 	enableChartDynamics: 54,
+
+	// Pro Keys
+	glissando: 55,
 } as const
 
 /** A single event in a chart's track. Note that more than one event can occur at the same time. */

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -74,6 +74,16 @@ export interface RawChartData {
 		tick: number
 	}[]
 	/**
+	 * Remaining text-like events from the EVENTS track that weren't recognized
+	 * and routed to a typed field (sections, endEvents, vocalTracks). These
+	 * include crowd events, music_start/end, drums mix events, coda markers,
+	 * and any custom/unknown text events.
+	 */
+	unrecognizedEvents: {
+		tick: number
+		text: string
+	}[]
+	/**
 	 * Issues detected at parse time (before `findChartIssues` runs). `chart-scanner`
 	 * concatenates these into the final `chartIssues` array, attaching the standard
 	 * description from `chartIssueDescriptions`. Use this for issues that the parser

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -91,6 +91,8 @@ export interface RawChartData {
 	 * away, malformed events that get dropped).
 	 */
 	parseIssues: Omit<NotesData['chartIssues'][number], 'description'>[]
+	/** VENUE track events: lighting, camera, post-processing, spotlights, singalongs, stage effects. */
+	venue: VenueEvent[]
 	trackData: {
 		instrument: Instrument
 		difficulty: Difficulty
@@ -254,6 +256,14 @@ export interface VocalTrackData {
 		tick: number
 		length: number
 	}[]
+}
+
+export type VenueEventType = 'lighting' | 'postProcessing' | 'cameraCut' | 'cameraCutConstraint' | 'spotlight' | 'singalong' | 'stageEffect'
+export interface VenueEvent {
+	tick: number
+	type: VenueEventType
+	/** Semantic name of the event (e.g. 'verse', 'bloom', 'directed_guitar', 'bass') */
+	name: string
 }
 
 export type EventType = ObjectValues<typeof eventTypes>

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -91,6 +91,8 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 				textEvents: setEventMsTimes(track.textEvents, timedTempos, rawChartData.chartTicksPerBeat),
 				versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, rawChartData.chartTicksPerBeat),
 				animations: setEventMsTimes(track.animations, timedTempos, rawChartData.chartTicksPerBeat),
+				proKeysRangeShifts: setEventMsTimes(track.proKeysRangeShifts, timedTempos, rawChartData.chartTicksPerBeat),
+				rawNotes: setEventMsTimes(track.rawNotes, timedTempos, rawChartData.chartTicksPerBeat),
 				noteEventGroups: _.chain(track.trackEvents)
 					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.groupBy(note => note.tick)

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -65,6 +65,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		venue: setEventMsTimes(rawChartData.venue, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 
-import { DrumType, drumTypes, Instrument } from 'src/interfaces'
+import { Difficulty, DrumType, drumTypes, getInstrumentType, Instrument, instrumentTypes } from 'src/interfaces'
 import { parseNotesFromChart } from './chart-parser'
 import { parseNotesFromMidi } from './midi-parser'
 import {
@@ -83,16 +83,29 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.thru(events => sortAndFixInvalidEventOverlaps(events))
 					.value(),
+				glissandoSections: setEventMsTimes(track.glissandoSections, timedTempos, rawChartData.chartTicksPerBeat),
 				flexLanes: _.chain(track.flexLanes)
 					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.thru(events => sortAndFixInvalidFlexLaneOverlaps(events))
 					.value(),
 				drumFreestyleSections: setEventMsTimes(track.drumFreestyleSections, timedTempos, rawChartData.chartTicksPerBeat),
 				textEvents: setEventMsTimes(track.textEvents, timedTempos, rawChartData.chartTicksPerBeat),
+				handMaps: setEventMsTimes(track.handMaps, timedTempos, rawChartData.chartTicksPerBeat),
+				strumMaps: setEventMsTimes(track.strumMaps, timedTempos, rawChartData.chartTicksPerBeat),
+				characterStates: setEventMsTimes(track.characterStates, timedTempos, rawChartData.chartTicksPerBeat),
 				versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, rawChartData.chartTicksPerBeat),
-				animations: setEventMsTimes(track.animations, timedTempos, rawChartData.chartTicksPerBeat),
+				animations: setEventMsTimes(
+						nameAnimations(track.animations, track.instrument),
+						timedTempos, rawChartData.chartTicksPerBeat,
+					),
 				proKeysRangeShifts: setEventMsTimes(track.proKeysRangeShifts, timedTempos, rawChartData.chartTicksPerBeat),
-				rawNotes: setEventMsTimes(track.rawNotes, timedTempos, rawChartData.chartTicksPerBeat),
+				rawNotes: setEventMsTimes(
+						interpretRawNotes(
+							trimRawNoteSustains(track.rawNotes, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format),
+							track.instrument, track.difficulty,
+						),
+						timedTempos, rawChartData.chartTicksPerBeat,
+					),
 				noteEventGroups: _.chain(track.trackEvents)
 					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.groupBy(note => note.tick)
@@ -978,4 +991,122 @@ function sortAndFixInvalidNoteOverlaps(noteGroups: UntimedNoteEvent[][]) {
 			}
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Raw note semantic interpretation for new instruments
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Raw note sustain trimming (same logic as standard instruments)
+// ---------------------------------------------------------------------------
+
+function trimRawNoteSustains(
+	rawNotes: RawNote[],
+	sustain_cutoff_threshold: number,
+	chartTicksPerBeat: number,
+	format: 'chart' | 'mid',
+) {
+	// Pro instruments use a slightly different threshold than standard instruments:
+	// resolution/3 with strict < (vs standard's resolution/3 + 1 with <=)
+	const sustainThresholdTicks =
+		sustain_cutoff_threshold !== -1 ? sustain_cutoff_threshold
+		: format === 'mid' ? Math.floor(chartTicksPerBeat / 3)
+		: 0
+
+	if (sustainThresholdTicks > 0) {
+		for (const note of rawNotes) {
+			if (note.length < sustainThresholdTicks) {
+				note.length = 0
+			}
+		}
+	}
+
+	return rawNotes
+}
+
+// ---------------------------------------------------------------------------
+// Animation naming
+// ---------------------------------------------------------------------------
+
+/** Drum animation MIDI note → semantic name (YARG AnimationLookup). */
+const drumAnimationNames: { [noteNumber: number]: string } = {
+	24: 'kick', 25: 'hiHatOpen', 26: 'snareLHHard', 27: 'snareRHHard',
+	28: 'snareLHSoft', 29: 'snareRHSoft', 30: 'hiHatLeft', 31: 'hiHatRight',
+	32: 'percussionRight',
+	34: 'crash1LHHard', 35: 'crash1LHSoft', 36: 'crash1RHHard', 37: 'crash1RHSoft',
+	38: 'crash2RHHard', 39: 'crash2RHSoft', 40: 'crash1Choke', 41: 'crash2Choke',
+	42: 'rideRight', 43: 'rideLeft', 44: 'crash2LHHard', 45: 'crash2LHSoft',
+	46: 'tom1Left', 47: 'tom1Right', 48: 'tom2Left', 49: 'tom2Right',
+	50: 'floorTomLeft', 51: 'floorTomRight',
+}
+
+/** Guitar/bass/keys animation MIDI note → semantic name. */
+function getGuitarAnimationName(noteNumber: number): string | undefined {
+	if (noteNumber >= 40 && noteNumber <= 59) {
+		return `leftHandPosition${noteNumber - 39}`
+	}
+	return undefined
+}
+
+type AnimationEntry = RawChartData['trackData'][number]['animations'][number]
+
+function nameAnimations(animations: AnimationEntry[], instrument: Instrument): AnimationEntry[] {
+	const instrumentType = getInstrumentType(instrument)
+	for (const anim of animations) {
+		if (instrumentType === instrumentTypes.drums) {
+			anim.name = drumAnimationNames[anim.noteNumber]
+		} else {
+			anim.name = getGuitarAnimationName(anim.noteNumber)
+		}
+	}
+	return animations
+}
+
+// ---------------------------------------------------------------------------
+// Raw note semantic interpretation for new instruments
+// ---------------------------------------------------------------------------
+
+const proGuitarDiffStarts: { [key in Difficulty]: number } = { easy: 24, medium: 48, hard: 72, expert: 96 }
+const eliteDrumsDiffStarts: { [key in Difficulty]: number } = { easy: 2, medium: 26, hard: 50, expert: 74 }
+const proGuitarChannelModifiers: { [channel: number]: RawChartData['trackData'][number]['rawNotes'][number]['noteModifier'] } = {
+	0: 'normal', 1: 'ghost', 2: 'bend', 3: 'muted', 4: 'tapped', 5: 'harmonics', 6: 'pinchHarmonics',
+}
+/** Elite Drums: MIDI note offset from difficulty start → pad name. Offset -2=hatPedal, 0=kick, etc. */
+const eliteDrumsPadByOffset: { [offset: number]: RawChartData['trackData'][number]['rawNotes'][number]['pad'] } = {
+	[-2]: 'hatPedal', 0: 'kick', 1: 'snare', 2: 'hiHat', 3: 'leftCrash',
+	4: 'tom1', 5: 'tom2', 6: 'tom3', 7: 'ride', 8: 'rightCrash',
+}
+
+type RawNote = RawChartData['trackData'][number]['rawNotes'][number]
+
+function interpretRawNotes(rawNotes: RawNote[], instrument: Instrument, difficulty: Difficulty): RawNote[] {
+	const instrumentType = getInstrumentType(instrument)
+
+	if (instrumentType === instrumentTypes.proGuitar) {
+		const diffStart = proGuitarDiffStarts[difficulty]
+		const maxFret = instrument === 'proguitar22' || instrument === 'probass22' ? 22 : 17
+		for (const note of rawNotes) {
+			const offset = note.noteNumber - diffStart
+			if (offset >= 0 && offset <= 5) {
+				note.string = offset
+				note.fret = Math.min(Math.max(0, note.velocity - 100), maxFret)
+			}
+			note.noteModifier = proGuitarChannelModifiers[note.channel] ?? 'normal'
+		}
+	} else if (instrumentType === instrumentTypes.proKeys) {
+		for (const note of rawNotes) {
+			if (note.noteNumber >= 48 && note.noteNumber <= 72) {
+				note.key = note.noteNumber - 48
+			}
+		}
+	} else if (instrumentType === instrumentTypes.eliteDrums) {
+		const diffStart = eliteDrumsDiffStarts[difficulty]
+		for (const note of rawNotes) {
+			const offset = note.noteNumber - diffStart
+			note.pad = eliteDrumsPadByOffset[offset]
+		}
+	}
+
+	return rawNotes
 }

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -64,6 +64,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		parseIssues: rawChartData.parseIssues,
 		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -40,8 +40,8 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 	const drumTracks = rawChartData.trackData.filter(track => track.instrument === 'drums')
 	const drumType =
 		drumTracks.length === 0 ? null
-		: iniChartModifiers.pro_drums ? drumTypes.fourLanePro
 		: iniChartModifiers.five_lane_drums ? drumTypes.fiveLane
+		: iniChartModifiers.pro_drums ? drumTypes.fourLanePro
 		: drumTracks.find(track => track.trackEvents.find(e => isCymbalOrTomMarker(e.type))) ? drumTypes.fourLanePro
 		: drumTracks.find(track => track.trackEvents.find(e => e.type === eventTypes.fiveGreenDrum)) ? drumTypes.fiveLane
 		: drumTypes.fourLane
@@ -54,35 +54,23 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		)
 		.value()
 
-	return {
-		resolution: rawChartData.chartTicksPerBeat,
-		drumType,
-		metadata: rawChartData.metadata,
-		hasLyrics: Object.values(rawChartData.vocalTracks).some(v => v.lyrics.length > 0),
-		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
-		hasForcedNotes,
-		parseIssues: rawChartData.parseIssues,
-		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
-		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
-		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
-		venue: setEventMsTimes(rawChartData.venue, timedTempos, rawChartData.chartTicksPerBeat),
-		tempos: timedTempos,
-		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
-		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
-		trackData: _.chain(rawChartData.trackData)
-			.map(track => ({
+	const normalizedVocalTracks = normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat)
+	// Evaluate trackData first — normalizedVocalTracks is used below for phrase-level hasLyrics check.
+	const trackDataResult = _.chain(rawChartData.trackData)
+			.map(track => {
+				return {
 				instrument: track.instrument,
 				difficulty: track.difficulty,
 				starPowerSections: _.chain(track.starPowerSections)
 					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.thru(events => sortAndFixInvalidEventOverlaps(events))
+					.thru(events => sortAndFixInvalidEventOverlaps(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.value(),
 				rejectedStarPowerSections: _.chain(track.rejectedStarPowerSections)
 					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.value(),
 				soloSections: _.chain(track.soloSections)
 					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.thru(events => sortAndFixInvalidEventOverlaps(events))
+					.thru(events => sortAndFixInvalidEventOverlaps(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.value(),
 				glissandoSections: setEventMsTimes(track.glissandoSections, timedTempos, rawChartData.chartTicksPerBeat),
 				flexLanes: _.chain(track.flexLanes)
@@ -108,7 +96,6 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 						timedTempos, rawChartData.chartTicksPerBeat,
 					),
 				noteEventGroups: _.chain(track.trackEvents)
-					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.groupBy(note => note.tick)
 					.values()
 					.thru(eventGroups =>
@@ -118,10 +105,35 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 					)
 					.thru(noteGroups => snapChords(noteGroups, iniChartModifiers.chord_snap_threshold, track.instrument))
 					.tap(noteGroups => sortAndFixInvalidNoteOverlaps(noteGroups))
+					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
 					.thru(events => setEventGroupMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.value(),
-			}))
-			.value(),
+				}
+			})
+			.value()
+
+	return {
+		resolution: rawChartData.chartTicksPerBeat,
+		drumType,
+		metadata: rawChartData.metadata,
+		// Check phrase-level lyrics to decide hasLyrics — raw lyric events that
+		// get filtered (brackets, whitespace-only) should not count.
+		hasLyrics: Object.values(normalizedVocalTracks.parts).some(p =>
+			p.notePhrases.some(ph => ph.lyrics.length > 0)),
+		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
+		hasForcedNotes,
+		parseIssues: rawChartData.parseIssues,
+		vocalTracks: normalizedVocalTracks,
+		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		venue: setEventMsTimes(rawChartData.venue, timedTempos, rawChartData.chartTicksPerBeat),
+		beatTrack: rawChartData.beatTrack
+			? setEventMsTimes(rawChartData.beatTrack, timedTempos, rawChartData.chartTicksPerBeat)
+			: undefined,
+		tempos: timedTempos,
+		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
+		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
+		trackData: trackDataResult,
 	}
 }
 
@@ -143,7 +155,7 @@ function normalizeVocalTracks(
 	const sourcePart = vocalTracks['vocals'] ?? vocalTracks['harmony1']
 
 	for (const [partName, data] of entries) {
-		parts[partName] = normalizeVocalPart(data, timedTempos, resolution)
+		parts[partName] = normalizeVocalPart(data, timedTempos, resolution, partName)
 	}
 
 	return {
@@ -161,15 +173,94 @@ function normalizeVocalPart(
 	data: VocalTrackData,
 	timedTempos: TimedTempos,
 	resolution: number,
+	partName: string,
 ): NormalizedVocalPart {
-	const notePhrases = groupIntoPhrases(data.vocalPhrases, data, timedTempos, resolution)
+	const isPartVocals = partName === 'vocals'
+	const isHarm2or3 = partName === 'harmony2' || partName === 'harmony3'
+
+	// PART VOCALS: merge note 105 + 106 into a single phrase list with player
+	// tags. Both create scoring + static lyric phrases in YARG.
+	// Harmonies: keep 105 (scoring) and 106 (static lyric) separate for
+	// lossless round-trip — the writer needs to emit them on their original
+	// MIDI note numbers, and CopyDown relies on HARM1's vocalPhrases (105 only).
+	let notePhrases: NormalizedVocalPhrase[]
+	let staticLyricPhrases: NormalizedVocalPhrase[]
+
+	if (isPartVocals) {
+		// Merge 105 + 106 for PART VOCALS
+		const mergedPhrases: { tick: number; length: number; _source: 105 | 106 }[] = []
+		for (const p of data.vocalPhrases) {
+			mergedPhrases.push({ tick: p.tick, length: p.length, _source: 105 })
+		}
+		for (const p of data.staticLyricPhrases) {
+			mergedPhrases.push({ tick: p.tick, length: p.length, _source: 106 })
+		}
+		mergedPhrases.sort((a, b) => a.tick - b.tick)
+
+		// Dedup same-tick phrases (keep longest), track source of survivor
+		const dedupedPhrases: typeof mergedPhrases = []
+		const phraseSourceByTick = new Map<number, 105 | 106>()
+		for (const p of mergedPhrases) {
+			const existing = dedupedPhrases.find(d => d.tick === p.tick)
+			if (existing) {
+				if (p.length > existing.length) {
+					existing.length = p.length
+					existing._source = p._source
+				}
+			} else {
+				dedupedPhrases.push(p)
+			}
+			phraseSourceByTick.set(p.tick, dedupedPhrases.find(d => d.tick === p.tick)!._source)
+		}
+
+		notePhrases = groupIntoPhrases(dedupedPhrases, data, timedTempos, resolution)
+
+		// Set player field
+		for (const phrase of notePhrases) {
+			const source = phraseSourceByTick.get(phrase.tick)
+			phrase.player = source === 106 ? 2 : 1
+		}
+
+		// staticLyricPhrases = copy of notePhrases for PART VOCALS
+		staticLyricPhrases = notePhrases.map(p => ({ ...p }))
+	} else {
+		// Harmonies: separate 105/106 for lossless round-trip
+		notePhrases = groupIntoPhrases(data.vocalPhrases, data, timedTempos, resolution)
+		staticLyricPhrases = data.staticLyricPhrases.length > 0
+			? groupIntoPhrases(data.staticLyricPhrases, data, timedTempos, resolution)
+			: []
+	}
+
 	return {
 		notePhrases,
-		staticLyricPhrases: data.staticLyricPhrases.length > 0
-			? groupIntoPhrases(data.staticLyricPhrases, data, timedTempos, resolution)
-			: notePhrases,
+		staticLyricPhrases,
 		starPowerSections: setEventMsTimes(data.starPowerSections, timedTempos, resolution),
+		rangeShifts: setEventMsTimes(
+			data.rangeShifts.map(r => ({ tick: r.tick, length: r.length })),
+			timedTempos,
+			resolution,
+		),
+		lyricShifts: setEventMsTimes(
+			data.lyricShifts.map(l => ({ tick: l.tick, length: l.length })),
+			timedTempos,
+			resolution,
+		),
+		textEvents: (data.textEvents ?? []).map(t => {
+			let idx = 0
+			while (timedTempos[idx + 1] && timedTempos[idx + 1].tick <= t.tick) idx++
+			const tempo = timedTempos[idx]
+			const msTime = tempo.msTime + ((t.tick - tempo.tick) * 60000) / (tempo.beatsPerMinute * resolution)
+			return { tick: t.tick, msTime, text: t.text }
+		}),
 	}
+}
+
+/** Standard emptiness check for lyrics (matching YARG's IsNullOrWhiteSpace
+ * on StripForVocals output). Symbol-only lyrics like "+" strip to empty
+ * and are dropped. */
+function isLyricKept(text: string): boolean {
+	const stripped = stripLyricSymbols(text)
+	return stripped.length > 0 && stripped.replace(/_/g, ' ').trim().length > 0
 }
 
 function groupIntoPhrases(
@@ -223,38 +314,52 @@ function groupIntoPhrases(
 		// Check if a pitch slide from a previous phrase carries into this one
 		const hasCarriedNote = carriedNoteEndTick >= phrase.tick
 
-		// Build notes and lyrics by iterating notes and collecting lyrics up to each note's tick
-		// (matching YARG's ProcessNoteEvent pattern where moonTextIndex is shared across phrases).
 		const notes: NormalizedVocalNote[] = []
 		const untimedLyrics: { tick: number; text: string; flags: number }[] = []
-		for (const note of rawNotes) {
-			// YARG only processes note 96 (percussion), not note 97 (percussionHidden/nonplayed)
-			if (note.type === 'percussionHidden') continue
 
-			// Skip percussion notes at the exact phrase start tick when it's the first note.
-			// In MIDI, noteOn for note 96 can arrive before noteOn for note 105 at the same tick,
-			// causing the percussion note to not be included in the phrase by YARG's normalizer.
+		// Pre-collect all lyrics within this phrase's tick range. This advances
+		// lyricIdx to a consistent position (phraseEnd) regardless of which notes
+		// exist, preventing lyricIdx divergence when pitch slide notes are dropped
+		// on round-trip. Note processing uses a local iterator (phraseLyricIdx)
+		// over this pre-collected list for flag detection.
+		const phraseLyrics: { tick: number; text: string; flags: number }[] = []
+		while (lyricIdx < sortedLyrics.length && sortedLyrics[lyricIdx].tick < phraseEnd) {
+			const lyric = sortedLyrics[lyricIdx]
+			lyricIdx++
+			const text = lyric.text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
+			if (text.startsWith('[')) continue
+			phraseLyrics.push({ tick: lyric.tick, text, flags: parseLyricFlags(text) })
+		}
+		if (rawNotes.length === 0) {
+			// No-notes path (.chart format, empty phrases): add all phrase lyrics
+			for (const pl of phraseLyrics) {
+				if (isLyricKept(pl.text)) {
+					untimedLyrics.push({ tick: pl.tick, text: pl.text, flags: pl.flags })
+				}
+			}
+		}
+
+		// Process notes, using phraseLyrics for flag detection
+		let phraseLyricIdx = 0
+		for (const note of rawNotes) {
+			if (note.type === 'percussionHidden') continue
 			if (note.type === 'percussion' && note.tick === phrase.tick && notes.length === 0) {
 				continue
 			}
 
-			// Collect all lyrics up to and including this note's tick
+			// Collect lyrics up to and including this note's tick (local iterator)
 			let noteLyricFlags = 0
-			while (lyricIdx < sortedLyrics.length && sortedLyrics[lyricIdx].tick <= note.tick) {
-				const lyric = sortedLyrics[lyricIdx]
-				lyricIdx++
+			while (phraseLyricIdx < phraseLyrics.length && phraseLyrics[phraseLyricIdx].tick <= note.tick) {
+				let { tick, text, flags } = phraseLyrics[phraseLyricIdx]
+				phraseLyricIdx++
 
-				// Trim ASCII whitespace (0x00-0x20) from both ends, matching YARG's
-				// NormalizeTextEvent.TrimAscii() which processes text before storage.
-				let text = lyric.text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
-
-				// Skip bracketed events — YARG's NormalizeTextEvent strips brackets and
-				// prevents bracketed FF 01 text events from becoming lyrics.
-				if (text.startsWith('[')) continue
-
-				let flags = parseLyricFlags(text)
 				noteLyricFlags = flags
 
+				// DeferredLyricJoinWorkaround: "+-" or "-+" merges the hyphen into
+				// the previous lyric's flags. We update noteLyricFlags for pitch
+				// slide detection but keep the original text "+-" for lossless
+				// round-trip — changing it to "+" causes the workaround to trigger
+				// differently on re-parse (state-dependent, not idempotent).
 				// DeferredLyricJoinWorkaround: "+-" or "-+" merges the hyphen into the previous lyric
 				if (untimedLyrics.length > 0 && (text === '+-' || text === '-+')) {
 					const prev = untimedLyrics[untimedLyrics.length - 1]
@@ -270,41 +375,37 @@ function groupIntoPhrases(
 					}
 				}
 
-				const strippedText = stripLyricSymbols(text)
-				// Skip lyrics that would be whitespace-only after _ → space replacement.
-				// Matches YARG's IsNullOrWhiteSpace check which runs on StripForVocals output
-				// (where _ is replaced with space).
-				if (strippedText.length > 0 && strippedText.replace(/_/g, ' ').trim().length > 0) {
-					untimedLyrics.push({ tick: lyric.tick, text: strippedText, flags })
+				if (isLyricKept(text)) {
+					untimedLyrics.push({ tick, text, flags })
 				}
 			}
 
 			const isPitchSlide = (noteLyricFlags & lyricFlags.pitchSlide) !== 0
-			const isNonPitched = (noteLyricFlags & lyricFlags.nonPitched) !== 0 ||
-				note.type === 'percussion'
 
 			if (isPitchSlide) {
-				const slideEnd = note.tick + note.length
-				if (notes.length > 0) {
-					// Within-phrase slide: merges with previousNote (a separate chain from carriedNote).
-					// Do NOT extend carriedNoteEndTick — previousNote is not necessarily the carriedNote.
-					// In YARG, AddChildNote only updates the parent it's called on, not other notes.
-					continue
-				}
-				if (hasCarriedNote) {
-					// Cross-phrase slide via carried note: skip, extend total end
-					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
-					continue
-				}
-				// Cross-phrase slide via previousParentLyric (YARG behavior):
-				if (result.length === 0) {
-					// No phrases yet → charting error, skip
-					continue
-				}
-				if (hasPreviousLyricNote) {
-					// Add to previousParentLyric, set carriedNote
-					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
-					continue
+				// Only skip if the pitchSlide lyric survived the emptiness filter.
+				// Symbol-only "+" strips to empty and is filtered from output. If
+				// filtered, the lyric won't exist on re-parse, so the note wouldn't
+				// be detected as a pitch slide — keeping it ensures round-trip
+				// consistency for Harmonix-authored charts.
+				const lastStored = untimedLyrics.length > 0 ? untimedLyrics[untimedLyrics.length - 1] : null
+				const slideMarkerKept = lastStored !== null && (lastStored.flags & lyricFlags.pitchSlide) !== 0
+				if (slideMarkerKept) {
+					const slideEnd = note.tick + note.length
+					if (notes.length > 0) {
+						continue
+					}
+					if (hasCarriedNote) {
+						carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+						continue
+					}
+					if (result.length === 0) {
+						continue
+					}
+					if (hasPreviousLyricNote) {
+						carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+						continue
+					}
 				}
 			}
 
@@ -314,20 +415,29 @@ function groupIntoPhrases(
 				msTime: timed.msTime,
 				length: timed.length,
 				msLength: timed.msLength,
-				pitch: isNonPitched ? -1 : note.pitch,
+				// Keep original MIDI pitch for pitched notes (even nonPitched ones
+				// marked by lyric flags like #/^/*). Consumers check the lyric's
+				// nonPitched flag instead. Percussion always gets -1 (fixed MIDI note 96).
+				pitch: note.type === 'percussion' ? -1 : note.pitch,
 				type: note.type,
 			})
 			if (note.type === 'pitched') hasPreviousLyricNote = true
 		}
 
-		// Re-check carried note state after processing all notes in this phrase.
-		// Pitch slides during this phrase may have set carriedNoteEndTick via previousParentLyric.
-		const hasCarriedNoteAfter = carriedNoteEndTick >= phrase.tick
-
-		// Skip phrases with no notes and no carried note (matching YARG behavior)
-		if (notes.length < 1 && !hasCarriedNote && !hasCarriedNoteAfter) {
-			continue
+		// Add remaining pre-collected lyrics after the last note (with-notes path only;
+		// no-notes path already added all phraseLyrics above)
+		while (rawNotes.length > 0 && phraseLyricIdx < phraseLyrics.length) {
+			const { tick, text, flags } = phraseLyrics[phraseLyricIdx]
+			phraseLyricIdx++
+			if (isLyricKept(text)) {
+				untimedLyrics.push({ tick, text, flags })
+			}
 		}
+
+		// NOTE: Intentionally do NOT drop "empty" phrases (no notes, no lyrics, no carried
+		// note). Keeping them preserves the full set of phrase boundaries so that writers
+		// can round-trip the full MIDI state. Consumers wanting a YARG-compatible filtered
+		// view can filter notePhrases themselves.
 
 		// Track carry-over: only from notes that were added to the phrase (not pitch slide children).
 		// YARG sets carriedNote at line 219-222, which only runs for notes that pass through
@@ -448,19 +558,20 @@ function setEventOrEventGroupMsTimes<T extends { tick: number; length?: number }
 	return events as (T & { msTime: number; msLength: number })[][] | (T & { msTime: number; msLength: number })[]
 }
 
-function trimSustains(
-	trackEvents: { tick: number; length: number; type: EventType }[],
+function trimSustains<T extends { tick: number; length: number; type: EventType }[] | { tick: number; length: number; type: EventType }[][]>(
+	trackEvents: T,
 	sustain_cutoff_threshold: number,
 	chartTicksPerBeat: number,
 	format: 'chart' | 'mid',
-) {
+): T {
 	const sustainThresholdTicks =
 		sustain_cutoff_threshold !== -1 ? sustain_cutoff_threshold
 		: format === 'mid' ? Math.floor(chartTicksPerBeat / 3) + 1
 		: 0
 
 	if (sustainThresholdTicks > 0) {
-		for (const event of trackEvents) {
+		const items = Array.isArray(trackEvents[0]) ? (trackEvents as { length: number }[][]).flat() : trackEvents as { length: number }[]
+		for (const event of items) {
 			if (event.length <= sustainThresholdTicks) {
 				event.length = 0
 			}
@@ -503,11 +614,8 @@ function resolveDrumModifiers(trackEventGroups: TrackEvent[][], drumType: DrumTy
 			})
 		}
 
-		const hasOrangeAndGreen =
-			!!notes.find(e => e.type === eventTypes.fiveGreenDrum) && !!notes.find(e => e.type === eventTypes.fiveOrangeFourGreenDrum)
-
 		for (const note of notes) {
-			const type = getDrumNoteTypeFromEventType(note.type, hasOrangeAndGreen)!
+			const type = getDrumNoteTypeFromEventType(note.type, drumType)!
 			const canBeDisco = type === noteTypes.redDrum || type === noteTypes.yellowDrum
 			const discoFlag =
 				!canBeDisco || activeDiscoFlip === eventTypes.discoFlipOff ? noteFlags.none
@@ -553,7 +661,7 @@ function isKickNote(eventType: EventType) {
 	}
 }
 
-function getDrumNoteTypeFromEventType(eventType: EventType, hasOrangeAndGreen: boolean): NoteType | null {
+function getDrumNoteTypeFromEventType(eventType: EventType, drumType: DrumType): NoteType | null {
 	switch (eventType) {
 		case eventTypes.redDrum:
 			return noteTypes.redDrum
@@ -562,9 +670,11 @@ function getDrumNoteTypeFromEventType(eventType: EventType, hasOrangeAndGreen: b
 		case eventTypes.blueDrum:
 			return noteTypes.blueDrum
 		case eventTypes.fiveOrangeFourGreenDrum:
-			return noteTypes.greenDrum
+			// MIDI 100 is "green" in 4-lane/4-lane-pro but "orange" in 5-lane.
+			return drumType === drumTypes.fiveLane ? noteTypes.orangeDrum : noteTypes.greenDrum
 		case eventTypes.fiveGreenDrum:
-			return hasOrangeAndGreen ? noteTypes.blueDrum : noteTypes.greenDrum
+			// MIDI 101 is always the 5-lane green pad (5th lane).
+			return noteTypes.greenDrum
 		default:
 			return null
 	}
@@ -726,7 +836,6 @@ function resolveFretModifiers(
 			: events.find(n => n.type === eventTypes.forceStrum) ? noteFlags.strum
 			: (hasForceUnnatural && isNaturalHopo) || (!hasForceUnnatural && !isNaturalHopo) ? noteFlags.strum
 			: noteFlags.hopo
-
 		noteEventGroups.push(
 			notes.map(n => ({
 				tick: n.tick,
@@ -882,6 +991,9 @@ function snapChords(noteGroups: UntimedNoteEvent[][], chord_snap_threshold: numb
 					} else if (note.type === noteTypes.blueDrum) {
 						const lastBlueDrumFlags = lastNoteGroup.find(n => n.type === noteTypes.blueDrum)?.flags ?? null
 						note.flags = lastBlueDrumFlags === null ? note.flags : lastBlueDrumFlags
+					} else if (note.type === noteTypes.orangeDrum) {
+						const lastOrangeDrumFlags = lastNoteGroup.find(n => n.type === noteTypes.orangeDrum)?.flags ?? null
+						note.flags = lastOrangeDrumFlags === null ? note.flags : lastOrangeDrumFlags
 					} else if (note.type === noteTypes.greenDrum) {
 						const lastGreenDrumFlags = lastNoteGroup.find(n => n.type === noteTypes.greenDrum)?.flags ?? null
 						note.flags = lastGreenDrumFlags === null ? note.flags : lastGreenDrumFlags
@@ -939,7 +1051,11 @@ function sortAndFixInvalidFlexLaneOverlaps(events: { tick: number; length: numbe
 	return events
 }
 
-function sortAndFixInvalidEventOverlaps(events: { tick: number; length: number; msTime: number; msLength: number }[]) {
+function sortAndFixInvalidEventOverlaps(
+	events: { tick: number; length: number; msTime: number; msLength: number }[],
+	tempos?: { tick: number; beatsPerMinute: number; msTime: number }[],
+	chartTicksPerBeat?: number,
+) {
 	events.sort((a, b) => a.tick - b.tick || b.length - a.length) // Longest event is kept for duplicates
 	let removedEvents: { tick: number; length: number; msTime: number; msLength: number }[] | null = null
 	for (let i = 1; i < events.length; i++) {
@@ -952,13 +1068,35 @@ function sortAndFixInvalidEventOverlaps(events: { tick: number; length: number; 
 		_.pullAll(events, removedEvents)
 	}
 
+	// Helper: recompute msLength for an event from scratch using the tempo map,
+	// bit-identically to `setEventMsTimes`. This keeps round-trip stable —
+	// writers emit the post-overlap-fix length, and re-parse runs `setEventMsTimes`
+	// on that length, so we must match the same formula exactly.
+	const recomputeMsLength = (event: { tick: number; length: number; msTime: number }) => {
+		if (!tempos || !chartTicksPerBeat) return null
+		if (event.length === 0) return 0
+		let idx = 0
+		while (tempos[idx + 1] && tempos[idx + 1].tick <= event.tick + event.length) idx++
+		const endTempo = tempos[idx]
+		return endTempo.msTime - event.msTime + ((event.tick + event.length - endTempo.tick) * 60000) / (endTempo.beatsPerMinute * chartTicksPerBeat)
+	}
+
 	let previousEvent: { tick: number; length: number; msTime: number; msLength: number } | null = null
 	for (const event of events) {
 		if (previousEvent && previousEvent.tick + previousEvent.length > event.tick) {
+			// BTrack spec overlap resolution: "A's ending tick should be set to
+			// B's starting tick, and B's ending tick should be set to either A
+			// or B's ending tick, whichever is greater."
 			event.length = Math.max(event.length, previousEvent.length - (event.tick - previousEvent.tick))
-			event.msLength = Math.max(event.msLength, previousEvent.msLength - (event.msTime - previousEvent.msTime))
+			const recomputedEvent = recomputeMsLength(event)
+			event.msLength = recomputedEvent !== null
+				? recomputedEvent
+				: Math.max(event.msLength, previousEvent.msLength - (event.msTime - previousEvent.msTime))
 			previousEvent.length = event.tick - previousEvent.tick
-			previousEvent.msLength = event.msTime - previousEvent.msTime
+			const recomputedPrev = recomputeMsLength(previousEvent)
+			previousEvent.msLength = recomputedPrev !== null
+				? recomputedPrev
+				: event.msTime - previousEvent.msTime
 		}
 		previousEvent = event
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { scanVideo } from './video'
 export * from './interfaces'
 export * from './chart/note-parsing-interfaces'
 export { parseChartFile } from './chart/notes-parser'
+export { scanIni } from './ini'
 export { calculateTrackHash } from './chart/track-hasher'
 
 /**

--- a/src/ini/ini-scanner.ts
+++ b/src/ini/ini-scanner.ts
@@ -93,7 +93,7 @@ export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
 	const findIniDataResult = findIniData(files)
 	folderIssues.push(...findIniDataResult.folderIssues)
 	if (!findIniDataResult.iniData) {
-		return { metadata: null, folderIssues, metadataIssues: [] }
+		return { metadata: null, folderIssues, metadataIssues: [], unknownIniValues: {} }
 	}
 
 	const parseIniResult = parseIni(findIniDataResult.iniData)
@@ -101,12 +101,12 @@ export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
 	const songSection = parseIniResult.iniObject.song || parseIniResult.iniObject.Song || parseIniResult.iniObject.SONG
 	if (songSection === undefined) {
 		folderIssues.push({ folderIssue: 'invalidMetadata', description: '"song.ini" doesn\'t have a "[Song]" section.' })
-		return { metadata: null, folderIssues, metadataIssues: [] }
+		return { metadata: null, folderIssues, metadataIssues: [], unknownIniValues: {} }
 	}
 
-	const { metadata, metadataIssues } = extractSongMetadata(songSection)
+	const { metadata, metadataIssues, unknownIniValues } = extractSongMetadata(songSection)
 
-	return { metadata, folderIssues, metadataIssues }
+	return { metadata, folderIssues, metadataIssues, unknownIniValues }
 }
 
 /**
@@ -147,12 +147,20 @@ function findIniData(files: { fileName: string; data: Uint8Array }[]): {
 	}
 }
 
+/** All keys that extractSongMetadata reads (primary + legacy aliases). */
+const knownIniKeys = new Set([
+	...Object.keys(defaultMetadata),
+	'frets', 'track', 'hopofreq', 'star_power_note', // legacy aliases
+])
+
 /**
  * @returns the chart metadata found in `songSection`, using default values if not found.
+ * Also returns all unrecognized key-value pairs for roundtrip preservation.
  */
 function extractSongMetadata(songSection: { [key: string]: string }): {
 	metadata: typeof defaultMetadata
 	metadataIssues: { metadataIssue: MetadataIssueType; description: string }[]
+	unknownIniValues: { [key: string]: string }
 } {
 	const metadataIssues: { metadataIssue: MetadataIssueType; description: string }[] = []
 
@@ -228,7 +236,15 @@ function extractSongMetadata(songSection: { [key: string]: string }): {
 		})
 	}
 
-	return { metadata, metadataIssues }
+	// Collect all unrecognized key-value pairs for roundtrip writing
+	const unknownIniValues: { [key: string]: string } = {}
+	for (const key of Object.keys(songSection)) {
+		if (!knownIniKeys.has(key)) {
+			unknownIniValues[key] = songSection[key]
+		}
+	}
+
+	return { metadata, metadataIssues, unknownIniValues }
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -213,6 +213,13 @@ export const instruments = [
 	'guitarcoopghl', // GHL (6-fret) Co-op Guitar
 	'rhythmghl', // GHL (6-fret) Rhythm Guitar
 	'bassghl', // GHL (6-fret) Bass Guitar
+	'keysghl', // GHL (6-fret) Keys
+	'proguitar', // Pro Guitar (17-fret)
+	'proguitar22', // Pro Guitar (22-fret)
+	'probass', // Pro Bass (17-fret)
+	'probass22', // Pro Bass (22-fret)
+	'prokeys', // Pro Keys
+	'elitedrums', // Elite Drums
 ] as const
 
 export type InstrumentType = ObjectValues<typeof instrumentTypes>
@@ -220,14 +227,25 @@ export const instrumentTypes = {
 	sixFret: 0,
 	fiveFret: 1,
 	drums: 2,
+	proGuitar: 3,
+	proKeys: 4,
+	eliteDrums: 5,
 } as const
-export function getInstrumentType(instrument: Instrument) {
-	if (instrument === 'drums') {
-		return instrumentTypes.drums
-	} else if (instrument === 'guitarghl' || instrument === 'guitarcoopghl' || instrument === 'rhythmghl' || instrument === 'bassghl') {
-		return instrumentTypes.sixFret
-	} else {
-		return instrumentTypes.fiveFret
+export function getInstrumentType(instrument: Instrument): InstrumentType {
+	switch (instrument) {
+		case 'drums': return instrumentTypes.drums
+		case 'guitarghl':
+		case 'guitarcoopghl':
+		case 'rhythmghl':
+		case 'bassghl':
+		case 'keysghl': return instrumentTypes.sixFret
+		case 'proguitar':
+		case 'proguitar22':
+		case 'probass':
+		case 'probass22': return instrumentTypes.proGuitar
+		case 'prokeys': return instrumentTypes.proKeys
+		case 'elitedrums': return instrumentTypes.eliteDrums
+		default: return instrumentTypes.fiveFret
 	}
 }
 
@@ -264,6 +282,7 @@ export type ChartIssueType =
 	| 'invalidLyric' // A lyric event was found on the EVENTS track in a .mid chart and will not be displayed
 	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
+	| 'duplicateDrumsTrack' // Chart has both PART DRUMS and PART REAL_DRUMS_PS; the fallback (PART REAL_DRUMS_PS) was dropped
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -261,6 +261,9 @@ export type ChartIssueType =
 	| 'brokenNote' // This note is so close to the previous note that this was likely a charting mistake
 	| 'badSustainGap' // This note is not far enough ahead of the previous sustain
 	| 'babySustain' // The sustain on this note is too short
+	| 'invalidLyric' // A lyric event was found on the EVENTS track in a .mid chart and will not be displayed
+	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
+	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -283,6 +283,8 @@ export type ChartIssueType =
 	| 'invalidPhraseStart' // A phrase_start text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 	| 'invalidPhraseEnd' // A phrase_end text event was found on the EVENTS track in a .mid chart (vocal phrases use MIDI notes 105/106 on PART VOCALS, not text events)
 	| 'duplicateDrumsTrack' // Chart has both PART DRUMS and PART REAL_DRUMS_PS; the fallback (PART REAL_DRUMS_PS) was dropped
+	| 'orphanedNoteStart' // A noteOn had no matching noteOff and was dropped
+	| 'orphanedNoteEnd' // A noteOff had no matching noteOn and was dropped
 
 export type FolderIssueType =
 	| 'noMetadata' // This chart doesn't have "song.ini"


### PR DESCRIPTION
## Summary

**Core change:** Eliminate top-level `notes[]` and `lyrics[]` from `NormalizedVocalPart`. All vocal content is now accessed through phrase grouping (`notePhrases`/`staticLyricPhrases`).

### Vocal phrase refactor
- `NormalizedVocalPart`: removed `notes[]` and `lyrics[]`
- `NormalizedVocalPhrase`: added `player?: 1 | 2` for PART VOCALS versus mode
- `NormalizedLyricEvent.text`: stores original unstripped markup symbols
- `NormalizedVocalNote.pitch`: nonPitched notes keep original MIDI pitch (not -1)
- PART VOCALS merges note 105+106 phrases with player tags
- Harmonies keep separate 105/106 for lossless round-trip
- Pre-collect lyrics per phrase (lyricIdx advances to phraseEnd regardless of notes, preventing divergence on pitch slide round-trip)
- Pitch slide notes only skipped when controlling lyric survives emptiness filter
- HARM3 CopyDown: clone staticLyricPhrases from HARM2

### Supporting changes (same files, interleaved)
- Beat track: extract MIDI BEAT track for round-trip fidelity
- Chart parser: `resolveChartTrackName`, `parseChartSectionEventText`
- `orangeDrum` noteType for 5-lane drums, `_endSeq` modifier ordering
- `extractMidiVocalTextEvents` for stance/facial anim events
- `VenueEvent`: 'unknown' type and length field
- New tests: drum pads (4/5-lane) and guitar force modifiers

## Validation
- **Hash validation**: 13,338 matched, 0 mismatched
- **Round-trip**: 0 vocal/harmony diffs across 15,525 charts
- **Unit tests**: 46/46 pass