### PR TITLE
Fix section-name parser stripping trailing `]` from section names

### DIFF
--- a/src/__tests__/per-track-data.test.ts
+++ b/src/__tests__/per-track-data.test.ts
@@ -917,6 +917,84 @@ describe('.chart: global events', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Section name parsing — brackets must match as a pair
+// ---------------------------------------------------------------------------
+
+describe('section name parsing', () => {
+	it('.chart: plain `section NAME` preserves a trailing `]` inside the name', () => {
+		// Real-world case: "Commission Crew Solo Medley" (jdurand) uses section
+		// names with `<b>` tags and bracketed credit suffixes, ending in `]`:
+		//   section <b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]
+		// The old regex stripped the trailing `]` — this test pins that fixed.
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'270864 = E "section <b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]"',
+				'276432 = E "section Intro"',
+				'280000 = E "section [nested]"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.sections).toEqual([
+			{ tick: 270864, name: '<b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]' },
+			{ tick: 276432, name: 'Intro' },
+			{ tick: 280000, name: '[nested]' },
+		])
+	})
+
+	it('.chart: bracketed `[section NAME]` strips outer brackets but keeps inner `]`', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [
+				'0 = E "[section Intro]"',
+				'480 = E "[section verse [with brackets]]"',
+			],
+		})
+
+		const result = parseNotesFromChart(chart)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: 'Intro' },
+			{ tick: 480, name: 'verse [with brackets]' },
+		])
+	})
+
+	it('MIDI: `[section NAME]` strips outer brackets but keeps inner `]` in the name', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: '[section <b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]]' },
+			{ deltaTime: 480, type: 'text', text: '[section Intro]' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: '<b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]' },
+			{ tick: 480, name: 'Intro' },
+		])
+	})
+
+	it('MIDI: plain `section NAME` (no outer brackets) also preserves inner `]`', () => {
+		const events: MidiData['tracks'][number] = [
+			{ deltaTime: 0, type: 'trackName', text: 'EVENTS' },
+			{ deltaTime: 0, type: 'text', text: 'section credits [part 1]' },
+			{ deltaTime: 480, type: 'text', text: 'section Intro' },
+			{ deltaTime: 0, type: 'endOfTrack' },
+		]
+
+		const midi = buildMidi(480, [tempoTrack(), events])
+		const result = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(result.sections).toEqual([
+			{ tick: 0, name: 'credits [part 1]' },
+			{ tick: 480, name: 'Intro' },
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
 // MIDI: parseIssues for stray vocal events on the EVENTS track
 // ---------------------------------------------------------------------------
 

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -557,9 +557,16 @@ function scanEventsSection(eventLines: string[]): ChartEventsScanResult {
 		const tick = Number(match[1])
 		const text = match[2]
 
-		const sectionMatch = /^\[?(?:section|prc)[ _](.*?)\]?$/.exec(text)
-		if (sectionMatch) {
-			result.sections.push({ tick, name: sectionMatch[1] })
+		// Accept either `[section NAME]` (bracketed form — outer brackets are
+		// stripped) or `section NAME` (plain form — everything after the prefix
+		// is the name). Brackets must match as a pair: a trailing `]` is not
+		// stripped unless the text also started with `[`. This preserves section
+		// names that legitimately end in `]` (e.g. `section <b>…</b> [credits]`).
+		const bracketedSection = /^\[(?:section|prc)[ _](.*)\]$/.exec(text)
+		const plainSection = !bracketedSection && /^(?:section|prc)[ _](.*)$/.exec(text)
+		if (bracketedSection || plainSection) {
+			const name = (bracketedSection ?? plainSection as RegExpExecArray)[1]
+			result.sections.push({ tick, name })
 			continue
 		}
 		if (/^\[?end\]?$/.test(text)) {

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -968,9 +968,16 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 		const text = event.text
 		const tick = event.deltaTime
 
-		const sectionMatch = /^\[?(?:section|prc)[ _]([^\]]*)\]?$/.exec(text)
-		if (sectionMatch) {
-			result.sections.push({ tick, name: sectionMatch[1] })
+		// Accept either `[section NAME]` (bracketed form — outer brackets are
+		// stripped) or `section NAME` (plain form — everything after the prefix
+		// is the name). Brackets must match as a pair: a trailing `]` is not
+		// stripped unless the text also started with `[`. This preserves section
+		// names that legitimately end in `]` (e.g. `section <b>…</b> [credits]`).
+		const bracketedSection = /^\[(?:section|prc)[ _](.*)\]$/.exec(text)
+		const plainSection = !bracketedSection && /^(?:section|prc)[ _](.*)$/.exec(text)
+		if (bracketedSection || plainSection) {
+			const name = (bracketedSection ?? plainSection as RegExpExecArray)[1]
+			result.sections.push({ tick, name })
 			continue
 		}
 		if (/^\[?end\]?$/.test(text)) {


### PR DESCRIPTION
## Summary

The `.chart` and `.mid` section-name regexes used `\]?$` (optional trailing `]`) at the end of the capture. That made any section name ending in `]` lose its closing bracket on parse. Concrete real-world case from a Commission Crew Solo Medley chart (jdurand):

```
270864 = E "section <b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_]"
```

Before this fix, the parsed `sections[i].name` was:

```
<b>Hot Mulligan - And a Big Load</b> [jdurandTV & Pix_
```

(missing the closing `]`). The bracket that appears in-game was silently dropped by scan-chart.

## The fix

Replaced the single regex (`^\[?(?:section|prc)[ _](.*?)\]?$`) with two alternatives:

- `^\[(?:section|prc)[ _](.*)\]$` — bracketed form, strips outer brackets only
- `^(?:section|prc)[ _](.*)$` — plain form, keeps everything after the prefix

Brackets must match as a pair: a trailing `]` is no longer stripped unless the text also started with `[`. Section names that contain `]` (inner or trailing) now round-trip verbatim. Same change applied to both the `.chart` parser (`src/chart/chart-parser.ts`) and the `.mid` parser (`src/chart/midi-parser.ts`).

## Tests

Four new tests in `src/__tests__/per-track-data.test.ts` under a new \`section name parsing\` describe:

- `.chart` plain \`section NAME\` — uses the exact Hot Mulligan string as the regression check; also covers \`section Intro\` (no brackets) and \`section [nested]\` (inner brackets).
- `.chart` bracketed \`[section NAME]\` — strips outer brackets; covers \`[section verse [with brackets]]\`.
- `.mid` bracketed \`[section NAME]\` — Hot Mulligan + \`[section Intro]\`.
- `.mid` plain \`section NAME\` — \`section credits [part 1]\`.

All 278 existing + new tests pass. Chart-edit (yarn-linked consumer) also builds and passes its full 199-test suite with the rebuilt scan-chart.

## Test plan
- [x] \`npx vitest run src/__tests__/per-track-data.test.ts -t "section name parsing"\` — 4/4 passing
- [x] \`npx vitest run\` — 278/278 passing
- [x] Parsed the original Commission Crew Solo Medley chart; section at tick 270864 now preserves the full name including trailing \`]\`