### PR TITLE
Vocal phrase refactor

### DIFF
--- a/src/__tests__/lyric-parser.test.ts
+++ b/src/__tests__/lyric-parser.test.ts
@@ -5,16 +5,12 @@ import {
 	parseChartVocalPhraseLine,
 	extractChartLyrics,
 	extractChartVocalPhrases,
+	extractChartOrphanPhraseEnds,
 	isMidiVocalLyric,
 	isBracketedControlEvent,
 	normalizeLyricText,
 	extractMidiLyricText,
-	extractMidiLyrics,
-	extractMidiVocalPhrases,
-	extractMidiVocalNotes,
-	extractMidiVocalStarPower,
-	extractMidiRangeShifts,
-	extractMidiLyricShifts,
+	scanVocalTrack,
 	parseLyricFlags,
 	stripLyricSymbols,
 } from '../chart/lyric-parser'
@@ -265,16 +261,17 @@ describe('extractChartVocalPhrases', () => {
 		expect(phrases[1]).toEqual({ tick: 960, length: 480 })
 	})
 
-	it('keeps orphaned phrase_end (creates phrase from tick 0)', () => {
+	it('skips orphaned phrase_end from extractChartVocalPhrases (preserved separately)', () => {
 		const lines = [
 			'480 = E "phrase_end"',
 			'960 = E "phrase_start"',
 			'1440 = E "phrase_end"',
 		]
 		const phrases = extractChartVocalPhrases(lines)
-		expect(phrases).toHaveLength(2)
-		expect(phrases[0]).toEqual({ tick: 0, length: 480 })
-		expect(phrases[1]).toEqual({ tick: 960, length: 480 })
+		expect(phrases).toHaveLength(1)
+		expect(phrases[0]).toEqual({ tick: 960, length: 480 })
+		// Orphan phrase_ends are surfaced via extractChartOrphanPhraseEnds.
+		expect(extractChartOrphanPhraseEnds(lines)).toEqual([{ tick: 480 }])
 	})
 })
 
@@ -354,17 +351,17 @@ describe('isMidiVocalLyric', () => {
 })
 
 // ---------------------------------------------------------------------------
-// extractMidiLyrics
+// scanVocalTrack — lyrics bucket
 // ---------------------------------------------------------------------------
 
