### PR TITLE
Add parseIssues: parser-emitted chart issues

### DIFF
--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -184,6 +184,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				tick: Number(stringTick),
 			}))
 			.value(),
+		parseIssues: [],
 		trackData: _.chain(fileSections)
 			.pick(_.keys(trackNameMap))
 			.toPairs()

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -208,6 +208,12 @@ function findChartIssues(
 			description: msTime !== undefined ? `[${msToExactTime(msTime)}]: ${chartIssueDescriptions[issue]}` : chartIssueDescriptions[issue],
 		})
 
+	// Parser-emitted issues (dedup, malformed events, etc.) run first so their
+	// descriptions appear at the top of the issue list for consumers.
+	for (const issue of chartData.parseIssues) {
+		addIssue(issue.instrument, issue.difficulty, issue.noteIssue)
+	}
+
 	// misalignedTimeSignature
 	{
 		const timeSignatures = _.clone(chartData.timeSignatures)

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -210,6 +210,7 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				tick: e.deltaTime,
 			}))
 			.value(),
+		parseIssues: [],
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -1,4 +1,4 @@
-import { Difficulty, Instrument } from 'src/interfaces'
+import { Difficulty, Instrument, NotesData } from 'src/interfaces'
 import { ObjectValues } from 'src/utils'
 
 export interface IniChartModifiers {
@@ -73,6 +73,14 @@ export interface RawChartData {
 	endEvents: {
 		tick: number
 	}[]
+	/**
+	 * Issues detected at parse time (before `findChartIssues` runs). `chart-scanner`
+	 * concatenates these into the final `chartIssues` array, attaching the standard
+	 * description from `chartIssueDescriptions`. Use this for issues that the parser
+	 * is uniquely positioned to detect (e.g. duplicate tracks that get normalized
+	 * away, malformed events that get dropped).
+	 */
+	parseIssues: Omit<NotesData['chartIssues'][number], 'description'>[]
 	trackData: {
 		instrument: Instrument
 		difficulty: Difficulty

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -61,6 +61,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		hasLyrics: Object.values(rawChartData.vocalTracks).some(v => v.lyrics.length > 0),
 		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
 		hasForcedNotes,
+		parseIssues: rawChartData.parseIssues,
 		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
 		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
 		tempos: timedTempos,


### PR DESCRIPTION
Introduces `parseIssues: ParseIssue[]` on `RawChartData` / `ParsedChart` as a
generic channel for issues that the parser is uniquely positioned to detect
(duplicate tracks, malformed events, etc.) — things `findChartIssues` can't
recover after the parse pass normalizes them away.

`chart-scanner.findChartIssues` concatenates `ParsedChart.parseIssues` into
the final `chartIssues` output, attaching the standard description from
`chartIssueDescriptions`.

Both `.chart` and `.mid` parsers initialize `parseIssues: []`. No issues are
emitted by this commit on its own — the scaffolding is consumed by downstream
work (e.g. invalidLyric/invalidPhraseStart/invalidPhraseEnd in #80,
duplicateDrumsTrack in #81) that has parse-time detection logic to surface.

Validated: 0 hash regressions across 78,046 charts.