-describe('extractMidiLyrics', () => {
+describe('scanVocalTrack (lyrics)', () => {
 	it('extracts lyrics from lyric events', () => {
 		const events = [
 			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'Hel+' },
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'lo' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0]).toEqual({ tick: 480, length: 0, text: 'Hel+' })
 		expect(lyrics[1]).toEqual({ tick: 960, length: 0, text: 'lo' })
@@ -376,7 +373,7 @@ describe('extractMidiLyrics', () => {
 			{ deltaTime: 480, type: 'text' as const, text: 'Life' },
 			{ deltaTime: 960, type: 'text' as const, text: 'is' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0]).toEqual({ tick: 480, length: 0, text: 'Life' })
 	})
@@ -387,16 +384,17 @@ describe('extractMidiLyrics', () => {
 			{ deltaTime: 480, type: 'lyrics' as const, text: '[play]' },
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'Hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(1)
 		expect(lyrics[0]).toEqual({ tick: 960, length: 0, text: 'Hello' })
 	})
 
 	it('preserves original text including whitespace', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: ' hey^ ' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(1)
 		expect(lyrics[0].text).toBe(' hey^ ')
 	})
@@ -410,7 +408,7 @@ describe('extractMidiLyrics', () => {
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'is' },
 			{ deltaTime: 1440, type: 'text' as const, text: '[idle]' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0]).toEqual({ tick: 480, length: 0, text: 'Life' })
 		expect(lyrics[1]).toEqual({ tick: 960, length: 0, text: 'is' })
@@ -418,18 +416,18 @@ describe('extractMidiLyrics', () => {
 })
 
 // ---------------------------------------------------------------------------
-// extractMidiVocalPhrases
+// scanVocalTrack — phrases105 / phrases106
 // ---------------------------------------------------------------------------
 
-describe('extractMidiVocalPhrases', () => {
+describe('scanVocalTrack (phrases)', () => {
 	it('extracts note 105 phrases', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, channel: 0, noteNumber: 105, velocity: 100 },
 			{ deltaTime: 1440, type: 'noteOff' as const, channel: 0, noteNumber: 105, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(1)
-		expect(phrases[0]).toEqual({ tick: 480, length: 960, noteNumber: 105 })
+		const result = scanVocalTrack(events)
+		expect(result.phrases105).toEqual([{ tick: 480, length: 960 }])
+		expect(result.phrases106).toEqual([])
 	})
 
 	it('extracts note 106 phrases', () => {
@@ -437,9 +435,9 @@ describe('extractMidiVocalPhrases', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, channel: 0, noteNumber: 106, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, channel: 0, noteNumber: 106, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(1)
-		expect(phrases[0]).toEqual({ tick: 480, length: 480, noteNumber: 106 })
+		const result = scanVocalTrack(events)
+		expect(result.phrases106).toEqual([{ tick: 480, length: 480 }])
+		expect(result.phrases105).toEqual([])
 	})
 
 	it('handles velocity 0 noteOn as noteOff', () => {
@@ -447,9 +445,7 @@ describe('extractMidiVocalPhrases', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, channel: 0, noteNumber: 105, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOn' as const, channel: 0, noteNumber: 105, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(1)
-		expect(phrases[0]).toEqual({ tick: 480, length: 480, noteNumber: 105 })
+		expect(scanVocalTrack(events).phrases105).toEqual([{ tick: 480, length: 480 }])
 	})
 
 	it('handles overlapping 105 and 106', () => {
@@ -459,10 +455,9 @@ describe('extractMidiVocalPhrases', () => {
 			{ deltaTime: 960, type: 'noteOff' as const, channel: 0, noteNumber: 105, velocity: 0 },
 			{ deltaTime: 1200, type: 'noteOff' as const, channel: 0, noteNumber: 106, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(2)
-		expect(phrases[0]).toEqual({ tick: 480, length: 480, noteNumber: 105 })
-		expect(phrases[1]).toEqual({ tick: 720, length: 480, noteNumber: 106 })
+		const result = scanVocalTrack(events)
+		expect(result.phrases105).toEqual([{ tick: 480, length: 480 }])
+		expect(result.phrases106).toEqual([{ tick: 720, length: 480 }])
 	})
 
 	it('ignores duplicate noteOn (YARG behavior)', () => {
@@ -472,18 +467,17 @@ describe('extractMidiVocalPhrases', () => {
 			{ deltaTime: 960, type: 'noteOn' as const, channel: 0, noteNumber: 105, velocity: 100 },  // duplicate, ignored
 			{ deltaTime: 1440, type: 'noteOff' as const, channel: 0, noteNumber: 105, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(1)
-		expect(phrases[0]).toEqual({ tick: 480, length: 960, noteNumber: 105 })
+		expect(scanVocalTrack(events).phrases105).toEqual([{ tick: 480, length: 960 }])
 	})
 
-	it('ignores non-105/106 notes', () => {
+	it('does not route non-105/106 notes into phrase buckets', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, channel: 0, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, channel: 0, noteNumber: 60, velocity: 0 },
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(0)
+		const result = scanVocalTrack(events)
+		expect(result.phrases105).toEqual([])
+		expect(result.phrases106).toEqual([])
 	})
 
 	it('handles unpaired noteOn (ignored)', () => {
@@ -491,8 +485,7 @@ describe('extractMidiVocalPhrases', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, channel: 0, noteNumber: 105, velocity: 100 },
 			// No noteOff
 		]
-		const phrases = extractMidiVocalPhrases(events )
-		expect(phrases).toHaveLength(0)
+		expect(scanVocalTrack(events).phrases105).toEqual([])
 	})
 })
 
@@ -500,25 +493,29 @@ describe('extractMidiVocalPhrases', () => {
 // Edge cases: dedup and whitespace
 // ---------------------------------------------------------------------------
 
-describe('extractMidiLyrics edge cases', () => {
+describe('scanVocalTrack edge cases', () => {
 	it('deduplicates lyrics at same tick with same text', () => {
 		const events = [
 			{ deltaTime: 480, type: 'lyrics' as const, text: '+' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: '+' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(1)
 	})
 
-	it('filters tick-0 text event that duplicates track name', () => {
+	it('does NOT filter tick-0 text events that duplicate the track name (caller responsibility)', () => {
+		// scanVocalTrack doesn't take a track name parameter — the
+		// duplicate filter lives in midi-parser.scanInstrumentTrack instead.
+		// Verify that the classifier returns both lyrics; the integration filter
+		// is covered by per-track-data.test.ts.
 		const events = [
 			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 0, type: 'text' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'Hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
-		expect(lyrics).toHaveLength(1)
-		expect(lyrics[0].text).toBe('Hello')
+		const lyrics = scanVocalTrack(events).lyrics
+		expect(lyrics).toHaveLength(2)
+		expect(lyrics.map(l => l.text)).toEqual(['PART VOCALS', 'Hello'])
 	})
 
 	it('keeps tick-0 text event if it does NOT match track name', () => {
@@ -527,7 +524,7 @@ describe('extractMidiLyrics edge cases', () => {
 			{ deltaTime: 0, type: 'text' as const, text: 'intro' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'Hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('intro')
 	})
@@ -538,7 +535,7 @@ describe('extractMidiLyrics edge cases', () => {
 			{ deltaTime: 0, type: 'lyrics' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'Hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 	})
 
@@ -548,17 +545,18 @@ describe('extractMidiLyrics edge cases', () => {
 			{ deltaTime: 480, type: 'text' as const, text: 'PART VOCALS' },
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'Hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('PART VOCALS')
 	})
 
 	it('keeps empty lyrics (YARG stores as "lyric ")', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: '' },
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('')
 		expect(lyrics[1].text).toBe('hello')
@@ -566,10 +564,11 @@ describe('extractMidiLyrics edge cases', () => {
 
 	it('keeps space-only lyrics (preserves original)', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: ' ' },
 			{ deltaTime: 960, type: 'lyrics' as const, text: 'hello' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe(' ')
 		expect(lyrics[1].text).toBe('hello')
@@ -577,34 +576,38 @@ describe('extractMidiLyrics edge cases', () => {
 
 	it('keeps lyrics at same tick with different text', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'a' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'b' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(2)
 	})
 
 	it('preserves trailing spaces in lyric text', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'hello ' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics[0].text).toBe('hello ')
 	})
 
 	it('preserves leading spaces in lyric text', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: ' hey^' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics[0].text).toBe(' hey^')
 	})
 
 	it('preserves internal spaces in lyric text', () => {
 		const events = [
+			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'hello world' },
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics[0].text).toBe('hello world')
 	})
 })
@@ -815,13 +818,13 @@ describe('MIDI text encoding: Latin-1 fallback', () => {
 		expect((lyricEvent ).text).toBe('një')
 	})
 
-	it('Latin-1 lyrics pass through extractMidiLyrics correctly', () => {
+	it('Latin-1 lyrics pass through scanVocalTrack correctly', () => {
 		// Simulate what happens after midi-file decodes Latin-1 text
 		const events = [
 			{ deltaTime: 0, type: 'trackName' as const, text: 'PART VOCALS' },
 			{ deltaTime: 480, type: 'lyrics' as const, text: 'Só' }, // Latin-1 decoded
 		]
-		const lyrics = extractMidiLyrics(events )
+		const lyrics = scanVocalTrack(events).lyrics
 		expect(lyrics).toHaveLength(1)
 		expect(lyrics[0].text).toBe('Só')
 	})
@@ -836,10 +839,10 @@ describe('MIDI text encoding: Latin-1 fallback', () => {
 })
 
 // ---------------------------------------------------------------------------
-// extractMidiVocalNotes
+// scanVocalTrack — notes (pitched / percussion)
 // ---------------------------------------------------------------------------
 
-describe('extractMidiVocalNotes', () => {
+describe('scanVocalTrack (notes)', () => {
 	it('extracts pitched notes (36-84)', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
@@ -847,7 +850,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 960, type: 'noteOn' as const, noteNumber: 72, velocity: 100 },
 			{ deltaTime: 1200, type: 'noteOff' as const, noteNumber: 72, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(2)
 		expect(notes[0]).toEqual({ tick: 480, length: 240, pitch: 60, type: 'pitched' })
 		expect(notes[1]).toEqual({ tick: 960, length: 240, pitch: 72, type: 'pitched' })
@@ -858,7 +861,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 96, velocity: 100 },
 			{ deltaTime: 720, type: 'noteOff' as const, noteNumber: 96, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(1)
 		expect(notes[0]).toEqual({ tick: 480, length: 240, pitch: 96, type: 'percussion' })
 	})
@@ -868,7 +871,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 97, velocity: 100 },
 			{ deltaTime: 720, type: 'noteOff' as const, noteNumber: 97, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(1)
 		expect(notes[0]).toEqual({ tick: 480, length: 240, pitch: 97, type: 'percussionHidden' })
 	})
@@ -882,7 +885,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 1440, type: 'noteOn' as const, noteNumber: 105, velocity: 100 },
 			{ deltaTime: 1680, type: 'noteOff' as const, noteNumber: 105, velocity: 0 },
 		]
-		expect(extractMidiVocalNotes(events)).toHaveLength(0)
+		expect(scanVocalTrack(events).notes).toHaveLength(0)
 	})
 
 	it('handles velocity-0 noteOn as noteOff', () => {
@@ -890,7 +893,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 720, type: 'noteOn' as const, noteNumber: 60, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(1)
 		expect(notes[0]).toEqual({ tick: 480, length: 240, pitch: 60, type: 'pitched' })
 	})
@@ -904,7 +907,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 720, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(2)
 		expect(notes[0]).toEqual({ tick: 480, length: 200, pitch: 60, type: 'pitched' })
 		expect(notes[1]).toEqual({ tick: 720, length: 240, pitch: 60, type: 'pitched' })
@@ -925,7 +928,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 960, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 1200, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		// Should produce 2 notes: 480-680 and 960-1200
 		// (zero-length noteOn at 680 is duplicate → ignored; noteOff at 680 closes note at 480)
 		expect(notes).toHaveLength(2)
@@ -941,7 +944,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 720, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 60, velocity: 100 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(2)
 	})
 
@@ -952,7 +955,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 720, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
 			{ deltaTime: 720, type: 'noteOff' as const, noteNumber: 96, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(2)
 	})
 
@@ -963,7 +966,7 @@ describe('extractMidiVocalNotes', () => {
 			{ deltaTime: 960, type: 'noteOn' as const, noteNumber: 84, velocity: 100 },
 			{ deltaTime: 1200, type: 'noteOff' as const, noteNumber: 84, velocity: 0 },
 		]
-		const notes = extractMidiVocalNotes(events)
+		const notes = scanVocalTrack(events).notes
 		expect(notes).toHaveLength(2)
 		expect(notes[0].type).toBe('pitched')
 		expect(notes[1].type).toBe('pitched')
@@ -971,16 +974,16 @@ describe('extractMidiVocalNotes', () => {
 })
 
 // ---------------------------------------------------------------------------
-// extractMidiVocalStarPower
+// scanVocalTrack — starPower
 // ---------------------------------------------------------------------------
 
-describe('extractMidiVocalStarPower', () => {
+describe('scanVocalTrack (starPower)', () => {
 	it('extracts star power from note 116', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 116, velocity: 100 },
 			{ deltaTime: 1440, type: 'noteOff' as const, noteNumber: 116, velocity: 0 },
 		]
-		const sp = extractMidiVocalStarPower(events)
+		const sp = scanVocalTrack(events).starPower
 		expect(sp).toHaveLength(1)
 		expect(sp[0]).toMatchObject({ tick: 480, length: 960 })
 	})
@@ -992,7 +995,7 @@ describe('extractMidiVocalStarPower', () => {
 			{ deltaTime: 1920, type: 'noteOn' as const, noteNumber: 116, velocity: 100 },
 			{ deltaTime: 2880, type: 'noteOff' as const, noteNumber: 116, velocity: 0 },
 		]
-		const sp = extractMidiVocalStarPower(events)
+		const sp = scanVocalTrack(events).starPower
 		expect(sp).toHaveLength(2)
 	})
 
@@ -1001,21 +1004,21 @@ describe('extractMidiVocalStarPower', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 60, velocity: 100 },
 			{ deltaTime: 720, type: 'noteOff' as const, noteNumber: 60, velocity: 0 },
 		]
-		expect(extractMidiVocalStarPower(events)).toHaveLength(0)
+		expect(scanVocalTrack(events).starPower).toHaveLength(0)
 	})
 })
 
 // ---------------------------------------------------------------------------
-// extractMidiRangeShifts / extractMidiLyricShifts
+// scanVocalTrack — rangeShifts / lyricShifts
 // ---------------------------------------------------------------------------
 
-describe('extractMidiRangeShifts', () => {
+describe('scanVocalTrack (rangeShifts)', () => {
 	it('extracts range shift from note 0', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 0, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 0, velocity: 0 },
 		]
-		const shifts = extractMidiRangeShifts(events)
+		const shifts = scanVocalTrack(events).rangeShifts
 		expect(shifts).toHaveLength(1)
 		expect(shifts[0]).toMatchObject({ tick: 480, length: 480 })
 	})
@@ -1025,17 +1028,17 @@ describe('extractMidiRangeShifts', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 1, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 1, velocity: 0 },
 		]
-		expect(extractMidiRangeShifts(events)).toHaveLength(0)
+		expect(scanVocalTrack(events).rangeShifts).toHaveLength(0)
 	})
 })
 
-describe('extractMidiLyricShifts', () => {
+describe('scanVocalTrack (lyricShifts)', () => {
 	it('extracts lyric shift from note 1', () => {
 		const events = [
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 1, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 1, velocity: 0 },
 		]
-		const shifts = extractMidiLyricShifts(events)
+		const shifts = scanVocalTrack(events).lyricShifts
 		expect(shifts).toHaveLength(1)
 		expect(shifts[0]).toMatchObject({ tick: 480, length: 480 })
 	})
@@ -1045,7 +1048,7 @@ describe('extractMidiLyricShifts', () => {
 			{ deltaTime: 480, type: 'noteOn' as const, noteNumber: 0, velocity: 100 },
 			{ deltaTime: 960, type: 'noteOff' as const, noteNumber: 0, velocity: 0 },
 		]
-		expect(extractMidiLyricShifts(events)).toHaveLength(0)
+		expect(scanVocalTrack(events).lyricShifts).toHaveLength(0)
 	})
 })
 

--- a/src/__tests__/vocal-tracks.test.ts
+++ b/src/__tests__/vocal-tracks.test.ts
@@ -44,7 +44,10 @@ type TimedEvent = { absTick: number; event: MidiData['tracks'][number][number] }
 function vocalTrack(name: string, opts: {
 	notes?: { tick: number; pitch: number; length: number }[]
 	lyrics?: { tick: number; text: string }[]
+	/** Note 105 phrases (scoring phrases). */
 	phrases?: { tick: number; length: number }[]
+	/** Note 106 phrases (static lyric phrases / versus player 2). */
+	phrases106?: { tick: number; length: number }[]
 }): MidiData['tracks'][number] {
 	const track: MidiData['tracks'][number] = [
 		{ deltaTime: 0, type: 'trackName', text: name },
@@ -78,6 +81,17 @@ function vocalTrack(name: string, opts: {
 		timedEvents.push({
 			absTick: p.tick + p.length,
 			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 105, velocity: 0 },
+		})
+	}
+
+	for (const p of opts.phrases106 ?? []) {
+		timedEvents.push({
+			absTick: p.tick,
+			event: { deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 106, velocity: 100 },
+		})
+		timedEvents.push({
+			absTick: p.tick + p.length,
+			event: { deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 106, velocity: 0 },
 		})
 	}
 
@@ -602,7 +616,7 @@ describe('normalizedVocalTracks', () => {
 		expect(result.vocalTracks.parts.vocals.notePhrases[0].notes[0].pitch).toBe(62)
 	})
 
-	it('strips lyric symbols and sets flags', () => {
+	it('preserves lyric symbols in text and derives flags', () => {
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -621,15 +635,15 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
-		expect(lyrics[0].text).toBe('Cha')
+		expect(lyrics[0].text).toBe('Cha#')
 		expect(lyrics[0].flags).toBe(lyricFlags.nonPitched)
-		expect(lyrics[1].text).toBe('hid-')
+		expect(lyrics[1].text).toBe('$hid-')
 		expect(lyrics[1].flags).toBe(lyricFlags.harmonyHidden | lyricFlags.joinWithNext)
 	})
 
-	it('.chart vocals produce 0 notePhrases (no vocal notes in .chart format)', () => {
+	it('.chart vocals keep phrases with lyrics (no vocal notes in .chart format)', () => {
 		// .chart format has lyrics and phrase markers but no vocal notes (MIDI-only).
-		// Matching YARG behavior: phrases with no notes are skipped.
+		// Phrases are kept so all lyrics are accessible through phrase grouping.
 		const chart = buildChart({
 			Song: ['Resolution = 480'],
 			SyncTrack: ['0 = B 120000'],
@@ -643,7 +657,11 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(chart, 'chart')
 		const vocals = result.vocalTracks.parts.vocals
-		expect(vocals.notePhrases).toHaveLength(0)
+		expect(vocals.notePhrases).toHaveLength(1)
+		expect(vocals.notePhrases[0].lyrics).toHaveLength(2)
+		expect(vocals.notePhrases[0].lyrics[0].text).toBe('Hello')
+		expect(vocals.notePhrases[0].lyrics[1].text).toBe('World')
+		expect(vocals.notePhrases[0].notes).toHaveLength(0)
 	})
 
 	it('preserves star power sections as separate array', () => {
@@ -730,15 +748,16 @@ describe('normalizedVocalTracks', () => {
 		expect(phrase.lyrics[0].msTime).toBeGreaterThan(0)
 	})
 
-	it('skips empty lyrics after symbol stripping (e.g. standalone "+")', () => {
-		// YARG's ProcessLyric: if IsNullOrWhiteSpace(strippedLyric) → skip
+	it('pitch slide with filtered "+" keeps the note for round-trip consistency', () => {
+		// When "+" strips to empty and is filtered, the pitch slide note is NOT
+		// skipped — on re-parse "+" wouldn't exist, so consistency requires keeping it.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
 					{ tick: 480, text: 'me' },
-					{ tick: 720, text: '+' },  // stripped to "", should be skipped
+					{ tick: 720, text: '+' },  // stripped to "" → filtered → note NOT skipped
 					{ tick: 960, text: 'too' },
 				],
 				notes: [
@@ -752,13 +771,18 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
+		// "+" stripped to empty → filtered. Pitch slide note NOT skipped.
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('me')
 		expect(lyrics[1].text).toBe('too')
+		// All 3 notes kept (pitch slide at 720 not skipped because "+" was filtered)
+		const notes = result.vocalTracks.parts.vocals.notePhrases[0].notes
+		expect(notes).toHaveLength(3)
 	})
 
-	it('applies nonPitched flag to set note pitch to -1', () => {
-		// Real pattern: lyrics with '#' or '^' suffix mark non-pitched notes
+	it('nonPitched flag keeps original MIDI pitch (consumers check lyric flags)', () => {
+		// NonPitched notes (lyric with '#' suffix) keep their original MIDI pitch
+		// for lossless round-trip. Consumers check lyric flags for nonPitched status.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -771,7 +795,8 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const note = result.vocalTracks.parts.vocals.notePhrases[0].notes[0]
-		expect(note.pitch).toBe(-1)  // nonPitched flag → pitch = -1
+		expect(note.pitch).toBe(60)  // keeps original MIDI pitch
+		expect(note.type).toBe('pitched')
 	})
 
 	it('excludes percussionHidden (note 97) from normalized notes', () => {
@@ -797,21 +822,22 @@ describe('normalizedVocalTracks', () => {
 		expect(notes[1].type).toBe('percussion')
 	})
 
-	it('pitch slide note is skipped (merged into previous)', () => {
-		// Real pattern: lyric "+" means the next note slides from previous.
-		// YARG merges it as a child note — we skip it entirely in the flat list.
+	it('pitch slide note is skipped when lyric survives filtering', () => {
+		// When the pitchSlide lyric has displayable text (e.g. "oh+"), it survives
+		// the emptiness filter → the pitch slide note IS skipped for round-trip
+		// consistency (the lyric will exist on re-parse too).
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
 					{ tick: 480, text: 'oh' },
-					{ tick: 720, text: '+' },   // pitch slide → note at 720 is skipped
+					{ tick: 720, text: 'slide+' },  // pitchSlide with displayable text → survives filter
 					{ tick: 960, text: 'yeah' },
 				],
 				notes: [
 					{ tick: 480, pitch: 60, length: 240 },
-					{ tick: 720, pitch: 62, length: 240 },  // this is the slide target
+					{ tick: 720, pitch: 62, length: 240 },  // pitch slide target → skipped
 					{ tick: 960, pitch: 64, length: 240 },
 				],
 				phrases: [{ tick: 480, length: 720 }],
@@ -825,8 +851,9 @@ describe('normalizedVocalTracks', () => {
 		expect(notes[1].tick).toBe(960)
 	})
 
-	it('skips phrases with no notes (matching YARG behavior)', () => {
-		// Real pattern: HARM1 has phrases for all parts; phrases with no notes are skipped.
+	it('keeps phrases without notes (lyrics stay in their phrase)', () => {
+		// All phrases are kept — even without notes — so that all content is
+		// accessible through phrase grouping and writers can round-trip boundaries.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
@@ -834,15 +861,23 @@ describe('normalizedVocalTracks', () => {
 				lyrics: [{ tick: 480, text: 'hey' }, { tick: 1920, text: 'yo' }],
 				notes: [{ tick: 1920, pitch: 60, length: 240 }],  // only in second phrase
 				phrases: [
-					{ tick: 480, length: 480 },   // empty — skipped
-					{ tick: 1920, length: 480 },  // has note — kept
+					{ tick: 480, length: 480 },   // no notes, but has lyrics
+					{ tick: 1920, length: 480 },  // has note + lyric
 				],
 			}),
 		])
 
 		const result = parseChartFile(midi, 'mid')
-		expect(result.vocalTracks.parts.vocals.notePhrases).toHaveLength(1)
-		expect(result.vocalTracks.parts.vocals.notePhrases[0].tick).toBe(1920)
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+		expect(phrases[0].tick).toBe(480)
+		expect(phrases[0].notes).toHaveLength(0)
+		expect(phrases[0].lyrics).toHaveLength(1)
+		expect(phrases[0].lyrics[0].text).toBe('hey')
+		expect(phrases[1].tick).toBe(1920)
+		expect(phrases[1].notes).toHaveLength(1)
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('yo')
 	})
 
 	it('deduplicates phrases at same tick (note 105 + 106)', () => {
@@ -887,7 +922,7 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
-		// "sto" becomes "sto-" with JoinWithNext, "+-" becomes "+" which is empty → skipped
+		// "sto" becomes "sto-" with JoinWithNext, "+-" becomes "+" which is filtered
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('sto-')
 		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
@@ -944,7 +979,7 @@ describe('normalizedVocalTracks', () => {
 		const lyrics = result.vocalTracks.parts.vocals.notePhrases[0].lyrics
 		// After sorting: "+-" comes before "re" at tick 720.
 		// DeferredLyricJoinWorkaround triggers on "+-": modifies "mo" → "mo-".
-		// Then "re" is processed normally with flags=None.
+		// "+-" becomes "+" which is filtered. "re" processed normally.
 		expect(lyrics).toHaveLength(2)
 		expect(lyrics[0].text).toBe('mo-')
 		expect(lyrics[0].flags & lyricFlags.joinWithNext).toBeTruthy()
@@ -966,7 +1001,7 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const lyric = result.vocalTracks.parts.vocals.notePhrases[0].lyrics[0]
-		expect(lyric.text).toBe('uh')
+		expect(lyric.text).toBe('uh#$')
 		expect(lyric.flags & lyricFlags.harmonyHidden).toBeTruthy()
 		expect(lyric.flags & lyricFlags.nonPitched).toBeTruthy()
 	})
@@ -1013,11 +1048,12 @@ describe('normalizedVocalTracks', () => {
 
 		const result = parseChartFile(midi, 'mid')
 		const phrase = result.vocalTracks.parts.vocals.notePhrases[0]
-		// Note at 720 should be skipped (pitch slide from trimmed "+ ")
-		expect(phrase.notes).toHaveLength(2)
+		// Lyric "+ " trimmed to "+" → stripped to empty → filtered.
+		// Pitch slide note at 720 NOT skipped (filtered lyric → no round-trip marker).
+		expect(phrase.notes).toHaveLength(3)
 		expect(phrase.notes[0].tick).toBe(480)
-		expect(phrase.notes[1].tick).toBe(960)
-		// Lyric "+ " should be stripped to empty and skipped
+		expect(phrase.notes[1].tick).toBe(720)
+		expect(phrase.notes[2].tick).toBe(960)
 		expect(phrase.lyrics).toHaveLength(2)
 		expect(phrase.lyrics[0].text).toBe('mo-')
 		expect(phrase.lyrics[1].text).toBe('bile')
@@ -1072,38 +1108,128 @@ describe('normalizedVocalTracks', () => {
 		const result = parseChartFile(midi, 'mid')
 		const phrases = result.vocalTracks.parts.vocals.notePhrases
 		expect(phrases).toHaveLength(2)
-		// Phrase 2: note at 1440 is pitch slide, attached to phrase 1's note via previousParentLyric
-		expect(phrases[1].notes).toHaveLength(1)
-		expect(phrases[1].notes[0].tick).toBe(1920)
+		// Phrase 2: "+" is filtered → pitch slide note at 1440 is NOT skipped
+		// (ensures round-trip consistency — "+" won't exist on re-parse either)
+		expect(phrases[1].notes).toHaveLength(2)
+		expect(phrases[1].notes[0].tick).toBe(1440)
+		expect(phrases[1].notes[1].tick).toBe(1920)
 	})
 
-	it('carries lyrics from skipped phrases to next phrase (shared lyricIdx)', () => {
-		// Real case: "30 Seconds to Mars - Attack" has lyrics in a phrase with no notes.
-		// YARG's shared moonTextIndex carries those lyrics to the next phrase's first note.
+	it('lyrics stay in their phrase even when phrase has no notes', () => {
+		// All phrases are kept. Lyrics remain in their phrase — the phrase
+		// exists as a boundary even without notes. Writers iterate all phrases.
 		const midi = buildMidi(480, [
 			tempoTrack(),
 			eventsTrack(),
 			vocalTrack('PART VOCALS', {
 				lyrics: [
-					{ tick: 480, text: 'Whoa' },   // in skipped phrase (no notes)
-					{ tick: 1920, text: 'I' },      // in kept phrase
+					{ tick: 480, text: 'Whoa' },   // in first phrase (no notes)
+					{ tick: 1920, text: 'I' },      // in second phrase
 				],
 				notes: [
 					{ tick: 1920, pitch: 60, length: 240 },
 				],
 				phrases: [
-					{ tick: 480, length: 480 },   // skipped (no notes)
-					{ tick: 1920, length: 480 },  // kept
+					{ tick: 480, length: 480 },   // no notes, has lyric
+					{ tick: 1920, length: 480 },  // has note + lyric
 				],
 			}),
 		])
 
 		const result = parseChartFile(midi, 'mid')
 		const phrases = result.vocalTracks.parts.vocals.notePhrases
-		expect(phrases).toHaveLength(1)
-		// Both lyrics should be in the kept phrase
-		expect(phrases[0].lyrics).toHaveLength(2)
+		expect(phrases).toHaveLength(2)
+		expect(phrases[0].lyrics).toHaveLength(1)
 		expect(phrases[0].lyrics[0].text).toBe('Whoa')
-		expect(phrases[0].lyrics[1].text).toBe('I')
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('I')
+	})
+
+	it('note 106 phrases create player 2 phrases on PART VOCALS (Dani California pattern)', () => {
+		// Test A: note 106 phrase before first note 105 phrase.
+		// Both 105 and 106 create phrases; merged set tagged with player.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 100, text: 'Hel-' },
+					{ tick: 500, text: 'lo' },
+				],
+				notes: [
+					{ tick: 100, pitch: 60, length: 100 },
+					{ tick: 500, pitch: 62, length: 100 },
+				],
+				phrases106: [{ tick: 0, length: 480 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+
+		// First phrase (from note 106) — player 2
+		expect(phrases[0].tick).toBe(0)
+		expect(phrases[0].player).toBe(2)
+		expect(phrases[0].notes).toHaveLength(1)
+		expect(phrases[0].notes[0].tick).toBe(100)
+		expect(phrases[0].lyrics).toHaveLength(1)
+		expect(phrases[0].lyrics[0].text).toBe('Hel-')
+
+		// Second phrase (from note 105) — player 1
+		expect(phrases[1].tick).toBe(480)
+		expect(phrases[1].player).toBe(1)
+		expect(phrases[1].notes).toHaveLength(1)
+		expect(phrases[1].notes[0].tick).toBe(500)
+		expect(phrases[1].lyrics).toHaveLength(1)
+		expect(phrases[1].lyrics[0].text).toBe('lo')
+	})
+
+	it('absorbs orphaned lyrics before first phrase into that phrase', () => {
+		// Test D: lyrics before the first phrase are absorbed into it.
+		// Notes before all phrases are dropped.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 100, text: 'orphan' },  // before all phrases
+					{ tick: 500, text: 'inside' },   // inside phrase
+				],
+				notes: [
+					{ tick: 100, pitch: 60, length: 50 },  // before phrase — dropped
+					{ tick: 500, pitch: 62, length: 100 }, // inside phrase — kept
+				],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(1)
+		// Note at tick 100 is dropped (outside all phrases)
+		expect(phrases[0].notes).toHaveLength(1)
+		expect(phrases[0].notes[0].tick).toBe(500)
+		// Orphaned lyric at tick 100 is absorbed into the phrase
+		expect(phrases[0].lyrics).toHaveLength(2)
+		expect(phrases[0].lyrics[0].text).toBe('orphan')
+		expect(phrases[0].lyrics[1].text).toBe('inside')
+	})
+
+	it('harmony phrases have no player field', () => {
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('HARM1', {
+				lyrics: [{ tick: 480, text: 'hey' }],
+				notes: [{ tick: 480, pitch: 60, length: 240 }],
+				phrases: [{ tick: 480, length: 480 }],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrase = result.vocalTracks.parts.harmony1.notePhrases[0]
+		expect(phrase.player).toBeUndefined()
 	})
 })

--- a/src/__tests__/vocal-tracks.test.ts
+++ b/src/__tests__/vocal-tracks.test.ts
@@ -1217,6 +1217,84 @@ describe('normalizedVocalTracks', () => {
 		expect(phrases[0].lyrics[1].text).toBe('inside')
 	})
 
+	it('lyric at exact tick of an adjacent phrase boundary belongs to the new phrase', () => {
+		// Phrase 1 ends at tick 960, phrase 2 starts at tick 960. The lyric at
+		// tick 960 should belong to phrase 2 (the one starting there), not the
+		// previous phrase. The vocalTrack helper sorts events by tick — at the
+		// same tick, lyric events are pushed before phrase events (insertion
+		// order), so the lyric appears FIRST in the file. The grouping logic
+		// must still place the lyric in the new phrase, not the closing one.
+		const midi = buildMidi(480, [
+			tempoTrack(),
+			eventsTrack(),
+			vocalTrack('PART VOCALS', {
+				lyrics: [
+					{ tick: 480, text: 'phrase1lyric' }, // in phrase 1
+					{ tick: 960, text: 'boundary' },     // exactly at phrase 1 end / phrase 2 start
+					{ tick: 1200, text: 'phrase2lyric' },
+				],
+				notes: [
+					{ tick: 480, pitch: 60, length: 240 },
+					{ tick: 960, pitch: 62, length: 240 },
+					{ tick: 1200, pitch: 64, length: 240 },
+				],
+				phrases: [
+					{ tick: 480, length: 480 },   // [480, 960)
+					{ tick: 960, length: 480 },   // [960, 1440)
+				],
+			}),
+		])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+
+		// Phrase 1 [480, 960): only "phrase1lyric"
+		expect(phrases[0].tick).toBe(480)
+		expect(phrases[0].lyrics.map(l => l.text)).toEqual(['phrase1lyric'])
+
+		// Phrase 2 [960, 1440): "boundary" + "phrase2lyric"
+		expect(phrases[1].tick).toBe(960)
+		expect(phrases[1].lyrics.map(l => l.text)).toEqual(['boundary', 'phrase2lyric'])
+	})
+
+	it('lyric at boundary tick stays in new phrase regardless of MIDI event ordering', () => {
+		// Same edge case as above, but explicitly construct the MIDI with the
+		// lyric event placed BEFORE the noteOff (phrase 1 end) and the noteOn
+		// (phrase 2 start) at the boundary tick — i.e., file order is
+		// `lyric → noteOff(105) → noteOn(105)` at tick 960. The parser sorts by
+		// tick + type before grouping, so file order shouldn't change which
+		// phrase the lyric ends up in.
+		const track: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'PART VOCALS' },
+			// Phrase 1 starts at 480
+			{ deltaTime: 480, type: 'noteOn', channel: 0, noteNumber: 105, velocity: 100 },
+			// Lyric in phrase 1
+			{ deltaTime: 0, type: 'lyrics', text: 'phrase1lyric' },
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 60, velocity: 100 },
+			{ deltaTime: 240, type: 'noteOff', channel: 0, noteNumber: 60, velocity: 0 },
+			// Boundary tick: lyric BEFORE noteOff(105) AND noteOn(105)
+			{ deltaTime: 240, type: 'lyrics', text: 'boundary' },
+			{ deltaTime: 0, type: 'noteOff', channel: 0, noteNumber: 105, velocity: 0 },
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 105, velocity: 100 },
+			{ deltaTime: 0, type: 'noteOn', channel: 0, noteNumber: 62, velocity: 100 },
+			{ deltaTime: 240, type: 'noteOff', channel: 0, noteNumber: 62, velocity: 0 },
+			{ deltaTime: 240, type: 'noteOff', channel: 0, noteNumber: 105, velocity: 0 },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+		const midi = buildMidi(480, [tempoTrack(), eventsTrack(), track])
+
+		const result = parseChartFile(midi, 'mid')
+		const phrases = result.vocalTracks.parts.vocals.notePhrases
+		expect(phrases).toHaveLength(2)
+		expect(phrases[0].tick).toBe(480)
+		expect(phrases[0].lyrics.map(l => l.text)).toEqual(['phrase1lyric'])
+		expect(phrases[1].tick).toBe(960)
+		// "boundary" lyric must be in phrase 2 even though it appears before
+		// the phrase-2 noteOn in file order.
+		expect(phrases[1].lyrics.map(l => l.text)).toEqual(['boundary'])
+	})
+
 	it('harmony phrases have no player field', () => {
 		const midi = buildMidi(480, [
 			tempoTrack(),

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -126,6 +126,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				rangeShifts: [],
 				lyricShifts: [],
 				staticLyricPhrases: [],
+				textEvents: [],
 			},
 		},
 		tempos: _.chain(fileSections['SyncTrack'])

--- a/src/chart/lyric-parser.ts
+++ b/src/chart/lyric-parser.ts
@@ -79,6 +79,9 @@ export function extractChartLyrics(eventLines: string[]): { tick: number; length
 
 /**
  * Extract vocal phrase boundaries from .chart [Events] phrase_start/phrase_end pairs.
+ * Returns normal paired phrases. Orphan phrase_end events (no preceding
+ * phrase_start) are NOT included here; use `extractChartOrphanPhraseEnds` to
+ * retrieve them separately.
  */
 export function extractChartVocalPhrases(eventLines: string[]): { tick: number; length: number }[] {
 	const phrases: { tick: number; length: number }[] = []
@@ -94,17 +97,44 @@ export function extractChartVocalPhrases(eventLines: string[]): { tick: number; 
 			}
 			currentStart = result.tick
 		} else {
-			// If no phrase_start is open, treat as starting from tick 0.
-			// Orphaned phrase_ends are kept so editors can surface them for manual fixing.
-			if (currentStart === null) {
-				currentStart = 0
+			// phrase_end: only push if a phrase_start is open. Orphan phrase_ends
+			// (no preceding phrase_start) are skipped here — a synthetic (0, endTick)
+			// phrase would corrupt lyric grouping by "stealing" lyrics from earlier
+			// real phrases via the shared lyricIdx. Orphans are preserved via
+			// `extractChartOrphanPhraseEnds` so writers can re-emit them verbatim.
+			if (currentStart !== null) {
+				phrases.push({ tick: currentStart, length: result.tick - currentStart })
+				currentStart = null
 			}
-			phrases.push({ tick: currentStart, length: result.tick - currentStart })
-			currentStart = null
 		}
 	}
 
 	return phrases
+}
+
+/**
+ * Extract orphan `phrase_end` events from .chart [Events] — a `phrase_end`
+ * whose most recent predecessor is NOT a matching `phrase_start`. These are
+ * malformed but exist in some charts; YARG preserves them as text events in
+ * its globalEvents output, so we keep them here for round-trip fidelity.
+ */
+export function extractChartOrphanPhraseEnds(eventLines: string[]): { tick: number }[] {
+	const orphans: { tick: number }[] = []
+	let currentStart: number | null = null
+	for (const line of eventLines) {
+		const result = parseChartVocalPhraseLine(line)
+		if (!result) continue
+		if (result.type === 'start') {
+			currentStart = result.tick
+		} else {
+			if (currentStart === null) {
+				orphans.push({ tick: result.tick })
+			} else {
+				currentStart = null
+			}
+		}
+	}
+	return orphans
 }
 
 // ---------------------------------------------------------------------------
@@ -178,110 +208,6 @@ export function extractMidiLyricText(event: MidiTextLikeEvent): string {
 	return event.text ?? ''
 }
 
-/**
- * Extract all lyrics from a PART VOCALS MIDI track's events.
- * Events must already be in absolute time (deltaTime = absolute tick).
- * Deduplicates by tick+text (matching MoonSong InsertionEquals).
- */
-export function extractMidiLyrics(trackEvents: MidiLyricEvent[]): { tick: number; length: number; text: string }[] {
-	// Find the track name so we can skip tick-0 text events that duplicate it.
-	// Some MIDI files have an FF 01 text event "PART VOCALS" at tick 0 which is
-	// a duplicate of the FF 03 trackName — not a real lyric. YARG keeps these
-	// (a YARG bug), but we filter them out.
-	const trackNameEvent = trackEvents.find(e => e.type === 'trackName')
-	const trackName = trackNameEvent?.text
-
-	const lyrics: { tick: number; length: number; text: string }[] = []
-	const seen = new Set<string>()
-	for (const event of trackEvents) {
-		if (isMidiVocalLyric(event)) {
-			const text = extractMidiLyricText(event)
-			// Skip tick-0 text events that match the track name (instrumentName duplicate)
-			if (event.deltaTime === 0 && text === trackName && event.type === 'text') continue
-			const key = `${event.deltaTime}:${text}`
-			if (seen.has(key)) continue
-			seen.add(key)
-			lyrics.push({ tick: event.deltaTime, length: 0, text })
-		}
-	}
-	return lyrics
-}
-
-// ---------------------------------------------------------------------------
-// Generic MIDI note-on/note-off pair extraction
-// ---------------------------------------------------------------------------
-
-/**
- * Extract note-on/note-off pairs for the given MIDI note numbers. Processes
- * events in MIDI file order (sorted stably by tick), matching YARG.Core's
- * `MidReader.ProcessNoteEvent`: velocity-0 noteOn is treated as noteOff,
- * duplicate noteOn while a note is already open is ignored.
- *
- * MIDI file order correctly handles zero-length notes (noteOn + noteOff at the
- * same tick for the same pitch): the noteOn opens the note and the following
- * noteOff closes it immediately. Without preserving order, sorting noteOff
- * before noteOn at the same tick would steal the close from a later real note
- * (real example: "The Lumineers - Ho Hey" has a zero-length note 60 at tick
- * 49840 that would otherwise steal the noteOff at tick 55080 from the real
- * note at tick 54880).
- *
- * Events must already be in absolute time (deltaTime = absolute tick).
- */
-function extractMidiNotePairs(
-	trackEvents: MidiLyricEvent[],
-	noteFilter: (noteNumber: number) => boolean,
-): { tick: number; length: number; noteNumber: number }[] {
-	const noteEvents: { tick: number; type: 'noteOn' | 'noteOff'; noteNumber: number }[] = []
-	for (const event of trackEvents) {
-		if ((event.type === 'noteOn' || event.type === 'noteOff') && event.noteNumber !== undefined && noteFilter(event.noteNumber)) {
-			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
-			noteEvents.push({
-				tick: event.deltaTime,
-				type: isOff ? 'noteOff' : 'noteOn',
-				noteNumber: event.noteNumber,
-			})
-		}
-	}
-	// Stable sort by tick only, preserving MIDI file order at the same tick.
-	noteEvents.sort((a, b) => a.tick - b.tick)
-
-	const phraseStarts: Map<number, number> = new Map()
-	const results: { tick: number; length: number; noteNumber: number }[] = []
-
-	for (const event of noteEvents) {
-		if (event.type === 'noteOn') {
-			// YARG ignores duplicate noteOns — if a note is already open, skip.
-			if (phraseStarts.has(event.noteNumber)) continue
-			phraseStarts.set(event.noteNumber, event.tick)
-		} else {
-			const startTick = phraseStarts.get(event.noteNumber)
-			if (startTick !== undefined) {
-				results.push({ tick: startTick, length: event.tick - startTick, noteNumber: event.noteNumber })
-				phraseStarts.delete(event.noteNumber)
-			}
-		}
-	}
-
-	results.sort((a, b) => a.tick - b.tick)
-	return results
-}
-
-// ---------------------------------------------------------------------------
-// MIDI vocal phrase extraction
-// ---------------------------------------------------------------------------
-
-/**
- * Extract vocal phrase boundaries from MIDI notes 105/106 on PART VOCALS.
- * Events must already be in absolute time (deltaTime = absolute tick).
- */
-export function extractMidiVocalPhrases(trackEvents: MidiLyricEvent[]): { tick: number; length: number; noteNumber: number }[] {
-	return extractMidiNotePairs(trackEvents, n => n === 105 || n === 106)
-}
-
-// ---------------------------------------------------------------------------
-// MIDI vocal notes (pitch 36-84, percussion 96/97)
-// ---------------------------------------------------------------------------
-
 export type VocalNoteType = 'pitched' | 'percussion' | 'percussionHidden'
 
 export interface VocalNote {
@@ -298,48 +224,150 @@ function noteNumberToVocalType(noteNumber: number): VocalNoteType | null {
 	return null
 }
 
-/**
- * Extract vocal notes (pitched 36-84, percussion 96/97) from a MIDI vocal track.
- * Events must already be in absolute time (deltaTime = absolute tick).
- */
-export function extractMidiVocalNotes(trackEvents: MidiLyricEvent[]): VocalNote[] {
-	const pairs = extractMidiNotePairs(
-		trackEvents,
-		n => (n >= 36 && n <= 84) || n === 96 || n === 97,
-	)
-	return pairs.map(p => ({
-		tick: p.tick,
-		length: p.length,
-		pitch: p.noteNumber,
-		type: noteNumberToVocalType(p.noteNumber)!,
-	}))
+/** Full classification of a MIDI vocal track — populated by one pass. */
+export interface VocalTrackScanResult {
+	/** Non-control text-like events (deduped by tick+text). */
+	lyrics: { tick: number; length: number; text: string }[]
+	/** Bracketed text events YARG preserves as MoonText ([play], [idle], etc.). */
+	textEvents: { tick: number; text: string }[]
+	/** Scoring phrase boundaries from note 105. */
+	phrases105: { tick: number; length: number }[]
+	/** Static lyric / player-2 phrase boundaries from note 106. */
+	phrases106: { tick: number; length: number }[]
+	/** Vocal notes: pitched 36–84, percussion 96 (displayed), 97 (hidden). */
+	notes: VocalNote[]
+	/** Star power sections from note 116. */
+	starPower: { tick: number; length: number }[]
+	/** Range shift markers from note 0 (length = transition speed). */
+	rangeShifts: { tick: number; length: number }[]
+	/** Lyric shift markers from note 1 (for static lyric scrolling). */
+	lyricShifts: { tick: number; length: number }[]
 }
 
-// ---------------------------------------------------------------------------
-// MIDI vocal star power, range shifts, lyric shifts
-// ---------------------------------------------------------------------------
+/** Regex for disco flip markers (drum-track concept; skipped on vocal tracks). */
+const discoFlipRegex = /^\s*\[?mix[ _][0-3][ _]drums[0-5](d|dnoflip|easy|easynokick|)\]?\s*$/
 
 /**
- * Extract star power sections from note 116 on a MIDI vocal track.
+ * Single-pass classification of a MIDI vocal track.
+ *
+ * One loop walks `trackEvents` once, routing each event to the appropriate
+ * bucket:
+ *
+ * - **text-like events** (`lyrics`, `text`, `marker`, `cuePoint`) are split
+ *   between `lyrics` and `textEvents`. Events consumed elsewhere
+ *   (`ENHANCED_OPENS`, `ENABLE_CHART_DYNAMICS`, `[mix N drumsM]` disco flips,
+ *   `[range_shift ...]`) are dropped — they're not vocal content, just carried
+ *   on this track. Bracketed events go into `textEvents` (MoonText round-trip);
+ *   known control markers (`[play]`, `[idle]`, stance/percussion switches) are
+ *   **not** lyrics, but unknown bracketed text like `[Everyone liked that]` is
+ *   (YARG's ProcessLyric accepts it).
+ *
+ * - **note events** (`noteOn` / `noteOff`) are paired by `noteNumber` and
+ *   routed: 0 → rangeShifts, 1 → lyricShifts, 105 → phrases105, 106 →
+ *   phrases106, 116 → starPower, 36–84 / 96 / 97 → notes. Velocity-0 noteOn
+ *   counts as noteOff. Duplicate noteOn while a note is already open is
+ *   ignored (matches YARG's `MidReader.ProcessNoteEvent`).
+ *
+ * Requires tick-sorted input — `trackEvents` must already be in absolute time
+ * (deltaTime = absolute tick). MIDI files are monotonic after
+ * `convertToAbsoluteTime`, so this holds by construction.
+ *
+ * Track-name skip: YARG.Core's `MidReader.ReadNotes` starts iteration at
+ * `i = 1` to skip the conventional track-name event at index 0. Some MIDI
+ * files have a stray FF 01 text duplicate of the track name at index 0 —
+ * YARG silently drops it, so we skip text classification for index 0 too.
+ *
+ * Single-pitch buckets (0, 1, 105, 106, 116) emit pairs in start-tick order
+ * automatically because a noteNumber can't overlap itself. `notes` holds
+ * multiple pitches (e.g. 60 and 72 can overlap), so a small bucket-local sort
+ * by start tick reorders the `notes` output. "The Lumineers - Ho Hey" is the
+ * canonical test case: zero-length note 60 at tick 49840 must not steal the
+ * noteOff at 55080 from the real note at 54880 — preserved by the
+ * first-matching-noteOff rule.
  */
-export function extractMidiVocalStarPower(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
-	return extractMidiNotePairs(trackEvents, n => n === 116)
-}
+export function scanVocalTrack(trackEvents: MidiLyricEvent[]): VocalTrackScanResult {
+	const lyrics: VocalTrackScanResult['lyrics'] = []
+	const textEvents: VocalTrackScanResult['textEvents'] = []
+	const phrases105: VocalTrackScanResult['phrases105'] = []
+	const phrases106: VocalTrackScanResult['phrases106'] = []
+	const notes: VocalNote[] = []
+	const starPower: VocalTrackScanResult['starPower'] = []
+	const rangeShifts: VocalTrackScanResult['rangeShifts'] = []
+	const lyricShifts: VocalTrackScanResult['lyricShifts'] = []
 
-/**
- * Extract range shift markers from note 0 on a MIDI vocal track.
- * Length determines the shift speed (gradual transition).
- */
-export function extractMidiRangeShifts(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
-	return extractMidiNotePairs(trackEvents, n => n === 0)
-}
+	const seenLyrics = new Set<string>()
+	const openNotes = new Map<number, number>() // noteNumber → open tick
 
-/**
- * Extract lyric shift markers from note 1 on a MIDI vocal track.
- * Used for static lyric display scrolling within a phrase.
- */
-export function extractMidiLyricShifts(trackEvents: MidiLyricEvent[]): { tick: number; length: number }[] {
-	return extractMidiNotePairs(trackEvents, n => n === 1)
+	for (let i = 0; i < trackEvents.length; i++) {
+		const event = trackEvents[i]
+
+		// --- Note events (all buckets except lyrics/textEvents) ---
+		if (event.type === 'noteOn' || event.type === 'noteOff') {
+			const n = event.noteNumber
+			if (n === undefined) continue
+			const vocalType = noteNumberToVocalType(n)
+			const isRelevantNote = n === 0 || n === 1 || n === 105 || n === 106 || n === 116 || vocalType !== null
+			if (!isRelevantNote) continue
+
+			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+			if (!isOff) {
+				// YARG ignores duplicate noteOns — if already open, skip.
+				if (!openNotes.has(n)) openNotes.set(n, event.deltaTime)
+			} else {
+				const startTick = openNotes.get(n)
+				if (startTick === undefined) continue
+				openNotes.delete(n)
+				const length = event.deltaTime - startTick
+				switch (n) {
+					case 0:   rangeShifts.push({ tick: startTick, length }); break
+					case 1:   lyricShifts.push({ tick: startTick, length }); break
+					case 105: phrases105.push({ tick: startTick, length }); break
+					case 106: phrases106.push({ tick: startTick, length }); break
+					case 116: starPower.push({ tick: startTick, length }); break
+					default:
+						notes.push({ tick: startTick, length, pitch: n, type: vocalType! })
+				}
+			}
+			continue
+		}
+
+		// --- Text-like events (lyrics + textEvents). Skip index 0. ---
+		if (i === 0) continue
+		const isTextLike = event.type === 'lyrics' || event.type === 'text' ||
+			event.type === 'marker' || event.type === 'cuePoint'
+		if (!isTextLike) continue
+		const text = event.text
+		if (text === undefined || text === null) continue
+
+		// Events consumed elsewhere — drop from both buckets.
+		if (text === 'ENHANCED_OPENS' || text === '[ENHANCED_OPENS]') continue
+		if (text === 'ENABLE_CHART_DYNAMICS' || text === '[ENABLE_CHART_DYNAMICS]') continue
+		if (discoFlipRegex.test(text)) continue
+
+		const trimmed = text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
+		const isBracketed = trimmed.startsWith('[') && trimmed.endsWith(']')
+		if (isBracketed && trimmed.startsWith('[range_shift')) continue
+
+		// Bracketed events round-trip as MoonText textEvents. Known control
+		// markers are never lyrics; unknown bracketed text is also kept as a
+		// textEvent (YARG emits it via both the lyric and MoonText paths).
+		if (isBracketed) {
+			textEvents.push({ tick: event.deltaTime, text })
+		}
+
+		const isKnownControlEvent = isBracketed && knownVocalControlEvents.has(trimmed.slice(1, -1))
+		if (isKnownControlEvent) continue
+
+		const key = `${event.deltaTime}:${text}`
+		if (seenLyrics.has(key)) continue
+		seenLyrics.add(key)
+		lyrics.push({ tick: event.deltaTime, length: 0, text })
+	}
+
+	// Only `notes` can have overlapping pitches emitting out of start-tick order.
+	notes.sort((a, b) => a.tick - b.tick)
+
+	return { lyrics, textEvents, phrases105, phrases106, notes, starPower, rangeShifts, lyricShifts }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -3,7 +3,19 @@ import { MidiData, MidiEvent, MidiSetTempoEvent, MidiTextEvent, MidiTimeSignatur
 
 import { difficulties, Difficulty, getInstrumentType, Instrument, InstrumentType, instrumentTypes } from 'src/interfaces'
 import { EventType, eventTypes, IniChartModifiers, RawChartData, VocalTrackData } from './note-parsing-interfaces'
-import { extractMidiLyrics, extractMidiVocalPhrases, extractMidiVocalNotes, extractMidiVocalStarPower, extractMidiRangeShifts, extractMidiLyricShifts } from './lyric-parser'
+import { scanVocalTrack } from './lyric-parser'
+
+// Union two phrase lists, dedup by tick (keep longest length), sort by tick.
+function mergePhraseLists(a: { tick: number; length: number }[], b: { tick: number; length: number }[]): { tick: number; length: number }[] {
+	const byTick = new Map<number, number>()
+	for (const p of [...a, ...b]) {
+		const existing = byTick.get(p.tick)
+		if (existing === undefined || p.length > existing) byTick.set(p.tick, p.length)
+	}
+	return [...byTick.entries()]
+		.sort((x, y) => x[0] - y[0])
+		.map(([tick, length]) => ({ tick, length }))
+}
 
 type TrackName = (typeof trackNames)[number]
 type VocalTrackName = 'PART VOCALS' | 'HARM1' | 'HARM2' | 'HARM3' | 'PART HARM1' | 'PART HARM2' | 'PART HARM3'
@@ -55,6 +67,7 @@ const instrumentNameMap: { [key in InstrumentTrackName]: Instrument } = {
 } as const
 /* eslint-enable @typescript-eslint/naming-convention */
 
+
 const sysExDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 const discoFlipDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 const fiveFretDiffStarts = { easy: 59, medium: 71, hard: 83, expert: 95 }
@@ -72,7 +85,10 @@ interface TrackEventEnd {
 }
 
 // Necessary because .mid stores some additional modifiers and information using velocity
-type MidiTrackEvent = RawChartData['trackData'][number]['trackEvents'][number] & { velocity: number; channel: number }
+type MidiTrackEvent = RawChartData['trackData'][number]['trackEvents'][number] & {
+	velocity: number
+	channel: number
+}
 
 /**
  * Parses `buffer` as a chart in the .mid format. Returns all the note data in `RawChartData`, but any
@@ -107,41 +123,66 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 	convertToAbsoluteTime(midiFile)
 
 	const tracks = getTracks(midiFile)
+	const parseIssues: RawChartData['parseIssues'] = []
 
-	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3
+	// Build vocalTracks from PART VOCALS and HARM1/HARM2/HARM3.
+	// Separate note 105 (scoring phrases) from note 106 (static lyric / player-2
+	// display phrases) at extraction time. This lets the writer round-trip HARM2/HARM3
+	// without any pre-CopyDown stashing: HARM2/HARM3 emit staticLyricPhrases as
+	// note 106 on their own track, HARM1 emits vocalPhrases as note 105, and CopyDown
+	// on re-parse re-copies HARM1's vocalPhrases to HARM2/HARM3 — identical result.
 	const vocalTracks: { [part: string]: VocalTrackData } = {}
 	for (const track of tracks) {
 		const partName = vocalTrackNameMap[track.trackName as VocalTrackName]
 		if (partName && !vocalTracks[partName]) {
-			const events = track.trackEvents
+			// Single pass over the vocal track classifies all fields at once:
+			// lyrics, textEvents (MoonText), note 105/106 phrases, pitched +
+			// percussion notes, star power (116), range shifts (0), lyric
+			// shifts (1). Consumed events (ENHANCED_OPENS, disco flip, etc.)
+			// are dropped inside the classifier.
+			//
+			// YARG treats BOTH note 105 (LYRICS_PHRASE_1) and note 106
+			// (LYRICS_PHRASE_2) as creating a `Vocals_StaticLyricPhrase` in
+			// HARM2/HARM3's specialPhrases (plus `Vocals_ScoringPhrase` which
+			// CopyDown later replaces from HARM1). Match that by unioning both
+			// sets for harmony parts. For solo vocals and HARM1, the
+			// static-lyric view is simply a duplicate of the note-phrase
+			// (scoring) list per YARG's MoonSongLoader.Vocals.cs.
+			const classified = scanVocalTrack(track.trackEvents)
+			const isHarmonyBacking = partName === 'harmony2' || partName === 'harmony3'
 			vocalTracks[partName] = {
-				lyrics: extractMidiLyrics(events),
-				vocalPhrases: extractMidiVocalPhrases(events),
-				notes: extractMidiVocalNotes(events),
-				starPowerSections: extractMidiVocalStarPower(events),
-				rangeShifts: extractMidiRangeShifts(events),
-				lyricShifts: extractMidiLyricShifts(events),
-				staticLyricPhrases: [],
+				lyrics: classified.lyrics,
+				vocalPhrases: classified.phrases105,
+				notes: classified.notes,
+				starPowerSections: classified.starPower,
+				rangeShifts: classified.rangeShifts,
+				lyricShifts: classified.lyricShifts,
+				staticLyricPhrases: isHarmonyBacking
+					? mergePhraseLists(classified.phrases105, classified.phrases106)
+					: classified.phrases106,
+				textEvents: classified.textEvents,
 			}
 		}
 	}
 
 	// YARG CopyDownPhrases: HARM2/HARM3 get scoring phrases AND star power from HARM1.
-	// HARM2 keeps its own note-105 phrases as staticLyricPhrases (for lyric display),
-	// then replaces vocalPhrases (scoring) and starPowerSections with HARM1's.
-	// HARM3 clones HARM2's staticLyricPhrases and also gets HARM1's scoring/starpower.
+	// This only touches vocalPhrases/starPowerSections — staticLyricPhrases are
+	// extracted directly from note 106 on HARM2/HARM3 and are NOT touched here.
+	// CopyDown is idempotent (re-parse → re-CopyDown produces the same result).
 	if (vocalTracks.harmony1) {
 		const harm1Phrases = vocalTracks.harmony1.vocalPhrases
 		const harm1StarPower = vocalTracks.harmony1.starPowerSections
 		if (vocalTracks.harmony2) {
-			vocalTracks.harmony2.staticLyricPhrases = vocalTracks.harmony2.vocalPhrases.map(p => ({ tick: p.tick, length: p.length }))
 			vocalTracks.harmony2.vocalPhrases = harm1Phrases.map(p => ({ ...p }))
 			vocalTracks.harmony2.starPowerSections = harm1StarPower.map(p => ({ ...p }))
 		}
 		if (vocalTracks.harmony3) {
-			vocalTracks.harmony3.staticLyricPhrases = (vocalTracks.harmony2?.staticLyricPhrases ?? []).map(p => ({ ...p }))
 			vocalTracks.harmony3.vocalPhrases = harm1Phrases.map(p => ({ ...p }))
 			vocalTracks.harmony3.starPowerSections = harm1StarPower.map(p => ({ ...p }))
+			// HARM3 gets HARM2's staticLyricPhrases (matching YARG's CopyDownPhrases)
+			if (vocalTracks.harmony2) {
+				vocalTracks.harmony3.staticLyricPhrases = vocalTracks.harmony2.staticLyricPhrases.map(p => ({ ...p }))
+			}
 		}
 	}
 
@@ -195,7 +236,6 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
-		parseIssues: eventsScan.parseIssues,
 		trackData: _.chain(tracks)
 			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
 			.map(t => {
@@ -203,10 +243,11 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				const instrumentType = getInstrumentType(instrument)
 				// Single scan pass extracts note-shaped events AND the
 				// data-carrying ones (text, versus, animations).
-				const { eventEnds, textEvents, versusPhrases, animations } = scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
-				const trackDifficulties = _.chain(eventEnds)
-					.thru(eventEnds => distributeInstrumentEvents(eventEnds)) // Removes 'all' difficulty
-					.thru(eventEnds => getTrackEvents(eventEnds)) // Connects note ends together
+				const { eventEnds, textEvents, versusPhrases, animations } =
+					scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+				const distributed = distributeInstrumentEvents(eventEnds) // Removes 'all' difficulty
+				const pairedEvents = getTrackEvents(distributed) // Connects note ends together
+				const trackDifficulties = _.chain(pairedEvents)
 					.thru(events => splitMidiModifierSustains(events, instrumentType))
 					.thru(events => fixLegacyGhStarPower(events, instrumentType, iniChartModifiers))
 					.thru(events => fixFlexLaneLds(events))
@@ -255,8 +296,20 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 				})
 			})
 			.flatMap()
-			.filter(track => track.trackEvents.length > 0)
+			.filter(track => {
+				// A track must have "real" content — actual notes or scorable sections.
+				// Tracks with only global modifier events (e.g. [ENABLE_CHART_DYNAMICS])
+				// and no actual notes should be filtered out so that round-trip behavior
+				// is stable (the writer doesn't need to emit placeholder text events).
+				const hasRealTrackEvents = track.trackEvents.some(e =>
+					e.type !== eventTypes.enableChartDynamics,
+				)
+				return hasRealTrackEvents
+					|| track.starPowerSections.length > 0
+					|| track.soloSections.length > 0
+			})
 			.value(),
+		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 	}
 }
 
@@ -274,17 +327,25 @@ function getTracks(midiData: MidiData) {
 	const tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[] = []
 
 	for (const track of midiData.tracks) {
+		// Match YARG.Core's MidiExtensions.GetTrackName: return the FIRST
+		// `SequenceTrackName` event (FF 03) seen at tick 0, even if it
+		// doesn't match any recognized instrument track. The early `break`
+		// below ensures we don't continue scanning for a "better" name.
+		// Some charts (e.g. "Culture Killer - Blindfolded Death") have a
+		// bogus leading trackname like `[ENHANCED_OPENS]` followed by the
+		// real `PART BASS` — YARG honors the first and skips the track.
 		let trackName: string | null = null
 		for (const event of track) {
 			if (event.deltaTime !== 0) {
 				break
 			}
-			if (event.type === 'trackName' && trackNames.includes(event.text as TrackName)) {
+			if (event.type === 'trackName') {
 				trackName = event.text
+				break
 			}
 		}
 
-		if (trackName !== null) {
+		if (trackName !== null && trackNames.includes(trackName as TrackName)) {
 			tracks.push({
 				trackName: trackName as TrackName,
 				trackEvents: track,
@@ -308,7 +369,7 @@ interface TrackScanResult {
  *     `distributeInstrumentEvents` / `getTrackEvents`)
  *   - data-carrying events that ride alongside the notes: `textEvents`,
  *     `versusPhrases` (notes 105/106), `animations` (notes 24-51 drums,
- *     40-59 fret)
+ *     40-59 fret).
  *
  * Versus phrases and animations live in the same MIDI event stream as the
  * playable notes, so they're emitted from this single iteration.
@@ -414,9 +475,10 @@ function scanInstrumentTrack(
 				}
 			} else {
 				const type =
-					(instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
+					instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
 					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(event.noteNumber, difficulty)
-					: get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)) ?? null
+					: instrumentType === instrumentTypes.fiveFret ? get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)
+					: null
 				if (type !== null) {
 					eventEnds[difficulty].push({
 						tick: event.deltaTime,
@@ -826,6 +888,7 @@ function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
 	return events
 }
 
+
 /**
  * YARG/MoonSong reads text-like events from multiple MIDI meta event types:
  * text (FF 01), lyrics (FF 05), marker (FF 06), cuePoint (FF 07).
@@ -847,17 +910,6 @@ interface EventsScanResult {
 	parseIssues: RawChartData['parseIssues']
 }
 
-/**
- * Single-pass scan of the EVENTS track that classifies each text-like event
- * into one of {section, endEvent, coda, lyric, phrase, unrecognized}. Lyrics
- * and phrase_start/phrase_end are consumed by the vocal parsing path — we
- * don't re-emit them here. Everything else that matches a recognized pattern
- * goes into its typed array; all remaining text-like events fall through to
- * `unrecognizedEvents`.
- *
- * Reads from all text-like event types (text, lyrics, marker, cuePoint),
- * matching YARG.Core's MoonText behavior.
- */
 function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[]): EventsScanResult {
 	const result: EventsScanResult = {
 		sections: [],

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -171,7 +171,6 @@ export interface VocalTrackData {
 	vocalPhrases: {
 		tick: number
 		length: number
-		noteNumber?: number
 	}[]
 	notes: import('./lyric-parser').VocalNote[]
 	starPowerSections: {
@@ -186,10 +185,24 @@ export interface VocalTrackData {
 		tick: number
 		length: number
 	}[]
-	/** HARM2/3 static lyric phrase boundaries (distinct from scoring phrases). */
+	/** HARM2/3 static lyric phrase boundaries (from note 106 — distinct from
+	 * scoring phrases which are note 105). On HARM1 this is typically empty. */
 	staticLyricPhrases: {
 		tick: number
 		length: number
+	}[]
+	/**
+	 * Raw text events on the vocal track (stance markers, Band_PlayFacialAnim, etc.).
+	 * YARG.Core parses these into the VocalsPart.TextEvents list, which is what
+	 * makes an otherwise-empty vocal track "non-empty" (and therefore visible to
+	 * ChartDump / UI). Storing them here lets the writer round-trip vocals-only
+	 * tracks that have no lyrics/notes/phrases but still have stance markers.
+	 * Does NOT include lyric events (which live in `lyrics`) or events scan-chart
+	 * consumes internally (`ENHANCED_OPENS`, `[mix N drumsM]`, `[range_shift ...]`).
+	 */
+	textEvents: {
+		tick: number
+		text: string
 	}[]
 }
 
@@ -338,9 +351,10 @@ export const lyricFlags = {
 export interface NormalizedLyricEvent {
 	tick: number
 	msTime: number
-	/** Flag symbols stripped, '=' → '-'. '_' and '§' kept as-is (consumer decides display). */
+	/** Original text from the source file, including markup symbols (#, ^, +, =, $, etc.).
+	 * Consumers should use `flags` for semantic interpretation, not parse `text` directly. */
 	text: string
-	/** Bitmask of `lyricFlags`. */
+	/** Bitmask of `lyricFlags`, derived from markup symbols in text. */
 	flags: number
 }
 
@@ -349,7 +363,9 @@ export interface NormalizedVocalNote {
 	msTime: number
 	length: number
 	msLength: number
-	/** MIDI pitch 36-84 for pitched, -1 for unpitched/percussion. */
+	/** MIDI pitch 36-84 for pitched, -1 for percussion. NonPitched notes
+	 * (lyric flags #/^/*) keep their original MIDI pitch — check the
+	 * associated lyric's nonPitched flag for semantic meaning. */
 	pitch: number
 	/** percussionHidden (note 97) is excluded from normalized output. */
 	type: 'pitched' | 'percussion'
@@ -362,17 +378,36 @@ export interface NormalizedVocalPhrase {
 	msLength: number
 	/** True if first note is percussion (YARG behavior — mixing types in one phrase is invalid data). */
 	isPercussion: boolean
+	/** Versus player (PART VOCALS only). 1 = player 1 (note 105), 2 = player 2 (note 106). */
+	player?: 1 | 2
 	notes: NormalizedVocalNote[]
 	lyrics: NormalizedLyricEvent[]
 }
 
 export interface NormalizedVocalPart {
-	/** Scoring phrases (from note 105). Notes and lyrics grouped into their containing phrase. */
+	/** Phrases with notes and lyrics grouped. Built from the union of note 105
+	 * and note 106 phrase boundaries. Notes outside all phrases are dropped. */
 	notePhrases: NormalizedVocalPhrase[]
-	/** Static lyric display phrases (from note 106 on HARM2/3, copy of notePhrases on vocals/HARM1). */
+	/** Static lyric display phrases (from note 106 on HARM2/3, copy of
+	 * notePhrases on vocals/HARM1). */
 	staticLyricPhrases: NormalizedVocalPhrase[]
 	/** Star power sections — separate array, not per-phrase. */
 	starPowerSections: { tick: number; msTime: number; length: number; msLength: number }[]
+	/**
+	 * Per-part range shift markers (MIDI note 0 on this part's track).
+	 * YARG computes rangeShifts from these markers. PART VOCALS and HARM1 often
+	 * have distinct marker sets — must be stored per-part for lossless round-trip.
+	 */
+	rangeShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+	/** Per-part lyric shift markers (MIDI note 1 on this part's track). */
+	lyricShifts: { tick: number; msTime: number; length: number; msLength: number }[]
+	/**
+	 * Raw text events on the vocal track (stance, facial anim, etc.). Required
+	 * so that vocal tracks with only text events (no notes/lyrics/phrases)
+	 * round-trip — YARG considers a VocalsPart non-empty iff it has phrases or
+	 * text events, so dropping them causes ChartDump to hide the track.
+	 */
+	textEvents: { tick: number; msTime: number; text: string }[]
 }
 
 /** Top-level normalized vocal track. */

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 
-import { DrumType, drumTypes, Instrument } from 'src/interfaces'
+import { Difficulty, DrumType, drumTypes, getInstrumentType, Instrument, instrumentTypes } from 'src/interfaces'
 import { parseNotesFromChart } from './chart-parser'
 import { parseNotesFromMidi } from './midi-parser'
 import {
@@ -54,22 +54,11 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		)
 		.value()
 
-	return {
-		resolution: rawChartData.chartTicksPerBeat,
-		drumType,
-		metadata: rawChartData.metadata,
-		hasLyrics: Object.values(rawChartData.vocalTracks).some(v => v.lyrics.length > 0),
-		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
-		hasForcedNotes,
-		parseIssues: rawChartData.parseIssues,
-		vocalTracks: normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat),
-		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
-		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
-		tempos: timedTempos,
-		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
-		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
-		trackData: _.chain(rawChartData.trackData)
-			.map(track => ({
+	const normalizedVocalTracks = normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat)
+	// Evaluate trackData first — normalizedVocalTracks is used below for phrase-level hasLyrics check.
+	const trackDataResult = _.chain(rawChartData.trackData)
+			.map(track => {
+				return {
 				instrument: track.instrument,
 				difficulty: track.difficulty,
 				starPowerSections: _.chain(track.starPowerSections)
@@ -104,8 +93,28 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 					.tap(noteGroups => sortAndFixInvalidNoteOverlaps(noteGroups))
 					.thru(events => setEventGroupMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
 					.value(),
-			}))
-			.value(),
+				}
+			})
+			.value()
+
+	return {
+		resolution: rawChartData.chartTicksPerBeat,
+		drumType,
+		metadata: rawChartData.metadata,
+		// Check phrase-level lyrics to decide hasLyrics — raw lyric events that
+		// get filtered (brackets, whitespace-only) should not count.
+		hasLyrics: Object.values(normalizedVocalTracks.parts).some(p =>
+			p.notePhrases.some(ph => ph.lyrics.length > 0)),
+		hasVocals: Object.values(rawChartData.vocalTracks).some(v => v.vocalPhrases.length > 0),
+		hasForcedNotes,
+		parseIssues: rawChartData.parseIssues,
+		vocalTracks: normalizedVocalTracks,
+		endEvents: setEventMsTimes(rawChartData.endEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		unrecognizedEvents: setEventMsTimes(rawChartData.unrecognizedEvents, timedTempos, rawChartData.chartTicksPerBeat),
+		tempos: timedTempos,
+		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
+		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
+		trackData: trackDataResult,
 	}
 }
 
@@ -127,7 +136,7 @@ function normalizeVocalTracks(
 	const sourcePart = vocalTracks['vocals'] ?? vocalTracks['harmony1']
 
 	for (const [partName, data] of entries) {
-		parts[partName] = normalizeVocalPart(data, timedTempos, resolution)
+		parts[partName] = normalizeVocalPart(data, timedTempos, resolution, partName)
 	}
 
 	return {
@@ -145,15 +154,80 @@ function normalizeVocalPart(
 	data: VocalTrackData,
 	timedTempos: TimedTempos,
 	resolution: number,
+	partName: string,
 ): NormalizedVocalPart {
-	const notePhrases = groupIntoPhrases(data.vocalPhrases, data, timedTempos, resolution)
+	const isPartVocals = partName === 'vocals'
+	const isHarm2or3 = partName === 'harmony2' || partName === 'harmony3'
+
+	// PART VOCALS: merge note 105 + 106 into a single phrase list with player
+	// tags. Both create scoring + static lyric phrases in YARG.
+	// Harmonies: keep 105 (scoring) and 106 (static lyric) separate for
+	// lossless round-trip — the writer needs to emit them on their original
+	// MIDI note numbers, and CopyDown relies on HARM1's vocalPhrases (105 only).
+	let notePhrases: NormalizedVocalPhrase[]
+	let staticLyricPhrases: NormalizedVocalPhrase[]
+
+	if (isPartVocals) {
+		// Merge 105 + 106 for PART VOCALS
+		const mergedPhrases: { tick: number; length: number; _source: 105 | 106 }[] = []
+		for (const p of data.vocalPhrases) {
+			mergedPhrases.push({ tick: p.tick, length: p.length, _source: 105 })
+		}
+		for (const p of data.staticLyricPhrases) {
+			mergedPhrases.push({ tick: p.tick, length: p.length, _source: 106 })
+		}
+		mergedPhrases.sort((a, b) => a.tick - b.tick)
+
+		// Dedup same-tick phrases (keep longest), track source of survivor
+		const dedupedPhrases: typeof mergedPhrases = []
+		const phraseSourceByTick = new Map<number, 105 | 106>()
+		for (const p of mergedPhrases) {
+			const existing = dedupedPhrases.find(d => d.tick === p.tick)
+			if (existing) {
+				if (p.length > existing.length) {
+					existing.length = p.length
+					existing._source = p._source
+				}
+			} else {
+				dedupedPhrases.push(p)
+			}
+			phraseSourceByTick.set(p.tick, dedupedPhrases.find(d => d.tick === p.tick)!._source)
+		}
+
+		notePhrases = groupIntoPhrases(dedupedPhrases, data, timedTempos, resolution)
+
+		// Set player field
+		for (const phrase of notePhrases) {
+			const source = phraseSourceByTick.get(phrase.tick)
+			phrase.player = source === 106 ? 2 : 1
+		}
+
+		// staticLyricPhrases = copy of notePhrases for PART VOCALS
+		staticLyricPhrases = notePhrases.map(p => ({ ...p }))
+	} else {
+		// Harmonies: separate 105/106 for lossless round-trip
+		notePhrases = groupIntoPhrases(data.vocalPhrases, data, timedTempos, resolution)
+		staticLyricPhrases = data.staticLyricPhrases.length > 0
+			? groupIntoPhrases(data.staticLyricPhrases, data, timedTempos, resolution)
+			: []
+	}
+
 	return {
 		notePhrases,
-		staticLyricPhrases: data.staticLyricPhrases.length > 0
-			? groupIntoPhrases(data.staticLyricPhrases, data, timedTempos, resolution)
-			: notePhrases,
+		staticLyricPhrases,
 		starPowerSections: setEventMsTimes(data.starPowerSections, timedTempos, resolution),
+		rangeShifts: setEventMsTimes(data.rangeShifts, timedTempos, resolution),
+		lyricShifts: setEventMsTimes(data.lyricShifts, timedTempos, resolution),
+		textEvents: setEventMsTimes(data.textEvents ?? [], timedTempos, resolution),
 	}
+}
+
+/** Standard emptiness check for lyrics (matching YARG's IsNullOrWhiteSpace
+ * on StripForVocals output). Symbol-only lyrics like "+" strip to empty
+ * and are dropped. */
+function isLyricKept(text: string): boolean {
+	const stripped = stripLyricSymbols(text)
+	return stripped.length > 0 && stripped.replace(/_/g, ' ').trim().length > 0
 }
 
 function groupIntoPhrases(
@@ -207,38 +281,52 @@ function groupIntoPhrases(
 		// Check if a pitch slide from a previous phrase carries into this one
 		const hasCarriedNote = carriedNoteEndTick >= phrase.tick
 
-		// Build notes and lyrics by iterating notes and collecting lyrics up to each note's tick
-		// (matching YARG's ProcessNoteEvent pattern where moonTextIndex is shared across phrases).
 		const notes: NormalizedVocalNote[] = []
 		const untimedLyrics: { tick: number; text: string; flags: number }[] = []
-		for (const note of rawNotes) {
-			// YARG only processes note 96 (percussion), not note 97 (percussionHidden/nonplayed)
-			if (note.type === 'percussionHidden') continue
 
-			// Skip percussion notes at the exact phrase start tick when it's the first note.
-			// In MIDI, noteOn for note 96 can arrive before noteOn for note 105 at the same tick,
-			// causing the percussion note to not be included in the phrase by YARG's normalizer.
+		// Pre-collect all lyrics within this phrase's tick range. This advances
+		// lyricIdx to a consistent position (phraseEnd) regardless of which notes
+		// exist, preventing lyricIdx divergence when pitch slide notes are dropped
+		// on round-trip. Note processing uses a local iterator (phraseLyricIdx)
+		// over this pre-collected list for flag detection.
+		const phraseLyrics: { tick: number; text: string; flags: number }[] = []
+		while (lyricIdx < sortedLyrics.length && sortedLyrics[lyricIdx].tick < phraseEnd) {
+			const lyric = sortedLyrics[lyricIdx]
+			lyricIdx++
+			const text = lyric.text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
+			if (text.startsWith('[')) continue
+			phraseLyrics.push({ tick: lyric.tick, text, flags: parseLyricFlags(text) })
+		}
+		if (rawNotes.length === 0) {
+			// No-notes path (.chart format, empty phrases): add all phrase lyrics
+			for (const pl of phraseLyrics) {
+				if (isLyricKept(pl.text)) {
+					untimedLyrics.push({ tick: pl.tick, text: pl.text, flags: pl.flags })
+				}
+			}
+		}
+
+		// Process notes, using phraseLyrics for flag detection
+		let phraseLyricIdx = 0
+		for (const note of rawNotes) {
+			if (note.type === 'percussionHidden') continue
 			if (note.type === 'percussion' && note.tick === phrase.tick && notes.length === 0) {
 				continue
 			}
 
-			// Collect all lyrics up to and including this note's tick
+			// Collect lyrics up to and including this note's tick (local iterator)
 			let noteLyricFlags = 0
-			while (lyricIdx < sortedLyrics.length && sortedLyrics[lyricIdx].tick <= note.tick) {
-				const lyric = sortedLyrics[lyricIdx]
-				lyricIdx++
+			while (phraseLyricIdx < phraseLyrics.length && phraseLyrics[phraseLyricIdx].tick <= note.tick) {
+				let { tick, text, flags } = phraseLyrics[phraseLyricIdx]
+				phraseLyricIdx++
 
-				// Trim ASCII whitespace (0x00-0x20) from both ends, matching YARG's
-				// NormalizeTextEvent.TrimAscii() which processes text before storage.
-				let text = lyric.text.replace(/^[\x00-\x20]+|[\x00-\x20]+$/g, '')
-
-				// Skip bracketed events — YARG's NormalizeTextEvent strips brackets and
-				// prevents bracketed FF 01 text events from becoming lyrics.
-				if (text.startsWith('[')) continue
-
-				let flags = parseLyricFlags(text)
 				noteLyricFlags = flags
 
+				// DeferredLyricJoinWorkaround: "+-" or "-+" merges the hyphen into
+				// the previous lyric's flags. We update noteLyricFlags for pitch
+				// slide detection but keep the original text "+-" for lossless
+				// round-trip — changing it to "+" causes the workaround to trigger
+				// differently on re-parse (state-dependent, not idempotent).
 				// DeferredLyricJoinWorkaround: "+-" or "-+" merges the hyphen into the previous lyric
 				if (untimedLyrics.length > 0 && (text === '+-' || text === '-+')) {
 					const prev = untimedLyrics[untimedLyrics.length - 1]
@@ -254,41 +342,37 @@ function groupIntoPhrases(
 					}
 				}
 
-				const strippedText = stripLyricSymbols(text)
-				// Skip lyrics that would be whitespace-only after _ → space replacement.
-				// Matches YARG's IsNullOrWhiteSpace check which runs on StripForVocals output
-				// (where _ is replaced with space).
-				if (strippedText.length > 0 && strippedText.replace(/_/g, ' ').trim().length > 0) {
-					untimedLyrics.push({ tick: lyric.tick, text: strippedText, flags })
+				if (isLyricKept(text)) {
+					untimedLyrics.push({ tick, text, flags })
 				}
 			}
 
 			const isPitchSlide = (noteLyricFlags & lyricFlags.pitchSlide) !== 0
-			const isNonPitched = (noteLyricFlags & lyricFlags.nonPitched) !== 0 ||
-				note.type === 'percussion'
 
 			if (isPitchSlide) {
-				const slideEnd = note.tick + note.length
-				if (notes.length > 0) {
-					// Within-phrase slide: merges with previousNote (a separate chain from carriedNote).
-					// Do NOT extend carriedNoteEndTick — previousNote is not necessarily the carriedNote.
-					// In YARG, AddChildNote only updates the parent it's called on, not other notes.
-					continue
-				}
-				if (hasCarriedNote) {
-					// Cross-phrase slide via carried note: skip, extend total end
-					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
-					continue
-				}
-				// Cross-phrase slide via previousParentLyric (YARG behavior):
-				if (result.length === 0) {
-					// No phrases yet → charting error, skip
-					continue
-				}
-				if (hasPreviousLyricNote) {
-					// Add to previousParentLyric, set carriedNote
-					carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
-					continue
+				// Only skip if the pitchSlide lyric survived the emptiness filter.
+				// Symbol-only "+" strips to empty and is filtered from output. If
+				// filtered, the lyric won't exist on re-parse, so the note wouldn't
+				// be detected as a pitch slide — keeping it ensures round-trip
+				// consistency for Harmonix-authored charts.
+				const lastStored = untimedLyrics.length > 0 ? untimedLyrics[untimedLyrics.length - 1] : null
+				const slideMarkerKept = lastStored !== null && (lastStored.flags & lyricFlags.pitchSlide) !== 0
+				if (slideMarkerKept) {
+					const slideEnd = note.tick + note.length
+					if (notes.length > 0) {
+						continue
+					}
+					if (hasCarriedNote) {
+						carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+						continue
+					}
+					if (result.length === 0) {
+						continue
+					}
+					if (hasPreviousLyricNote) {
+						carriedNoteEndTick = Math.max(carriedNoteEndTick, slideEnd)
+						continue
+					}
 				}
 			}
 
@@ -298,20 +382,29 @@ function groupIntoPhrases(
 				msTime: timed.msTime,
 				length: timed.length,
 				msLength: timed.msLength,
-				pitch: isNonPitched ? -1 : note.pitch,
+				// Keep original MIDI pitch for pitched notes (even nonPitched ones
+				// marked by lyric flags like #/^/*). Consumers check the lyric's
+				// nonPitched flag instead. Percussion always gets -1 (fixed MIDI note 96).
+				pitch: note.type === 'percussion' ? -1 : note.pitch,
 				type: note.type,
 			})
 			if (note.type === 'pitched') hasPreviousLyricNote = true
 		}
 
-		// Re-check carried note state after processing all notes in this phrase.
-		// Pitch slides during this phrase may have set carriedNoteEndTick via previousParentLyric.
-		const hasCarriedNoteAfter = carriedNoteEndTick >= phrase.tick
-
-		// Skip phrases with no notes and no carried note (matching YARG behavior)
-		if (notes.length < 1 && !hasCarriedNote && !hasCarriedNoteAfter) {
-			continue
+		// Add remaining pre-collected lyrics after the last note (with-notes path only;
+		// no-notes path already added all phraseLyrics above)
+		while (rawNotes.length > 0 && phraseLyricIdx < phraseLyrics.length) {
+			const { tick, text, flags } = phraseLyrics[phraseLyricIdx]
+			phraseLyricIdx++
+			if (isLyricKept(text)) {
+				untimedLyrics.push({ tick, text, flags })
+			}
 		}
+
+		// NOTE: Intentionally do NOT drop "empty" phrases (no notes, no lyrics, no carried
+		// note). Keeping them preserves the full set of phrase boundaries so that writers
+		// can round-trip the full MIDI state. Consumers wanting a YARG-compatible filtered
+		// view can filter notePhrases themselves.
 
 		// Track carry-over: only from notes that were added to the phrase (not pitch slide children).
 		// YARG sets carriedNote at line 219-222, which only runs for notes that pass through
@@ -710,7 +803,6 @@ function resolveFretModifiers(
 			: events.find(n => n.type === eventTypes.forceStrum) ? noteFlags.strum
 			: (hasForceUnnatural && isNaturalHopo) || (!hasForceUnnatural && !isNaturalHopo) ? noteFlags.strum
 			: noteFlags.hopo
-
 		noteEventGroups.push(
 			notes.map(n => ({
 				tick: n.tick,


### PR DESCRIPTION
**Stacked on #84.** Merge #84 first.

## What changed

**Type structure — single source of truth for vocal data**

Removed top-level `notes[]` and `lyrics[]` from `NormalizedVocalPart`. All vocal content is now accessed through phrase grouping:

- `NormalizedVocalPart.notePhrases[].notes[]` — vocal notes (was: `NormalizedVocalPart.notes` + redundant copy under each phrase)
- `NormalizedVocalPart.notePhrases[].lyrics[]` — lyrics belonging to each phrase
- `NormalizedVocalPart.staticLyricPhrases[]` — note 106 display-only phrases (HARM2/3)

Previously the same notes/lyrics existed in two places (top-level array + per-phrase). Consumers had to know which to use, and a malformed file could cause them to disagree. The new structure has one location per piece of data.

**New fields on `NormalizedVocalPart`**

- `rangeShifts[]` — vocal range shift markers (MIDI note 0). Per-part because PART VOCALS and HARM1 often have distinct sets that must be preserved separately for round-trip.
- `lyricShifts[]` — vocal lyric shift markers (MIDI note 1). Same per-part rationale.
- `textEvents[]` — raw text events on the vocal track (stance markers, `Band_PlayFacialAnim`, etc.). YARG considers a `VocalsPart` non-empty iff it has phrases OR text events; without storing these, vocal tracks with only stance markers (no notes/lyrics/phrases) round-trip to empty and the track disappears.

**New field on `NormalizedVocalPhrase`**

- `player?: 1 | 2` — versus player tag (PART VOCALS only). Note 105 → player 1, note 106 → player 2. Required for versus-mode rendering. Previously, note 106 phrases were stored separately in `staticLyricPhrases` on PART VOCALS, which lost the distinction between "this is a player 2 scoring phrase" and "this is a HARM2/3 static lyric phrase".

**PART VOCALS phrase merging**

PART VOCALS now merges note 105 + note 106 phrase boundaries into a single `notePhrases` list (with player tags), matching YARG's `MoonSongLoader.Vocals.cs` behavior. Both notes create scoring phrases in YARG; they only differ in versus-player attribution. Previously we treated 105 and 106 as separate phrase lists, which caused notes near 106 boundaries to appear "orphaned" (~10K charts in the corpus had this artifact).

**Harmonies keep 105/106 separate**

HARM1/2/3 keep distinct 105 (scoring) and 106 (static lyric) phrase lists for lossless round-trip. The writer needs to emit each on its original MIDI note number, and CopyDown relies on HARM1's `vocalPhrases` (note 105 only) to know which phrases to clone to HARM2/3.

**HARM3 `CopyDownPhrases`**

HARM3 now clones `staticLyricPhrases` from HARM2 (in addition to scoring phrases from HARM1), matching YARG `CopyDownPhrases` exactly. Previously HARM3 had no static lyric phrases unless authored directly on the HARM3 track.

**Lyric text preservation**

`NormalizedLyricEvent.text` now stores the original unstripped text including markup symbols (`#`, `^`, `+`, `=`, `$`, `_`, `§`, etc.). Consumers should use the `flags` bitmask for semantic interpretation rather than parsing the text directly. Previously we stripped flag symbols and replaced `=` with `-`, which made round-trip writing incorrect (writers couldn't reconstruct the original text).

**Pitch preservation for nonPitched notes**

`NormalizedVocalNote.pitch` keeps the original MIDI pitch for nonPitched notes (lyric flags `#`/`^`/`*`). Previously we set pitch to `-1` for both percussion and nonPitched, losing the distinction. Consumers check the associated lyric's `nonPitched` flag for semantic meaning.

**Pre-collect lyrics per phrase**

The phrase-grouping algorithm now advances the lyric index to the phrase end regardless of whether the phrase has notes. Previously, pitch-slide-only phrases (no notes) would leave their lyrics stranded between phrases, causing divergence on round-trip.

**Pitch-slide skip refinement**

Pitch-slide notes are only skipped when their associated lyric survives the emptiness filter. Prevents losing slides whose lyrics would otherwise be dropped.

**`extractMidiVocalTextEvents`**

New helper extracts bracketed control-event text events on vocal tracks (stance markers, `Band_PlayFacialAnim`, etc.) into `VocalTrackData.textEvents`. Filters out lyrics (handled separately) and events scan-chart consumes internally (`ENHANCED_OPENS`, `[mix N drumsM]`, `[range_shift ...]`).

## Generic chart-parser helpers (used by both .chart and .mid paths)

These aren't strictly vocal-related but are bundled because the vocal work needed them and they're load-bearing elsewhere:

- `resolveChartTrackName(sectionName)` — matches YARG `ChartReader` logic for resolving a `.chart` section name like `ExpertDoubleDrums` into an `{instrument, difficulty}` pair. Handles non-standard names (e.g. "ExpertDoubleDrums" in `Megadeth - Bite the Hand`) which YARG accepts via prefix+suffix matching.
- `parseChartSectionEventText(text)` — matches YARG's `TextEvents.NormalizeTextEvent → TryParseSectionEvent` pipeline for section event detection. Handles typo cases like `sections Pre-Chorus` that YARG's `StartsWith("section")` accepts.

## Why

The previous vocal data structure (PR #85 / `vocal-normalization`) correctly produced phrase-grouped output but left several issues unresolved:

1. **Ambiguity**: notes/lyrics existed in two places (top-level + per-phrase). Future code changes risked them drifting apart.
2. **Round-trip incorrectness**: lyric symbols were stripped, pitches were lost, range/lyric shifts and text events weren't exposed, so the writer couldn't reconstruct the original chart.
3. **Versus mode unsupported**: player attribution was lost when 105/106 phrases were merged on PART VOCALS, blocking versus-mode rendering.
4. **HARM2/3 round-trip**: needed the distinction between 105 (scoring, copied from HARM1) and 106 (static lyric, kept on the harmony track) for the writer to re-emit them on the correct MIDI note.

This refactor doesn't change YARG-comparable output — both before and after produce 0 vocal phrase diffs across **78,452 charts**. The value is enabling round-trip writing, exposing data consumers need (player tags, shifts, text events), and removing the dual-storage ambiguity.

## Validation

- 268 unit tests pass
- 0 hash regressions vs upstream master baseline (15,524 charts)
- 0 vocal phrase diffs vs YARG dumps across the **full corpus (78,452 charts)** — phrase boundaries, note ticks/pitches, lyric counts/text/flags all match YARG exactly