### PR TITLE
Perf: parseChartAndIni 24% faster on 78K-chart corpus (31 commits)

### DIFF
--- a/patches/midi-file+1.2.4.patch
+++ b/patches/midi-file+1.2.4.patch
@@ -2,7 +2,8 @@ diff --git a/node_modules/midi-file/lib/midi-parser.js b/node_modules/midi-file/
 index 50ed069..93868ee 100644
 --- a/node_modules/midi-file/lib/midi-parser.js
 +++ b/node_modules/midi-file/lib/midi-parser.js
-@@ -309,8 +309,47 @@ Parser.prototype.readBytes = function(len) {
+@@ -308,9 +308,47 @@ Parser.prototype.readBytes = function(len) {
+   return bytes
  }
 
 +var sharedUtf8Decoder = new TextDecoder('utf-8')
@@ -49,8 +50,33 @@ index 50ed069..93868ee 100644
 +  // Build Latin-1 string via fromCharCode on the byte values.
 +  return String.fromCharCode.apply(null, bytes)
  }
- 
+
  Parser.prototype.readVarInt = function() {
+@@ -321,14 +359,19 @@ Parser.prototype.readBytes = function(len) {
+
+ Parser.prototype.readVarInt = function() {
+   var result = 0
+-  while (!this.eof()) {
+-    var b = this.readUInt8()
++  var buffer = this.buffer
++  var pos = this.pos
++  var bufferLen = this.bufferLen
++  while (pos < bufferLen) {
++    var b = buffer[pos++]
+     if (b & 0x80) {
+       result += (b & 0x7f)
+       result <<= 7
+     } else {
+       // b is last byte
++      this.pos = pos
+       return result + b
+     }
+   }
+   // premature eof
++  this.pos = pos
+   return result
+ }
+
 diff --git a/node_modules/midi-file/lib/midi-writer.js b/node_modules/midi-file/lib/midi-writer.js
 index c1a438d..cbd1a73 100644
 --- a/node_modules/midi-file/lib/midi-writer.js
@@ -63,7 +89,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'copyrightNotice':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x02)
@@ -71,7 +97,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'trackName':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x03)
@@ -79,7 +105,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'instrumentName':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x04)
@@ -87,7 +113,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'lyrics':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x05)
@@ -95,7 +121,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'marker':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x06)
@@ -103,7 +129,7 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'cuePoint':
        w.writeUInt8(0xFF)
        w.writeUInt8(0x07)
@@ -111,11 +137,11 @@ index c1a438d..cbd1a73 100644
 -      w.writeString(text)
 +      w.writeStringWithLength(text)
        break;
- 
+
      case 'channelPrefix':
 @@ -325,11 +318,14 @@ Writer.prototype.writeBytes = function(arr) {
  }
- 
+
  Writer.prototype.writeString = function(str) {
 -  var i, len = str.length, arr = []
 -  for (i=0; i < len; i++) {
@@ -131,5 +157,5 @@ index c1a438d..cbd1a73 100644
 +  this.writeVarInt(bytes.length)
 +  this.writeBytes(bytes)
  }
- 
+
  Writer.prototype.writeVarInt = function(v) {

--- a/patches/midi-file+1.2.4.patch
+++ b/patches/midi-file+1.2.4.patch
@@ -2,20 +2,52 @@ diff --git a/node_modules/midi-file/lib/midi-parser.js b/node_modules/midi-file/
 index 50ed069..93868ee 100644
 --- a/node_modules/midi-file/lib/midi-parser.js
 +++ b/node_modules/midi-file/lib/midi-parser.js
-@@ -309,8 +309,15 @@ Parser.prototype.readBytes = function(len) {
+@@ -309,8 +309,47 @@ Parser.prototype.readBytes = function(len) {
  }
- 
+
++var sharedUtf8Decoder = new TextDecoder('utf-8')
++
  Parser.prototype.readString = function(len) {
-+  // Strings can be multibyte-encoded or not.
-+  // Try UTF-8 first; fall back to Latin-1 if UTF-8 produces replacement chars.
-   var bytes = this.readBytes(len)
+-  var bytes = this.readBytes(len)
 -  return String.fromCharCode.apply(null, bytes)
-+  var multibyteString = new TextDecoder().decode(bytes)
-+  var singlebyteString = String.fromCharCode.apply(null, bytes)
-+  if (singlebyteString.length > multibyteString.length && !multibyteString.includes('\uFFFD')) {
++  // Strings can be multibyte-encoded or not.
++  // Fast path: all ASCII (bytes < 0x80) -> fromCharCode directly, no TextDecoder.
++  // Slow path: try UTF-8, fall back to Latin-1 if UTF-8 produces replacement chars.
++  var start = this.pos
++  var end = start + len
++  var buffer = this.buffer
++  var allAscii = true
++  for (var i = start; i < end; i++) {
++    if (buffer[i] >= 0x80) { allAscii = false; break }
++  }
++  this.pos = end
++  if (allAscii) {
++    // fromCharCode.apply is the fastest path for small ASCII strings.
++    // For very long strings, the stack can blow up — chunk it.
++    var CHUNK = 0x8000
++    if (len <= CHUNK) {
++      // Use subarray (no copy) when available (Uint8Array); fall back to slice for plain arrays.
++      var view = buffer.subarray ? buffer.subarray(start, end) : buffer.slice(start, end)
++      return String.fromCharCode.apply(null, view)
++    }
++    var out = ''
++    for (var j = start; j < end; j += CHUNK) {
++      var chunkEnd = j + CHUNK < end ? j + CHUNK : end
++      var chunk = buffer.subarray ? buffer.subarray(j, chunkEnd) : buffer.slice(j, chunkEnd)
++      out += String.fromCharCode.apply(null, chunk)
++    }
++    return out
++  }
++  // Non-ASCII: try UTF-8 decode; fall back to Latin-1 (fromCharCode per byte) if
++  // UTF-8 produced replacement chars or didn't shorten the string.
++  var bytes = buffer.subarray ? buffer.subarray(start, end) : buffer.slice(start, end)
++  var multibyteString = sharedUtf8Decoder.decode(bytes)
++  // Latin-1 interpretation: each byte → one codepoint. Length equals `len`.
++  if (multibyteString.length < len && multibyteString.indexOf('\uFFFD') === -1) {
 +    return multibyteString
 +  }
-+  return singlebyteString
++  // Build Latin-1 string via fromCharCode on the byte values.
++  return String.fromCharCode.apply(null, bytes)
  }
  
  Parser.prototype.readVarInt = function() {

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -309,6 +309,12 @@ function getFileSections(chartText: string) {
  * out from textEvents since they're consumed as disco flip modifiers. */
 const chartDiscoFlipRegex = /^\s*\[?mix[ _][0-3][ _]drums[0-5](d|dnoflip|easy|easynokick|)\]?\s*$/
 
+// Hoisted regexes — avoid re-parsing on every parseTrackLine call.
+const chartLineEQuoted = /^(\d+) = E "([^"\r\n]*)"$/
+const chartLineEUnquoted = /^(\d+) = E ([^\r\n]+?)$/
+const chartLineNS = /^(\d+) = ([NS]) (\w+)( \d+)?$/
+const chartLineDiscoFlipE = /^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/
+
 /**
  * Events parsed from a single .chart track line. Note-shaped events flow into
  * `trackEvents` and friends via the distribution loop; text and versus events
@@ -330,8 +336,25 @@ type ParsedTrackLine = ParsedNoteEvent | ParsedTextEvent | ParsedVersusEvent
  *   TICK = N VALUE LENGTH    → note (with instrument-specific mapping)
  */
 function parseTrackLine(line: string, instrument: Instrument, difficulty: Difficulty): ParsedTrackLine | null {
+	// Most lines are N/S (notes). Try them first to short-circuit the common case.
+	const nsMatch = chartLineNS.exec(line)
+	if (nsMatch) {
+		const tick = Number(nsMatch[1])
+		const typeCode = nsMatch[2]
+		const value = nsMatch[3]
+		const length = Number(nsMatch[4]) || 0
+		if (typeCode === 'S') {
+			if (value === '0' || value === '1') {
+				return { kind: 'versus', tick, length, isPlayer2: value === '1' }
+			}
+			const type = getSEventType(value)
+			return type !== null ? { kind: 'note', tick, type, length } : null
+		}
+		const type = getNEventType(value, instrument)
+		return type !== null ? { kind: 'note', tick, type, length } : null
+	}
 	// E events have quoted arbitrary text, so handle them separately from N/S.
-	const eMatch = /^(\d+) = E "([^"\r\n]*)"$/.exec(line) ?? /^(\d+) = E ([^\r\n]+?)$/.exec(line)
+	const eMatch = chartLineEQuoted.exec(line) ?? chartLineEUnquoted.exec(line)
 	if (eMatch) {
 		const tick = Number(eMatch[1])
 		const value = eMatch[2]
@@ -343,25 +366,6 @@ function parseTrackLine(line: string, instrument: Instrument, difficulty: Diffic
 		const stripped = value.replace(/^\[/, '').replace(/\]$/, '').trim()
 		if (stripped === 'ENABLE_CHART_DYNAMICS' || stripped === 'ENHANCED_OPENS') return null
 		return { kind: 'text', tick, text: value }
-	}
-	// N/S events have numeric value + optional length
-	const nsMatch = /^(\d+) = ([NS]) (\w+)( \d+)?$/.exec(line)
-	if (nsMatch) {
-		const tick = Number(nsMatch[1])
-		const typeCode = nsMatch[2]
-		const value = nsMatch[3]
-		const length = Number(nsMatch[4]) || 0
-		if (typeCode === 'S') {
-			// S 0 (player 1) / S 1 (player 2) are versus phrases, not note-shaped
-			if (value === '0' || value === '1') {
-				return { kind: 'versus', tick, length, isPlayer2: value === '1' }
-			}
-			const type = getSEventType(value)
-			return type !== null ? { kind: 'note', tick, type, length } : null
-		}
-		// N: instrument-dependent note mapping
-		const type = getNEventType(value, instrument)
-		return type !== null ? { kind: 'note', tick, type, length } : null
 	}
 	return null
 }

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -191,11 +191,13 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				// plus data-carrying events (text, versus). Note-shaped events flow through
 				// the same distribution loop as before; the data-carrying ones are routed
 				// to their dedicated arrays inside the same loop.
-				const parsedEvents = _.chain(lines)
-					.map(line => parseTrackLine(line, instrument, difficulty))
-					.compact()
-					.orderBy('tick') // Most parsers reject charts that aren't already sorted, but it's easier to just sort it here
-					.value()
+				const parsedEvents: ParsedTrackLine[] = []
+				for (const line of lines) {
+					const parsed = parseTrackLine(line, instrument, difficulty)
+					if (parsed !== null) parsedEvents.push(parsed)
+				}
+				// Most parsers reject charts that aren't already sorted, but it's easier to just sort it here
+				parsedEvents.sort((a, b) => a.tick - b.tick)
 
 				// Merge solo/soloend pairs in place (note-shaped events only)
 				const trackEvents = mergeSoloEvents(

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -226,48 +226,69 @@ function getFileSections(chartText: string) {
 	let readStartIndex = 0
 	let readingSection = false
 	let thisSection: string | null = null
-	for (let i = 0; i < chartText.length; i++) {
+	const len = chartText.length
+	for (let i = 0; i < len; i++) {
+		const c = chartText.charCodeAt(i)
 		if (readingSection) {
-			if (chartText[i] === ']') {
+			if (c === 93) { // ']'
 				readingSection = false
 				thisSection = chartText.slice(readStartIndex, i)
-			}
-			if (chartText[i] === '\n') {
+			} else if (c === 10) { // '\n'
 				throw `Invalid .chart file: unexpected new line when parsing section at index ${i}`
 			}
 			continue // Keep reading section until it ends
 		}
 
-		if (chartText[i] === '=') {
+		if (c === 61) { // '='
 			skipLine = true
-		} // Skip all user-entered values
-		if (chartText[i] === '\n') {
+		} else if (c === 10) { // '\n'
 			skipLine = false
 		}
-		if (skipLine) {
-			continue
-		} // Keep skipping until '\n' is found
+		if (skipLine) continue
 
-		if (chartText[i] === '{') {
+		if (c === 123) { // '{'
 			skipLine = true
 			readStartIndex = i + 1
-		} else if (chartText[i] === '}') {
+		} else if (c === 125) { // '}'
 			if (!thisSection) {
 				throw `Invalid .chart file: end of section reached before a section name was found at index ${i}`
 			}
-			// Trim each line because of Windows \r\n shenanigans
-			sections[thisSection] = chartText
-				.slice(readStartIndex, i)
-				.split('\n')
-				.map(line => line.trim())
-				.filter(line => line.length)
-		} else if (chartText[i] === '[') {
+			sections[thisSection] = splitTrimmedNonEmptyLines(chartText, readStartIndex, i)
+		} else if (c === 91) { // '['
 			readStartIndex = i + 1
 			readingSection = true
 		}
 	}
 
 	return sections
+}
+
+/**
+ * Slice `source` from `start` to `end`, split on '\n', trim each line, and
+ * drop empty results — in one pass with no intermediate arrays.
+ */
+function splitTrimmedNonEmptyLines(source: string, start: number, end: number): string[] {
+	const out: string[] = []
+	let lineStart = start
+	for (let i = start; i <= end; i++) {
+		if (i === end || source.charCodeAt(i) === 10) {
+			// trim the slice [lineStart, i)
+			let a = lineStart, b = i
+			while (a < b) {
+				const cc = source.charCodeAt(a)
+				if (cc !== 32 && cc !== 9 && cc !== 13) break
+				a++
+			}
+			while (b > a) {
+				const cc = source.charCodeAt(b - 1)
+				if (cc !== 32 && cc !== 9 && cc !== 13) break
+				b--
+			}
+			if (b > a) out.push(source.slice(a, b))
+			lineStart = i + 1
+		}
+	}
+	return out
 }
 
 /** Regex matching disco flip mix events (any difficulty). Used to filter them

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -130,45 +130,8 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 				unrecognizedMidiEvents: [],
 			},
 		},
-		tempos: _.chain(fileSections['SyncTrack'])
-			.map(line => /^(\d+) = B (\d+)$/.exec(line))
-			.compact()
-			.map(([, stringTick, stringMillibeatsPerMinute]) => ({
-				tick: Number(stringTick),
-				beatsPerMinute: Number(stringMillibeatsPerMinute) / 1000,
-			}))
-			.tap(tempos => {
-				const zeroTempo = tempos.find(tempo => tempo.beatsPerMinute === 0)
-				if (zeroTempo) {
-					throw `Invalid .chart file: Tempo at tick ${zeroTempo.tick} was zero.`
-				}
-				if (!tempos[0] || tempos[0].tick !== 0) {
-					tempos.unshift({ tick: 0, beatsPerMinute: 120 })
-				}
-			})
-			.value(),
-		timeSignatures: _.chain(fileSections['SyncTrack'])
-			.map(line => /^(\d+) = TS (\d+)(?: (\d+))?$/.exec(line))
-			.compact()
-			.map(([, stringTick, stringNumerator, stringDenominatorExp]) => ({
-				tick: Number(stringTick),
-				numerator: Number(stringNumerator),
-				denominator: stringDenominatorExp ? Math.pow(2, Number(stringDenominatorExp)) : 4,
-			}))
-			.tap(timeSignatures => {
-				const zeroTimeSignatureN = timeSignatures.find(timeSignature => timeSignature.numerator === 0)
-				const zeroTimeSignatureD = timeSignatures.find(timeSignature => timeSignature.denominator === 0)
-				if (zeroTimeSignatureN) {
-					throw `Invalid .mid file: Time signature numerator at tick ${zeroTimeSignatureN.tick} was zero.`
-				}
-				if (zeroTimeSignatureD) {
-					throw `Invalid .mid file: Time signature denominator at tick ${zeroTimeSignatureD.tick} was zero.`
-				}
-				if (!timeSignatures[0] || timeSignatures[0].tick !== 0) {
-					timeSignatures.unshift({ tick: 0, numerator: 4, denominator: 4 })
-				}
-			})
-			.value(),
+		tempos: parseChartTempos(fileSections['SyncTrack']),
+		timeSignatures: parseChartTimeSignatures(fileSections['SyncTrack']),
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
@@ -316,6 +279,53 @@ const chartLineEQuoted = /^(\d+) = E "([^"\r\n]*)"$/
 const chartLineEUnquoted = /^(\d+) = E ([^\r\n]+?)$/
 const chartLineNS = /^(\d+) = ([NS]) (\w+)( \d+)?$/
 const chartLineDiscoFlipE = /^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/
+const chartSyncTempo = /^(\d+) = B (\d+)$/
+const chartSyncTS = /^(\d+) = TS (\d+)(?: (\d+))?$/
+
+function parseChartTempos(lines: string[]): { tick: number; beatsPerMinute: number }[] {
+	const tempos: { tick: number; beatsPerMinute: number }[] = []
+	for (const line of lines) {
+		const m = chartSyncTempo.exec(line)
+		if (!m) continue
+		tempos.push({ tick: Number(m[1]), beatsPerMinute: Number(m[2]) / 1000 })
+	}
+	for (const tempo of tempos) {
+		if (tempo.beatsPerMinute === 0) {
+			throw `Invalid .chart file: Tempo at tick ${tempo.tick} was zero.`
+		}
+	}
+	if (!tempos[0] || tempos[0].tick !== 0) {
+		tempos.unshift({ tick: 0, beatsPerMinute: 120 })
+	}
+	return tempos
+}
+
+function parseChartTimeSignatures(lines: string[]): { tick: number; numerator: number; denominator: number }[] {
+	const result: { tick: number; numerator: number; denominator: number }[] = []
+	for (const line of lines) {
+		const m = chartSyncTS.exec(line)
+		if (!m) continue
+		result.push({
+			tick: Number(m[1]),
+			numerator: Number(m[2]),
+			denominator: m[3] ? Math.pow(2, Number(m[3])) : 4,
+		})
+	}
+	for (const ts of result) {
+		if (ts.numerator === 0) {
+			throw `Invalid .mid file: Time signature numerator at tick ${ts.tick} was zero.`
+		}
+	}
+	for (const ts of result) {
+		if (ts.denominator === 0) {
+			throw `Invalid .mid file: Time signature denominator at tick ${ts.tick} was zero.`
+		}
+	}
+	if (!result[0] || result[0].tick !== 0) {
+		result.unshift({ tick: 0, numerator: 4, denominator: 4 })
+	}
+	return result
+}
 
 /**
  * Events parsed from a single .chart track line. Note-shaped events flow into

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -82,16 +82,19 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 	const chartText = decoder.decode(data)
 
 	const fileSections = getFileSections(chartText)
-	if (_.values(fileSections).length === 0) {
+	const fileSectionKeys = Object.keys(fileSections)
+	if (fileSectionKeys.length === 0) {
 		throw 'Invalid .chart file: no sections were found.'
 	}
 
-	const metadata = _.chain(fileSections['Song'])
-		.map(line => /^(.+?) = "?(.*?)"?$/.exec(line))
-		.compact()
-		.map(([, key, value]) => [key, value])
-		.fromPairs()
-		.value()
+	const metadata: { [key: string]: string } = {}
+	const songLines = fileSections['Song']
+	if (songLines) {
+		for (const line of songLines) {
+			const m = chartSongMetaRegex.exec(line)
+			if (m) metadata[m[1]] = m[2]
+		}
+	}
 
 	const resolution = Number(metadata['Resolution'])
 	if (!resolution) {
@@ -137,87 +140,101 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		parseIssues: [],
 		unrecognizedMidiTracks: [], // MIDI-only
-		unrecognizedChartSections: _.chain(fileSections)
-			.toPairs()
-			.filter(([sectionName]) =>
-				sectionName !== 'Song' && sectionName !== 'SyncTrack' && sectionName !== 'Events'
-				&& !(sectionName in trackNameMap),
-			)
-			.map(([name, lines]) => ({ name, lines: [...lines] }))
-			.value(),
-		trackData: _.chain(fileSections)
-			.pick(_.keys(trackNameMap))
-			.toPairs()
-			.map(([trackName, lines]) => {
-				const { instrument, difficulty } = trackNameMap[trackName as TrackName]
-				// Single parsing pass that produces note-shaped events (`{ tick, type, length }`)
-				// plus data-carrying events (text, versus). Note-shaped events flow through
-				// the same distribution loop as before; the data-carrying ones are routed
-				// to their dedicated arrays inside the same loop.
-				const parsedEvents: ParsedTrackLine[] = []
-				for (const line of lines) {
-					const parsed = parseTrackLine(line, instrument, difficulty)
-					if (parsed !== null) parsedEvents.push(parsed)
-				}
-				// Most parsers reject charts that aren't already sorted, but it's easier to just sort it here
-				parsedEvents.sort((a, b) => a.tick - b.tick)
-
-				// Merge solo/soloend pairs in place (note-shaped events only)
-				const trackEvents = mergeSoloEvents(
-					parsedEvents.filter((e): e is ParsedNoteEvent => e.kind === 'note'),
-				)
-
-				const result: RawChartData['trackData'][number] = {
-					instrument,
-					difficulty,
-					starPowerSections: [],
-					rejectedStarPowerSections: [],
-					soloSections: [],
-					flexLanes: [],
-					drumFreestyleSections: [],
-					trackEvents: [],
-					textEvents: [],
-					versusPhrases: [],
-					animations: [], // .chart format does not have note-based animations
-					unrecognizedMidiEvents: [], // MIDI-only
-				}
-
-				for (const event of trackEvents) {
-					if (event.type === eventTypes.starPower) {
-						result.starPowerSections.push(event)
-					} else if (event.type === eventTypes.rejectedStarPower) {
-						result.rejectedStarPowerSections.push(event)
-					} else if (event.type === eventTypes.soloSection) {
-						result.soloSections.push(event)
-					} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
-						result.flexLanes.push({
-							tick: event.tick,
-							length: event.length,
-							isDouble: event.type === eventTypes.flexLaneDouble,
-						})
-					} else if (event.type === eventTypes.freestyleSection) {
-						result.drumFreestyleSections.push({
-							tick: event.tick,
-							length: event.length,
-							isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
-						})
-					} else {
-						result.trackEvents.push(event)
-					}
-				}
-
-				for (const event of parsedEvents) {
-					if (event.kind === 'text') {
-						result.textEvents.push({ tick: event.tick, text: event.text })
-					} else if (event.kind === 'versus') {
-						result.versusPhrases.push({ tick: event.tick, length: event.length, isPlayer2: event.isPlayer2 })
-					}
-				}
-
-				return result
-			})
-			.value(),
+		unrecognizedChartSections: buildUnrecognizedChartSections(fileSections, fileSectionKeys),
+		trackData: buildChartTrackData(fileSections, firstCodaTick),
 	}
+}
+
+function buildUnrecognizedChartSections(
+	fileSections: { [k: string]: string[] },
+	fileSectionKeys: string[],
+): { name: string; lines: string[] }[] {
+	const out: { name: string; lines: string[] }[] = []
+	for (const name of fileSectionKeys) {
+		if (name === 'Song' || name === 'SyncTrack' || name === 'Events') continue
+		if (name in trackNameMap) continue
+		out.push({ name, lines: [...fileSections[name]] })
+	}
+	return out
+}
+
+function buildChartTrackData(
+	fileSections: { [k: string]: string[] },
+	firstCodaTick: number | null,
+): RawChartData['trackData'] {
+	const out: RawChartData['trackData'] = []
+	// Iterate in `trackNameMap` order (matches lodash's `_.pick(fileSections, _.keys(trackNameMap))`)
+	// so `trackData` output order is deterministic regardless of how the chart file orders sections.
+	for (const trackName of Object.keys(trackNameMap) as TrackName[]) {
+		const lines = fileSections[trackName]
+		if (!lines) continue
+		const { instrument, difficulty } = trackNameMap[trackName]
+
+		// Single parsing pass that produces note-shaped events ({tick, type, length})
+		// plus data-carrying events (text, versus).
+		const parsedEvents: ParsedTrackLine[] = []
+		for (const line of lines) {
+			const parsed = parseTrackLine(line, instrument, difficulty)
+			if (parsed !== null) parsedEvents.push(parsed)
+		}
+		// Most parsers reject charts that aren't already sorted, but sort here for safety.
+		parsedEvents.sort((a, b) => a.tick - b.tick)
+
+		// Merge solo/soloend pairs in place (note-shaped events only)
+		const trackEvents = mergeSoloEvents(
+			parsedEvents.filter((e): e is ParsedNoteEvent => e.kind === 'note'),
+		)
+
+		const result: RawChartData['trackData'][number] = {
+			instrument,
+			difficulty,
+			starPowerSections: [],
+			rejectedStarPowerSections: [],
+			soloSections: [],
+			flexLanes: [],
+			drumFreestyleSections: [],
+			trackEvents: [],
+			textEvents: [],
+			versusPhrases: [],
+			animations: [],
+			unrecognizedMidiEvents: [],
+		}
+
+		for (const event of trackEvents) {
+			if (event.type === eventTypes.starPower) {
+				result.starPowerSections.push(event)
+			} else if (event.type === eventTypes.rejectedStarPower) {
+				result.rejectedStarPowerSections.push(event)
+			} else if (event.type === eventTypes.soloSection) {
+				result.soloSections.push(event)
+			} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
+				result.flexLanes.push({
+					tick: event.tick,
+					length: event.length,
+					isDouble: event.type === eventTypes.flexLaneDouble,
+				})
+			} else if (event.type === eventTypes.freestyleSection) {
+				result.drumFreestyleSections.push({
+					tick: event.tick,
+					length: event.length,
+					isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
+				})
+			} else {
+				result.trackEvents.push(event)
+			}
+		}
+
+		for (const event of parsedEvents) {
+			if (event.kind === 'text') {
+				result.textEvents.push({ tick: event.tick, text: event.text })
+			} else if (event.kind === 'versus') {
+				result.versusPhrases.push({ tick: event.tick, length: event.length, isPlayer2: event.isPlayer2 })
+			}
+		}
+
+		out.push(result)
+	}
+	return out
 }
 
 function getFileSections(chartText: string) {
@@ -302,6 +319,7 @@ const chartLineNS = /^(\d+) = ([NS]) (\w+)( \d+)?$/
 const chartLineDiscoFlipE = /^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/
 const chartSyncTempo = /^(\d+) = B (\d+)$/
 const chartSyncTS = /^(\d+) = TS (\d+)(?: (\d+))?$/
+const chartSongMetaRegex = /^(.+?) = "?(.*?)"?$/
 
 function parseChartTempos(lines: string[]): { tick: number; beatsPerMinute: number }[] {
 	const tempos: { tick: number; beatsPerMinute: number }[] = []

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash'
-
 import { Difficulty, Instrument } from 'src/interfaces'
 import { getEncoding } from 'src/utils'
 import { EventType, eventTypes, RawChartData } from './note-parsing-interfaces'
@@ -579,7 +577,14 @@ function mergeSoloEvents(events: { tick: number; type: EventType; length: number
 		}
 	}
 
-	_.remove(events, event => event.type === eventTypes.soloSectionStart || event.type === eventTypes.soloSectionEnd)
+	let w = 0
+	for (let r = 0; r < events.length; r++) {
+		const t = events[r].type
+		if (t !== eventTypes.soloSectionStart && t !== eventTypes.soloSectionEnd) {
+			events[w++] = events[r]
+		}
+	}
+	events.length = w
 
 	return events
 }

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -196,44 +196,8 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		chartTicksPerBeat: midiFile.header.ticksPerBeat,
 		metadata: {}, // .mid does not have a mechanism for storing song metadata
 		vocalTracks,
-		tempos: _.chain(midiFile.tracks[0])
-			.filter((e): e is MidiSetTempoEvent => e.type === 'setTempo')
-			.map(e => ({
-				tick: e.deltaTime,
-				// Note that this operation is float64 division, and is impacted by floating point precision errors
-				beatsPerMinute: 60000000 / e.microsecondsPerBeat,
-			}))
-			.tap(tempos => {
-				const zeroTempo = tempos.find(tempo => tempo.beatsPerMinute === 0)
-				if (zeroTempo) {
-					throw `Invalid .mid file: Tempo at tick ${zeroTempo.tick} was zero.`
-				}
-				if (!tempos[0] || tempos[0].tick !== 0) {
-					tempos.unshift({ tick: 0, beatsPerMinute: 120 })
-				}
-			})
-			.value(),
-		timeSignatures: _.chain(midiFile.tracks[0])
-			.filter((e): e is MidiTimeSignatureEvent => e.type === 'timeSignature')
-			.map(e => ({
-				tick: e.deltaTime,
-				numerator: e.numerator,
-				denominator: e.denominator,
-			}))
-			.tap(timeSignatures => {
-				const zeroTimeSignatureN = timeSignatures.find(timeSignature => timeSignature.numerator === 0)
-				const zeroTimeSignatureD = timeSignatures.find(timeSignature => timeSignature.denominator === 0)
-				if (zeroTimeSignatureN) {
-					throw `Invalid .mid file: Time signature numerator at tick ${zeroTimeSignatureN.tick} was zero.`
-				}
-				if (zeroTimeSignatureD) {
-					throw `Invalid .mid file: Time signature denominator at tick ${zeroTimeSignatureD.tick} was zero.`
-				}
-				if (!timeSignatures[0] || timeSignatures[0].tick !== 0) {
-					timeSignatures.unshift({ tick: 0, numerator: 4, denominator: 4 })
-				}
-			})
-			.value(),
+		tempos: extractTempos(midiFile.tracks[0]),
+		timeSignatures: extractTimeSignatures(midiFile.tracks[0]),
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
@@ -320,6 +284,49 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 			.value(),
 		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 	}
+}
+
+function extractTempos(conductorTrack: MidiEvent[]): { tick: number; beatsPerMinute: number }[] {
+	const tempos: { tick: number; beatsPerMinute: number }[] = []
+	for (const e of conductorTrack) {
+		if (e.type !== 'setTempo') continue
+		tempos.push({
+			tick: e.deltaTime,
+			beatsPerMinute: 60000000 / (e as MidiSetTempoEvent).microsecondsPerBeat,
+		})
+	}
+	for (const tempo of tempos) {
+		if (tempo.beatsPerMinute === 0) {
+			throw `Invalid .mid file: Tempo at tick ${tempo.tick} was zero.`
+		}
+	}
+	if (!tempos[0] || tempos[0].tick !== 0) {
+		tempos.unshift({ tick: 0, beatsPerMinute: 120 })
+	}
+	return tempos
+}
+
+function extractTimeSignatures(conductorTrack: MidiEvent[]): { tick: number; numerator: number; denominator: number }[] {
+	const result: { tick: number; numerator: number; denominator: number }[] = []
+	for (const e of conductorTrack) {
+		if (e.type !== 'timeSignature') continue
+		const ts = e as MidiTimeSignatureEvent
+		result.push({ tick: e.deltaTime, numerator: ts.numerator, denominator: ts.denominator })
+	}
+	for (const ts of result) {
+		if (ts.numerator === 0) {
+			throw `Invalid .mid file: Time signature numerator at tick ${ts.tick} was zero.`
+		}
+	}
+	for (const ts of result) {
+		if (ts.denominator === 0) {
+			throw `Invalid .mid file: Time signature denominator at tick ${ts.tick} was zero.`
+		}
+	}
+	if (!result[0] || result[0].tick !== 0) {
+		result.unshift({ tick: 0, numerator: 4, denominator: 4 })
+	}
+	return result
 }
 
 function convertToAbsoluteTime(midiData: MidiData) {

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash'
 import { MidiData, MidiEvent, MidiSetTempoEvent, MidiTextEvent, MidiTimeSignatureEvent, parseMidi } from 'midi-file'
 
 import { difficulties, Difficulty, getInstrumentType, Instrument, InstrumentType, instrumentTypes } from 'src/interfaces'
@@ -872,9 +871,8 @@ function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent
 				continue
 			}
 
-			// In-place removal of ended modifiers. Equivalent to the original
-			// _.remove predicate: zero-length modifiers die when event.tick
-			// passes them; nonzero die when event.tick reaches their end.
+			// In-place removal of ended modifiers. Zero-length modifiers die when
+			// event.tick passes them; nonzero die when event.tick reaches their end.
 			if (activeModifiers.length > 0) {
 				const eventTick = event.tick
 				let w = 0
@@ -1002,20 +1000,22 @@ function fixLegacyGhStarPower(
 }
 
 function fixFlexLaneLds(events: { [key in Difficulty]: MidiTrackEvent[] }) {
-	_.remove(
-		events['easy'],
-		e => (e.type === eventTypes.flexLaneSingle || e.type === eventTypes.flexLaneDouble) && (e.velocity < 21 || e.velocity > 30),
-	)
-	_.remove(
-		events['medium'],
-		e => (e.type === eventTypes.flexLaneSingle || e.type === eventTypes.flexLaneDouble) && (e.velocity < 21 || e.velocity > 40),
-	)
-	_.remove(
-		events['hard'],
-		e => (e.type === eventTypes.flexLaneSingle || e.type === eventTypes.flexLaneDouble) && (e.velocity < 21 || e.velocity > 50),
-	)
-
+	filterFlexLaneVelocity(events.easy, 30)
+	filterFlexLaneVelocity(events.medium, 40)
+	filterFlexLaneVelocity(events.hard, 50)
 	return events
+}
+
+function filterFlexLaneVelocity(arr: MidiTrackEvent[], maxVelocity: number): void {
+	let w = 0
+	for (let r = 0; r < arr.length; r++) {
+		const e = arr[r]
+		const isFlex = e.type === eventTypes.flexLaneSingle || e.type === eventTypes.flexLaneDouble
+		if (!(isFlex && (e.velocity < 21 || e.velocity > maxVelocity))) {
+			arr[w++] = e
+		}
+	}
+	arr.length = w
 }
 
 

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -252,26 +252,25 @@ function buildMidiTrackData(
 			}
 
 			for (const event of trackDifficulties[difficulty]) {
-				if (event.type === eventTypes.starPower) {
-					result.starPowerSections.push(event)
-				} else if (event.type === eventTypes.rejectedStarPower) {
-					result.rejectedStarPowerSections.push(event)
-				} else if (event.type === eventTypes.soloSection) {
-					result.soloSections.push(event)
-				} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
-					result.flexLanes.push({
-						tick: event.tick,
-						length: event.length,
-						isDouble: event.type === eventTypes.flexLaneDouble,
-					})
-				} else if (event.type === eventTypes.freestyleSection) {
-					result.drumFreestyleSections.push({
-						tick: event.tick,
-						length: event.length,
-						isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
-					})
-				} else {
-					result.trackEvents.push(event)
+				switch (event.type) {
+					case eventTypes.starPower:
+						result.starPowerSections.push(event); break
+					case eventTypes.rejectedStarPower:
+						result.rejectedStarPowerSections.push(event); break
+					case eventTypes.soloSection:
+						result.soloSections.push(event); break
+					case eventTypes.flexLaneSingle:
+						result.flexLanes.push({ tick: event.tick, length: event.length, isDouble: false }); break
+					case eventTypes.flexLaneDouble:
+						result.flexLanes.push({ tick: event.tick, length: event.length, isDouble: true }); break
+					case eventTypes.freestyleSection:
+						result.drumFreestyleSections.push({
+							tick: event.tick,
+							length: event.length,
+							isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
+						}); break
+					default:
+						result.trackEvents.push(event)
 				}
 			}
 

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -452,39 +452,9 @@ function scanInstrumentTrack(
 	const unrecognizedEvents: MidiEvent[] = []
 
 	for (const event of events) {
-		// SysEx event (tap modifier or open)
-		if (event.type === 'sysEx' || event.type === 'endSysEx') {
-			// Phase Shift SysEx event header: 50 53 00 00 <diff> <type> <isStart>
-			const isPhaseShiftHeader =
-				event.data.length > 6 &&
-				event.data[0] === 0x50 &&
-				event.data[1] === 0x53 &&
-				event.data[2] === 0x00 &&
-				event.data[3] === 0x00
-			const type =
-				!isPhaseShiftHeader ? null
-				: event.data[5] === 0x01 ? eventTypes.forceOpen
-				: event.data[5] === 0x04 ? eventTypes.forceTap
-				: null
-
-			if (type !== null) {
-				const d = event.data[4]
-				const arr = d === 0xff ? eeAll
-					: d === 0 ? eeEasy
-					: d === 1 ? eeMedium
-					: d === 2 ? eeHard
-					: eeExpert
-				arr.push({
-					tick: event.deltaTime,
-					type,
-					channel: 1,
-					velocity: 127,
-					isStart: event.data[6] === 0x01,
-				})
-			} else {
-				unrecognizedEvents.push(event)
-			}
-		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
+		// Hot path: note events are ~90% of a typical instrument track. Dispatch them
+		// first so we don't fall through sysEx/text checks for every note event.
+		if (event.type === 'noteOn' || event.type === 'noteOff') {
 			// Within this branch, the event is definitely a note event — a noteOn with
 			// velocity 0 is semantically a noteOff for paired-start/end tracking.
 			const isOff = event.type === 'noteOff' || event.velocity === 0
@@ -574,6 +544,40 @@ function scanInstrumentTrack(
 			}
 
 			if (!consumed) unrecognizedEvents.push(event)
+			continue
+		}
+		// SysEx event (tap modifier or open)
+		if (event.type === 'sysEx' || event.type === 'endSysEx') {
+			// Phase Shift SysEx event header: 50 53 00 00 <diff> <type> <isStart>
+			const isPhaseShiftHeader =
+				event.data.length > 6 &&
+				event.data[0] === 0x50 &&
+				event.data[1] === 0x53 &&
+				event.data[2] === 0x00 &&
+				event.data[3] === 0x00
+			const type =
+				!isPhaseShiftHeader ? null
+				: event.data[5] === 0x01 ? eventTypes.forceOpen
+				: event.data[5] === 0x04 ? eventTypes.forceTap
+				: null
+
+			if (type !== null) {
+				const d = event.data[4]
+				const arr = d === 0xff ? eeAll
+					: d === 0 ? eeEasy
+					: d === 1 ? eeMedium
+					: d === 2 ? eeHard
+					: eeExpert
+				arr.push({
+					tick: event.deltaTime,
+					type,
+					channel: 1,
+					velocity: 127,
+					isStart: event.data[6] === 0x01,
+				})
+			} else {
+				unrecognizedEvents.push(event)
+			}
 		} else if (event.type === 'text') {
 			let consumedAsNote = false
 			if (instrumentType === instrumentTypes.drums) {

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -837,7 +837,19 @@ function splitMidiModifierSustains(events: { [key in Difficulty]: MidiTrackEvent
 				continue
 			}
 
-			_.remove(activeModifiers, m => (m.length === 0 ? m.tick + m.length < event.tick : m.tick + m.length <= event.tick))
+			// In-place removal of ended modifiers. Equivalent to the original
+			// _.remove predicate: zero-length modifiers die when event.tick
+			// passes them; nonzero die when event.tick reaches their end.
+			if (activeModifiers.length > 0) {
+				const eventTick = event.tick
+				let w = 0
+				for (let r = 0; r < activeModifiers.length; r++) {
+					const m = activeModifiers[r]
+					const ended = m.length === 0 ? m.tick < eventTick : m.tick + m.length <= eventTick
+					if (!ended) activeModifiers[w++] = m
+				}
+				activeModifiers.length = w
+			}
 
 			if (modifierSustains.includes(event.type)) {
 				activeModifiers.push(event)

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -416,22 +416,28 @@ function scanInstrumentTrack(
 	trackName: string,
 ): TrackScanResult {
 	let enhancedOpens = false
+	const eeAll: TrackEventEnd[] = []
+	const eeExpert: TrackEventEnd[] = []
+	const eeHard: TrackEventEnd[] = []
+	const eeMedium: TrackEventEnd[] = []
+	const eeEasy: TrackEventEnd[] = []
 	const eventEnds: { [difficulty in Difficulty | 'all']: TrackEventEnd[] } = {
-		all: [],
-		expert: [],
-		hard: [],
-		medium: [],
-		easy: [],
+		all: eeAll,
+		expert: eeExpert,
+		hard: eeHard,
+		medium: eeMedium,
+		easy: eeEasy,
 	}
 	const textEvents: { tick: number; text: string }[] = []
-	// Versus phrase + animation collectors need note-on/note-off pairing.
-	const versusStarts = new Map<number, number>() // noteNumber → startTick
+	// Versus phrase 105/106 pairing. Only these two note numbers ever appear,
+	// so hold two scalars instead of a Map allocation.
+	let versusStart105 = -1
+	let versusStart106 = -1
 	const versusPhrases: { tick: number; length: number; isPlayer2: boolean }[] = []
 	const animStarts = new Map<number, number>() // noteNumber → startTick
 	const animations: { tick: number; length: number; noteNumber: number }[] = []
-	const animationFilter = instrumentType === instrumentTypes.drums
-		? (n: number) => n >= 24 && n <= 51
-		: (n: number) => n >= 40 && n <= 59
+	const animMin = instrumentType === instrumentTypes.drums ? 24 : 40
+	const animMax = instrumentType === instrumentTypes.drums ? 51 : 59
 	// Events the typed parser doesn't consume — preserved verbatim for round-trip.
 	const unrecognizedEvents: MidiEvent[] = []
 
@@ -452,7 +458,13 @@ function scanInstrumentTrack(
 				: null
 
 			if (type !== null) {
-				eventEnds[event.data[4] === 0xff ? 'all' : discoFlipDifficultyMap[event.data[4]]].push({
+				const d = event.data[4]
+				const arr = d === 0xff ? eeAll
+					: d === 0 ? eeEasy
+					: d === 1 ? eeMedium
+					: d === 2 ? eeHard
+					: eeExpert
+				arr.push({
 					tick: event.deltaTime,
 					type,
 					channel: 1,
@@ -464,21 +476,26 @@ function scanInstrumentTrack(
 			}
 		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
 			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+			const nn = event.noteNumber
 			let consumed = false
 
 			// Collect versus phrase markers (notes 105/106). These don't overlap
 			// with any note-shaped events, so we don't fall through.
-			if (event.noteNumber === 105 || event.noteNumber === 106) {
+			if (nn === 105) {
 				if (!isOff) {
-					if (!versusStarts.has(event.noteNumber)) {
-						versusStarts.set(event.noteNumber, event.deltaTime)
-					}
-				} else {
-					const startTick = versusStarts.get(event.noteNumber)
-					if (startTick !== undefined) {
-						versusPhrases.push({ tick: startTick, length: event.deltaTime - startTick, isPlayer2: event.noteNumber === 106 })
-						versusStarts.delete(event.noteNumber)
-					}
+					if (versusStart105 === -1) versusStart105 = event.deltaTime
+				} else if (versusStart105 !== -1) {
+					versusPhrases.push({ tick: versusStart105, length: event.deltaTime - versusStart105, isPlayer2: false })
+					versusStart105 = -1
+				}
+				continue
+			}
+			if (nn === 106) {
+				if (!isOff) {
+					if (versusStart106 === -1) versusStart106 = event.deltaTime
+				} else if (versusStart106 !== -1) {
+					versusPhrases.push({ tick: versusStart106, length: event.deltaTime - versusStart106, isPlayer2: true })
+					versusStart106 = -1
 				}
 				continue
 			}
@@ -486,33 +503,33 @@ function scanInstrumentTrack(
 			// Collect animation events (notes 24-51 drums, 40-59 fret). These
 			// overlap with easy-difficulty playable notes (60-66), so the event
 			// must also fall through to the difficulty-based dispatch below.
-			if (animationFilter(event.noteNumber)) {
+			if (nn >= animMin && nn <= animMax) {
 				if (!isOff) {
-					if (!animStarts.has(event.noteNumber)) {
-						animStarts.set(event.noteNumber, event.deltaTime)
+					if (!animStarts.has(nn)) {
+						animStarts.set(nn, event.deltaTime)
 					}
 				} else {
-					const startTick = animStarts.get(event.noteNumber)
+					const startTick = animStarts.get(nn)
 					if (startTick !== undefined) {
-						animations.push({ tick: startTick, length: event.deltaTime - startTick, noteNumber: event.noteNumber })
-						animStarts.delete(event.noteNumber)
+						animations.push({ tick: startTick, length: event.deltaTime - startTick, noteNumber: nn })
+						animStarts.delete(nn)
 					}
 				}
 				consumed = true
 				// fall through — animation note ranges overlap easy-difficulty notes
 			}
 
-			const difficulty =
-				event.noteNumber <= 66 ? 'easy'
-				: event.noteNumber <= 78 ? 'medium'
-				: event.noteNumber <= 90 ? 'hard'
-				: event.noteNumber <= 102 ? 'expert'
-				: 'all'
+			let diffArr: TrackEventEnd[]
+			let difficulty: Difficulty | 'all'
+			if (nn <= 66) { diffArr = eeEasy; difficulty = 'easy' }
+			else if (nn <= 78) { diffArr = eeMedium; difficulty = 'medium' }
+			else if (nn <= 90) { diffArr = eeHard; difficulty = 'hard' }
+			else if (nn <= 102) { diffArr = eeExpert; difficulty = 'expert' }
+			else { diffArr = eeAll; difficulty = 'all' }
 			if (difficulty === 'all') {
-				// Instrument-wide event (solo marker, star power, etc...) (applies to all difficulties)
-				const type = getInstrumentEventType(event.noteNumber)
+				const type = getInstrumentEventType(nn)
 				if (type !== null) {
-					eventEnds[difficulty].push({
+					diffArr.push({
 						tick: event.deltaTime,
 						type,
 						velocity: event.velocity,
@@ -523,12 +540,12 @@ function scanInstrumentTrack(
 				}
 			} else {
 				const type =
-					instrumentType === instrumentTypes.sixFret ? get6FretNoteType(event.noteNumber, difficulty)
-					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(event.noteNumber, difficulty)
-					: instrumentType === instrumentTypes.fiveFret ? get5FretNoteType(event.noteNumber, difficulty, enhancedOpens)
+					instrumentType === instrumentTypes.sixFret ? get6FretNoteType(nn, difficulty)
+					: instrumentType === instrumentTypes.drums ? getDrumsNoteType(nn, difficulty)
+					: instrumentType === instrumentTypes.fiveFret ? get5FretNoteType(nn, difficulty, enhancedOpens)
 					: null
 				if (type !== null) {
-					eventEnds[difficulty].push({
+					diffArr.push({
 						tick: event.deltaTime,
 						type,
 						velocity: event.velocity,

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -73,6 +73,14 @@ const discoFlipDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 const fiveFretDiffStarts = { easy: 59, medium: 71, hard: 83, expert: 95 }
 const sixFretDiffStarts = { easy: 58, medium: 70, hard: 82, expert: 94 }
 const drumsDiffStarts = { easy: 60, medium: 72, hard: 84, expert: 96 }
+const midiDiscoFlipRegex = /^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/
+const eventsBracketedSectionRegex = /^\[(?:section|prc)[ _](.*)\]$/
+const eventsPlainSectionRegex = /^(?:section|prc)[ _](.*)$/
+const eventsEndRegex = /^\[?end\]?$/
+const eventsCodaRegex = /^\s*\[?coda\]?\s*$/
+const eventsLyricRegex = /^\[?\s*lyric[ \t]/
+const eventsPhraseStartRegex = /^\[?phrase_start\]?$/
+const eventsPhraseEndRegex = /^\[?phrase_end\]?$/
 
 interface TrackEventEnd {
 	tick: number
@@ -560,7 +568,7 @@ function scanInstrumentTrack(
 		} else if (event.type === 'text') {
 			let consumedAsNote = false
 			if (instrumentType === instrumentTypes.drums) {
-				const discoFlipMatch = event.text.match(/^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/)
+				const discoFlipMatch = midiDiscoFlipRegex.exec(event.text)
 				if (discoFlipMatch) {
 					const difficulty = sysExDifficultyMap[Number(discoFlipMatch[1])]
 					const flag = discoFlipMatch[3] as 'd' | 'dnoflip' | 'easy' | 'easynokick' | ''
@@ -1043,18 +1051,18 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 		// is the name). Brackets must match as a pair: a trailing `]` is not
 		// stripped unless the text also started with `[`. This preserves section
 		// names that legitimately end in `]` (e.g. `section <b>…</b> [credits]`).
-		const bracketedSection = /^\[(?:section|prc)[ _](.*)\]$/.exec(text)
-		const plainSection = !bracketedSection && /^(?:section|prc)[ _](.*)$/.exec(text)
+		const bracketedSection = eventsBracketedSectionRegex.exec(text)
+		const plainSection = !bracketedSection && eventsPlainSectionRegex.exec(text)
 		if (bracketedSection || plainSection) {
 			const name = (bracketedSection ?? plainSection as RegExpExecArray)[1]
 			result.sections.push({ tick, name })
 			continue
 		}
-		if (/^\[?end\]?$/.test(text)) {
+		if (eventsEndRegex.test(text)) {
 			result.endEvents.push({ tick })
 			continue
 		}
-		if (/^\s*\[?coda\]?\s*$/.test(text)) {
+		if (eventsCodaRegex.test(text)) {
 			result.codaEvents.push({ tick })
 			continue
 		}
@@ -1063,11 +1071,11 @@ function scanEventsTrack(tracks: { trackName: TrackName; trackEvents: MidiEvent[
 		// here. Record a parse issue so consumers can surface the misplacement,
 		// then fall through to unrecognizedEvents so the value round-trips back
 		// out — users can move it to PART VOCALS manually.
-		if (/^\[?\s*lyric[ \t]/.test(text)) {
+		if (eventsLyricRegex.test(text)) {
 			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidLyric' })
-		} else if (/^\[?phrase_start\]?$/.test(text)) {
+		} else if (eventsPhraseStartRegex.test(text)) {
 			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseStart' })
-		} else if (/^\[?phrase_end\]?$/.test(text)) {
+		} else if (eventsPhraseEndRegex.test(text)) {
 			result.parseIssues.push({ instrument: null, difficulty: null, noteIssue: 'invalidPhraseEnd' })
 		}
 

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -203,87 +203,84 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		unrecognizedEvents: eventsScan.unrecognizedEvents,
 		unrecognizedMidiTracks,
 		unrecognizedChartSections: [],
-		trackData: _.chain(tracks)
-			.filter(t => _.keys(instrumentNameMap).includes(t.trackName))
-			.map(t => {
-				const instrument = instrumentNameMap[t.trackName as InstrumentTrackName]
-				const instrumentType = getInstrumentType(instrument)
-				// Single scan pass extracts note-shaped events AND the
-				// data-carrying ones (text, versus, animations), plus the
-				// unrecognized events for round-trip preservation.
-				const { eventEnds, textEvents, versusPhrases, animations, unrecognizedEvents: trackUnrecognized } =
-					scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
-				const distributed = distributeInstrumentEvents(eventEnds) // Removes 'all' difficulty
-				const pairedEvents = getTrackEvents(distributed) // Connects note ends together
-				const trackDifficulties = _.chain(pairedEvents)
-					.thru(events => splitMidiModifierSustains(events, instrumentType))
-					.thru(events => fixLegacyGhStarPower(events, instrumentType, iniChartModifiers))
-					.thru(events => fixFlexLaneLds(events))
-					.value()
-
-				return difficulties.map(difficulty => {
-					const result: RawChartData['trackData'][number] = {
-						instrument,
-						difficulty,
-						starPowerSections: [],
-						rejectedStarPowerSections: [],
-						soloSections: [],
-						flexLanes: [],
-						drumFreestyleSections: [],
-						trackEvents: [],
-						textEvents,
-						versusPhrases,
-						animations,
-						// All difficulties on a single MIDI track share the same
-						// per-track unrecognized events (the writer only emits one
-						// MIDI track, so storing them once is fine — the writer
-						// reads from any difficulty).
-						unrecognizedMidiEvents: trackUnrecognized,
-					}
-
-					for (const event of trackDifficulties[difficulty]) {
-						if (event.type === eventTypes.starPower) {
-							result.starPowerSections.push(event)
-						} else if (event.type === eventTypes.rejectedStarPower) {
-							result.rejectedStarPowerSections.push(event)
-						} else if (event.type === eventTypes.soloSection) {
-							result.soloSections.push(event)
-						} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
-							result.flexLanes.push({
-								tick: event.tick,
-								length: event.length,
-								isDouble: event.type === eventTypes.flexLaneDouble,
-							})
-						} else if (event.type === eventTypes.freestyleSection) {
-							result.drumFreestyleSections.push({
-								tick: event.tick,
-								length: event.length,
-								isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
-							})
-						} else {
-							result.trackEvents.push(event)
-						}
-					}
-
-					return result
-				})
-			})
-			.flatMap()
-			.filter(track => {
-				// A track must have "real" content — actual notes or scorable sections.
-				// Tracks with only global modifier events (e.g. [ENABLE_CHART_DYNAMICS])
-				// and no actual notes should be filtered out so that round-trip behavior
-				// is stable (the writer doesn't need to emit placeholder text events).
-				const hasRealTrackEvents = track.trackEvents.some(e =>
-					e.type !== eventTypes.enableChartDynamics,
-				)
-				return hasRealTrackEvents
-					|| track.starPowerSections.length > 0
-					|| track.soloSections.length > 0
-			})
-			.value(),
+		trackData: buildMidiTrackData(tracks, iniChartModifiers, firstCodaTick),
 		parseIssues: [...parseIssues, ...eventsScan.parseIssues],
 	}
+}
+
+function buildMidiTrackData(
+	tracks: { trackName: TrackName; trackEvents: MidiEvent[] }[],
+	iniChartModifiers: IniChartModifiers,
+	firstCodaTick: number | null,
+): RawChartData['trackData'] {
+	const out: RawChartData['trackData'] = []
+
+	for (const t of tracks) {
+		const instrument = instrumentNameMap[t.trackName as InstrumentTrackName]
+		if (instrument === undefined) continue // vocal/EVENTS tracks handled elsewhere
+		const instrumentType = getInstrumentType(instrument)
+		const { eventEnds, textEvents, versusPhrases, animations, unrecognizedEvents: trackUnrecognized } =
+			scanInstrumentTrack(t.trackEvents, instrumentType, t.trackName)
+		const distributed = distributeInstrumentEvents(eventEnds)
+		const pairedEvents = getTrackEvents(distributed)
+		const step1 = splitMidiModifierSustains(pairedEvents, instrumentType)
+		const step2 = fixLegacyGhStarPower(step1, instrumentType, iniChartModifiers)
+		const trackDifficulties = fixFlexLaneLds(step2)
+
+		for (const difficulty of difficulties) {
+			const result: RawChartData['trackData'][number] = {
+				instrument,
+				difficulty,
+				starPowerSections: [],
+				rejectedStarPowerSections: [],
+				soloSections: [],
+				flexLanes: [],
+				drumFreestyleSections: [],
+				trackEvents: [],
+				textEvents,
+				versusPhrases,
+				animations,
+				unrecognizedMidiEvents: trackUnrecognized,
+			}
+
+			for (const event of trackDifficulties[difficulty]) {
+				if (event.type === eventTypes.starPower) {
+					result.starPowerSections.push(event)
+				} else if (event.type === eventTypes.rejectedStarPower) {
+					result.rejectedStarPowerSections.push(event)
+				} else if (event.type === eventTypes.soloSection) {
+					result.soloSections.push(event)
+				} else if (event.type === eventTypes.flexLaneSingle || event.type === eventTypes.flexLaneDouble) {
+					result.flexLanes.push({
+						tick: event.tick,
+						length: event.length,
+						isDouble: event.type === eventTypes.flexLaneDouble,
+					})
+				} else if (event.type === eventTypes.freestyleSection) {
+					result.drumFreestyleSections.push({
+						tick: event.tick,
+						length: event.length,
+						isCoda: firstCodaTick === null ? false : event.tick >= firstCodaTick,
+					})
+				} else {
+					result.trackEvents.push(event)
+				}
+			}
+
+			// A track must have real content — actual notes or scorable sections.
+			// Tracks with only global modifier events (e.g. [ENABLE_CHART_DYNAMICS])
+			// and no notes are dropped so writer round-trip stays stable.
+			let hasRealTrackEvents = false
+			for (const e of result.trackEvents) {
+				if (e.type !== eventTypes.enableChartDynamics) { hasRealTrackEvents = true; break }
+			}
+			if (hasRealTrackEvents || result.starPowerSections.length > 0 || result.soloSections.length > 0) {
+				out.push(result)
+			}
+		}
+	}
+
+	return out
 }
 
 function extractTempos(conductorTrack: MidiEvent[]): { tick: number; beatsPerMinute: number }[] {

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -452,17 +452,17 @@ function scanInstrumentTrack(
 	const unrecognizedEvents: MidiEvent[] = []
 
 	for (const event of events) {
+		const eventType = event.type
 		// Hot path: note events are ~90% of a typical instrument track. Dispatch them
 		// first so we don't fall through sysEx/text checks for every note event.
-		if (event.type === 'noteOn' || event.type === 'noteOff') {
-			// Within this branch, the event is definitely a note event — a noteOn with
-			// velocity 0 is semantically a noteOff for paired-start/end tracking.
-			const isOff = event.type === 'noteOff' || event.velocity === 0
-			// Note: `isStart` tracks the literal MIDI event type (not velocity),
-			// matching the original semantics that downstream code relies on.
-			const isStart = event.type === 'noteOn'
-			const nn = event.noteNumber
+		if (eventType === 'noteOn' || eventType === 'noteOff') {
+			// A noteOn with velocity 0 is semantically a noteOff for paired-start/end tracking,
+			// but `isStart` tracks the literal MIDI event type (not velocity) to match original
+			// downstream semantics.
+			const isStart = eventType === 'noteOn'
 			const velocity = event.velocity
+			const isOff = !isStart || velocity === 0
+			const nn = event.noteNumber
 			const channel = event.channel
 			let consumed = false
 
@@ -547,7 +547,7 @@ function scanInstrumentTrack(
 			continue
 		}
 		// SysEx event (tap modifier or open)
-		if (event.type === 'sysEx' || event.type === 'endSysEx') {
+		if (eventType === 'sysEx' || eventType === 'endSysEx') {
 			// Phase Shift SysEx event header: 50 53 00 00 <diff> <type> <isStart>
 			const isPhaseShiftHeader =
 				event.data.length > 6 &&
@@ -578,7 +578,7 @@ function scanInstrumentTrack(
 			} else {
 				unrecognizedEvents.push(event)
 			}
-		} else if (event.type === 'text') {
+		} else if (eventType === 'text') {
 			let consumedAsNote = false
 			if (instrumentType === instrumentTypes.drums) {
 				const discoFlipMatch = midiDiscoFlipRegex.exec(event.text)
@@ -614,7 +614,7 @@ function scanInstrumentTrack(
 				if (event.deltaTime === 0 && event.text === trackName) continue
 				textEvents.push({ tick: event.deltaTime, text: event.text })
 			}
-		} else if (event.type === 'trackName' || event.type === 'endOfTrack') {
+		} else if (eventType === 'trackName' || eventType === 'endOfTrack') {
 			// Trackname is the track identifier; endOfTrack is the MIDI marker.
 			// Both are required structural events — writers re-emit them — so
 			// they shouldn't appear in unrecognizedEvents.

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -236,6 +236,9 @@ function buildMidiTrackData(
 		const trackDifficulties = fixFlexLaneLds(step2)
 
 		for (const difficulty of difficulties) {
+			const diffEvents = trackDifficulties[difficulty]
+			if (diffEvents.length === 0) continue // uncharted difficulty — no need to allocate/emit
+
 			const result: RawChartData['trackData'][number] = {
 				instrument,
 				difficulty,
@@ -254,7 +257,7 @@ function buildMidiTrackData(
 			// Track "real content" flag inline so we don't need a second pass over
 			// result.trackEvents to decide whether to keep this difficulty result.
 			let hasRealTrackEvents = false
-			for (const event of trackDifficulties[difficulty]) {
+			for (const event of diffEvents) {
 				switch (event.type) {
 					case eventTypes.starPower:
 						result.starPowerSections.push(event); break

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -251,6 +251,9 @@ function buildMidiTrackData(
 				unrecognizedMidiEvents: trackUnrecognized,
 			}
 
+			// Track "real content" flag inline so we don't need a second pass over
+			// result.trackEvents to decide whether to keep this difficulty result.
+			let hasRealTrackEvents = false
 			for (const event of trackDifficulties[difficulty]) {
 				switch (event.type) {
 					case eventTypes.starPower:
@@ -271,16 +274,14 @@ function buildMidiTrackData(
 						}); break
 					default:
 						result.trackEvents.push(event)
+						if (!hasRealTrackEvents && event.type !== eventTypes.enableChartDynamics) {
+							hasRealTrackEvents = true
+						}
 				}
 			}
 
-			// A track must have real content — actual notes or scorable sections.
 			// Tracks with only global modifier events (e.g. [ENABLE_CHART_DYNAMICS])
 			// and no notes are dropped so writer round-trip stays stable.
-			let hasRealTrackEvents = false
-			for (const e of result.trackEvents) {
-				if (e.type !== eventTypes.enableChartDynamics) { hasRealTrackEvents = true; break }
-			}
 			if (hasRealTrackEvents || result.starPowerSections.length > 0 || result.soloSections.length > 0) {
 				out.push(result)
 			}

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -714,16 +714,29 @@ function distributeInstrumentEvents(eventEnds: { [difficulty in Difficulty | 'al
 			if (eventEnds[difficulty].length === 0) {
 				continue // Skip adding modifiers to uncharted difficulties
 			}
-			eventEnds[difficulty].push(_.clone(instrumentEvent))
+			eventEnds[difficulty].push({
+				tick: instrumentEvent.tick,
+				type: instrumentEvent.type,
+				velocity: instrumentEvent.velocity,
+				channel: instrumentEvent.channel,
+				isStart: instrumentEvent.isStart,
+			})
 		}
 	}
 
 	return {
-		expert: _.orderBy(eventEnds.expert, ['tick', 'type'], ['asc', 'desc']),
-		hard: _.orderBy(eventEnds.hard, ['tick', 'type'], ['asc', 'desc']),
-		medium: _.orderBy(eventEnds.medium, ['tick', 'type'], ['asc', 'desc']),
-		easy: _.orderBy(eventEnds.easy, ['tick', 'type'], ['asc', 'desc']),
+		expert: eventEnds.expert.sort(compareTickAscTypeDesc),
+		hard: eventEnds.hard.sort(compareTickAscTypeDesc),
+		medium: eventEnds.medium.sort(compareTickAscTypeDesc),
+		easy: eventEnds.easy.sort(compareTickAscTypeDesc),
 	}
+}
+
+function compareTickAscTypeDesc(a: TrackEventEnd, b: TrackEventEnd): number {
+	if (a.tick !== b.tick) return a.tick - b.tick
+	if (a.type < b.type) return 1
+	if (a.type > b.type) return -1
+	return 0
 }
 
 /**

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -746,14 +746,13 @@ function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }
 	const trackEvents: { [key in Difficulty]: MidiTrackEvent[] } = { expert: [], hard: [], medium: [], easy: [] }
 
 	for (const difficulty of difficulties) {
-		const partialTrackEventsMap = _.chain(eventTypes)
-			.values()
-			.map(k => [k, []])
-			.fromPairs()
-			.value() as { [key in EventType]: MidiTrackEvent[] }
+		// Lazy partial-event lists keyed by event type. Most types never appear on a
+		// given difficulty, so only allocate a list when we see one.
+		const partialTrackEventsMap: { [key: string]: MidiTrackEvent[] | undefined } = {}
+		const out = trackEvents[difficulty]
 
 		for (const trackEventEnd of trackEventEnds[difficulty]) {
-			const partialTrackEvents = partialTrackEventsMap[trackEventEnd.type]
+			let partialTrackEvents = partialTrackEventsMap[trackEventEnd.type]
 			if (trackEventEnd.isStart) {
 				const partialTrackEvent: MidiTrackEvent = {
 					tick: trackEventEnd.tick,
@@ -762,21 +761,33 @@ function getTrackEvents(trackEventEnds: { [key in Difficulty]: TrackEventEnd[] }
 					velocity: trackEventEnd.velocity,
 					channel: trackEventEnd.channel,
 				}
+				if (partialTrackEvents === undefined) {
+					partialTrackEvents = []
+					partialTrackEventsMap[trackEventEnd.type] = partialTrackEvents
+				}
 				partialTrackEvents.push(partialTrackEvent)
-				trackEvents[difficulty].push(partialTrackEvent)
-			} else if (partialTrackEvents.length) {
+				out.push(partialTrackEvent)
+			} else if (partialTrackEvents !== undefined && partialTrackEvents.length) {
 				let partialTrackEventIndex = partialTrackEvents.length - 1
 				while (partialTrackEventIndex >= 0 && partialTrackEvents[partialTrackEventIndex].channel !== trackEventEnd.channel) {
 					partialTrackEventIndex-- // Find the most recent partial event on the same channel
 				}
 				if (partialTrackEventIndex >= 0) {
-					const partialTrackEvent = _.pullAt(partialTrackEvents, partialTrackEventIndex)[0]
+					const partialTrackEvent = partialTrackEvents[partialTrackEventIndex]
+					partialTrackEvents.splice(partialTrackEventIndex, 1)
 					partialTrackEvent.length = trackEventEnd.tick - partialTrackEvent.tick
 				}
 			}
 		}
 
-		_.remove(trackEvents[difficulty], e => e.length === -1) // Remove all remaining partial events
+		// In-place filter: remove any remaining partial events whose length was never set.
+		let write = 0
+		for (let read = 0; read < out.length; read++) {
+			if (out[read].length !== -1) {
+				out[write++] = out[read]
+			}
+		}
+		out.length = write
 	}
 
 	return trackEvents

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -482,8 +482,15 @@ function scanInstrumentTrack(
 				unrecognizedEvents.push(event)
 			}
 		} else if (event.type === 'noteOn' || event.type === 'noteOff') {
-			const isOff = event.type === 'noteOff' || (event.type === 'noteOn' && event.velocity === 0)
+			// Within this branch, the event is definitely a note event — a noteOn with
+			// velocity 0 is semantically a noteOff for paired-start/end tracking.
+			const isOff = event.type === 'noteOff' || event.velocity === 0
+			// Note: `isStart` tracks the literal MIDI event type (not velocity),
+			// matching the original semantics that downstream code relies on.
+			const isStart = event.type === 'noteOn'
 			const nn = event.noteNumber
+			const velocity = event.velocity
+			const channel = event.channel
 			let consumed = false
 
 			// Collect versus phrase markers (notes 105/106). These don't overlap
@@ -539,9 +546,9 @@ function scanInstrumentTrack(
 					diffArr.push({
 						tick: event.deltaTime,
 						type,
-						velocity: event.velocity,
-						channel: event.channel,
-						isStart: event.type === 'noteOn',
+						velocity,
+						channel,
+						isStart,
 					})
 					consumed = true
 				}
@@ -555,9 +562,9 @@ function scanInstrumentTrack(
 					diffArr.push({
 						tick: event.deltaTime,
 						type,
-						velocity: event.velocity,
-						channel: event.channel,
-						isStart: event.type === 'noteOn',
+						velocity,
+						channel,
+						isStart,
 					})
 					consumed = true
 				}

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -355,6 +355,10 @@ export const noteTypes = {
 	greenDrum: 17,
 } as const
 
+/** Upper bound on noteType integer values — used for dense array-indexed lookups.
+ * Keep in sync with the maximum value in `noteTypes` above. */
+export const noteTypeCount = Math.max(...Object.values(noteTypes)) + 1
+
 /** Note: specific values here are standardized; they are constants used in the track hash calculation. */
 export const noteFlags = {
 	none: 0,

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash'
 
 import { Difficulty, DrumType, drumTypes, getInstrumentType, Instrument, instrumentTypes } from 'src/interfaces'
 import { parseNotesFromChart } from './chart-parser'
@@ -939,13 +938,16 @@ function isFretChord(note: TrackEvent[]) {
 }
 
 function isInFretNote(inNote: TrackEvent[], outerNote: TrackEvent[]) {
-	return (
-		_.differenceBy(
-			inNote.filter(n => isFretNote(n.type)),
-			outerNote.filter(n => isFretNote(n.type)),
-			note => note.type,
-		).length === 0
-	)
+	// True if every fret note type in `inNote` also appears in `outerNote`.
+	for (const n of inNote) {
+		if (!isFretNote(n.type)) continue
+		let found = false
+		for (const o of outerNote) {
+			if (o.type === n.type) { found = true; break }
+		}
+		if (!found) return false
+	}
+	return true
 }
 
 function getFretNoteTypeFromEventType(eventType: EventType): NoteType | null {
@@ -988,7 +990,7 @@ function snapChords(noteGroups: UntimedNoteEvent[][], chord_snap_threshold: numb
 
 	for (let i = 1; i < noteGroups.length; i++) {
 		const noteGroup = noteGroups[i]
-		const lastNoteGroup = _.last(newNoteGroups)!
+		const lastNoteGroup = newNoteGroups[newNoteGroups.length - 1]
 
 		if (noteGroup[0].tick - lastNoteGroup[0].tick >= chord_snap_threshold) {
 			newNoteGroups.push(noteGroup)

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -1058,17 +1058,16 @@ function sortAndFixInvalidEventOverlaps(events: { tick: number; length: number; 
 
 function sortAndFixInvalidNoteOverlaps(noteGroups: UntimedNoteEvent[][]) {
 	for (const noteGroup of noteGroups) {
+		if (noteGroup.length <= 1) continue
 		noteGroup.sort((a, b) => a.type - b.type || b.length - a.length || b.flags - a.flags) // Longest sustain is kept for duplicates
-		let removedNotes: UntimedNoteEvent[] | null = null
-		for (let i = 1; i < noteGroup.length; i++) {
-			if (noteGroup[i].type === noteGroup[i - 1].type) {
-				;(removedNotes ??= []).push(noteGroup[i])
+		// In-place dedup on consecutive same-type entries (first is kept — has longest sustain).
+		let w = 1
+		for (let r = 1; r < noteGroup.length; r++) {
+			if (noteGroup[r].type !== noteGroup[w - 1].type) {
+				noteGroup[w++] = noteGroup[r]
 			}
 		}
-
-		if (removedNotes) {
-			_.pullAll(noteGroup, removedNotes)
-		}
+		noteGroup.length = w
 	}
 
 	const previousNotesOfType = new Map<NoteType, UntimedNoteEvent>()

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -18,6 +18,7 @@ import {
 	noteFlags,
 	NoteType,
 	noteTypes,
+	noteTypeCount,
 	RawChartData,
 	VocalTrackData,
 } from './note-parsing-interfaces'
@@ -1101,11 +1102,12 @@ function sortAndFixInvalidNoteOverlaps(noteGroups: UntimedNoteEvent[][]) {
 		noteGroup.length = w
 	}
 
-	const previousNotesOfType = new Map<NoteType, UntimedNoteEvent>()
+	// noteTypes are dense small integers; array index is faster than Map lookup.
+	const previousNotesOfType: (UntimedNoteEvent | undefined)[] = new Array(noteTypeCount)
 	for (const noteGroup of noteGroups) {
 		for (const note of noteGroup) {
-			const previousNoteOfType = previousNotesOfType.get(note.type)
-			previousNotesOfType.set(note.type, note)
+			const previousNoteOfType = previousNotesOfType[note.type]
+			previousNotesOfType[note.type] = note
 			if (previousNoteOfType && previousNoteOfType.tick + previousNoteOfType.length > note.tick) {
 				note.length = Math.max(note.length, previousNoteOfType.length - (note.tick - previousNoteOfType.tick))
 				previousNoteOfType.length = note.tick - previousNoteOfType.tick

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -784,49 +784,82 @@ function resolveFretModifiers(
 	const noteEventGroups: UntimedNoteEvent[][] = []
 
 	let lastNotes: TrackEvent[] | null = null
-	// trackEventGroups only contain notes and note modifiers
 	for (let i = 0; i < trackEventGroups.length; i++) {
 		const events = trackEventGroups[i]
-		if (events.some(n => n.type === eventTypes.forceOpen)) {
-			// Apply open modifier
-			// Note: it's not possible for a forceOpen event to generate without there also being at least one playable note here
-			const longestEvent = _.maxBy(
-				events.filter(e => isFretNote(e.type)),
-				e => e.length,
-			)!
-			_.remove(events, e => isFretNote(e.type) || e.type === eventTypes.forceOpen)
-			longestEvent.type = eventTypes.open
-			events.push(longestEvent)
+
+		// Single partitioning pass over the group.
+		const notes: TrackEvent[] = []
+		let hasForceOpen = false
+		let hasForceTap = false
+		let hasForceHopo = false
+		let hasForceStrum = false
+		let hasForceUnnatural = false
+		let longestNote: TrackEvent | null = null
+		for (const e of events) {
+			const t = e.type
+			if (isFretNote(t)) {
+				notes.push(e)
+				if (!longestNote || e.length > longestNote.length) longestNote = e
+			} else if (t === eventTypes.forceOpen) {
+				hasForceOpen = true
+			} else if (t === eventTypes.forceTap) {
+				hasForceTap = true
+			} else if (t === eventTypes.forceHopo) {
+				hasForceHopo = true
+			} else if (t === eventTypes.forceStrum) {
+				hasForceStrum = true
+			} else if (t === eventTypes.forceUnnatural) {
+				hasForceUnnatural = true
+			}
 		}
-		const notes = events.filter(e => isFretNote(e.type))
-		if (!notes.length) {
-			continue // Skip any event groups with only modifiers
+
+		let effectiveNotes: TrackEvent[]
+		if (hasForceOpen && longestNote) {
+			// Apply open modifier: drop all fret notes, promote the longest one to `open`.
+			longestNote.type = eventTypes.open
+			effectiveNotes = [longestNote]
+			// Mutate events to drop forceOpen and all fret notes except the promoted one —
+			// keep the original _.remove + push(longestEvent) semantics so callers see the
+			// group with a single promoted event.
+			let w = 0
+			for (let r = 0; r < events.length; r++) {
+				const et = events[r].type
+				if (!isFretNote(et) && et !== eventTypes.forceOpen) events[w++] = events[r]
+			}
+			events.length = w
+			events.push(longestNote)
+		} else {
+			effectiveNotes = notes
 		}
+
+		if (!effectiveNotes.length) continue
 
 		const isNaturalHopo =
 			!!lastNotes &&
-			notes[0].tick - lastNotes[0].tick <= hopoThresholdTicks &&
-			!isFretChord(notes) &&
+			effectiveNotes[0].tick - lastNotes[0].tick <= hopoThresholdTicks &&
+			!isFretChord(effectiveNotes) &&
 			!isSameFretNote(events, lastNotes) &&
 			// This .mid exception is due to compatibility concerns with older games that primarily use .mid
-			!(format === 'mid' && isFretChord(lastNotes) && isInFretNote(notes, lastNotes))
-		const hasForceUnnatural = !!events.find(n => n.type === eventTypes.forceUnnatural)
+			!(format === 'mid' && isFretChord(lastNotes) && isInFretNote(effectiveNotes, lastNotes))
 		const forceResult =
-			events.find(n => n.type === eventTypes.forceTap) ? noteFlags.tap
-			: events.find(n => n.type === eventTypes.forceHopo) ? noteFlags.hopo
-			: events.find(n => n.type === eventTypes.forceStrum) ? noteFlags.strum
+			hasForceTap ? noteFlags.tap
+			: hasForceHopo ? noteFlags.hopo
+			: hasForceStrum ? noteFlags.strum
 			: (hasForceUnnatural && isNaturalHopo) || (!hasForceUnnatural && !isNaturalHopo) ? noteFlags.strum
 			: noteFlags.hopo
-		noteEventGroups.push(
-			notes.map(n => ({
+		const out: UntimedNoteEvent[] = new Array(effectiveNotes.length)
+		for (let j = 0; j < effectiveNotes.length; j++) {
+			const n = effectiveNotes[j]
+			out[j] = {
 				tick: n.tick,
 				length: n.length,
-				type: getFretNoteTypeFromEventType(n.type)!, // Should be the only event types at this point
+				type: getFretNoteTypeFromEventType(n.type)!,
 				flags: forceResult,
-			})),
-		)
+			}
+		}
+		noteEventGroups.push(out)
 
-		lastNotes = notes
+		lastNotes = effectiveNotes
 	}
 
 	return noteEventGroups

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -45,14 +45,16 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		: drumTracks.find(track => track.trackEvents.find(e => isCymbalOrTomMarker(e.type))) ? drumTypes.fourLanePro
 		: drumTracks.find(track => track.trackEvents.find(e => e.type === eventTypes.fiveGreenDrum)) ? drumTypes.fiveLane
 		: drumTypes.fourLane
-	const hasForcedNotes = _.chain(rawChartData.trackData)
-		.filter(track => track.instrument !== 'drums')
-		.some(track =>
-			_.some(track.trackEvents, e => {
-				return e.type === eventTypes.forceUnnatural || e.type === eventTypes.forceHopo || e.type === eventTypes.forceStrum
-			}),
-		)
-		.value()
+	let hasForcedNotes = false
+	outer: for (const track of rawChartData.trackData) {
+		if (track.instrument === 'drums') continue
+		for (const e of track.trackEvents) {
+			if (e.type === eventTypes.forceUnnatural || e.type === eventTypes.forceHopo || e.type === eventTypes.forceStrum) {
+				hasForcedNotes = true
+				break outer
+			}
+		}
+	}
 
 	const normalizedVocalTracks = normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat)
 	// Evaluate trackData first — normalizedVocalTracks is used below for phrase-level hasLyrics check.

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -548,27 +548,43 @@ function trimSustains(
 
 function resolveDrumModifiers(trackEventGroups: TrackEvent[][], drumType: DrumType, format: 'chart' | 'mid'): UntimedNoteEvent[][] {
 	const noteEventGroups: UntimedNoteEvent[][] = []
-	const discoFlipEventTypes = [eventTypes.discoFlipOff, eventTypes.discoFlipOn, eventTypes.discoNoFlipOn] as const
 
-	let activeDiscoFlip: (typeof discoFlipEventTypes)[number] = eventTypes.discoFlipOff
+	let activeDiscoFlip: EventType = eventTypes.discoFlipOff
+	const notes: TrackEvent[] = []
+	const kicks: TrackEvent[] = []
+	const modifiers: EventType[] = []
 	for (const events of trackEventGroups) {
-		const notes = events.filter(e => isDrumNote(e.type) && !isKickNote(e.type))
-		const kicks = events.filter(e => isKickNote(e.type))
-		const modifiers = events.filter(e => !isDrumNote(e.type)).map(m => m.type)
-		const discoFlipModifier = _.chain(modifiers)
-			.filter(e => discoFlipEventTypes.includes(e as (typeof discoFlipEventTypes)[number]))
-			.min()
-			.value()
-		if (discoFlipModifier) {
-			activeDiscoFlip = discoFlipModifier as 51 | 52 | 53 // Set before checked for this event (start inclusive, end exclusive)
+		notes.length = 0
+		kicks.length = 0
+		modifiers.length = 0
+		let flamFlag: number = noteFlags.none
+		let hasOrange = false
+		let hasGreen = false
+		let discoFlipModifier: number | null = null
+
+		for (const e of events) {
+			const t = e.type
+			if (isKickNote(t)) {
+				kicks.push(e)
+			} else if (isDrumNote(t)) {
+				notes.push(e)
+				if (t === eventTypes.fiveGreenDrum) hasGreen = true
+				else if (t === eventTypes.fiveOrangeFourGreenDrum) hasOrange = true
+			} else {
+				modifiers.push(t)
+				if (t === eventTypes.forceFlam) flamFlag = noteFlags.flam
+				if (t === eventTypes.discoFlipOff || t === eventTypes.discoFlipOn || t === eventTypes.discoNoFlipOn) {
+					if (discoFlipModifier === null || t < discoFlipModifier) discoFlipModifier = t
+				}
+			}
 		}
-		if (notes.length + kicks.length === 0) {
-			continue // Skip any event groups with only modifiers
+		if (discoFlipModifier !== null) {
+			activeDiscoFlip = discoFlipModifier as EventType
 		}
+		if (notes.length + kicks.length === 0) continue
 
 		const noteEventGroup: UntimedNoteEvent[] = []
 
-		const flamFlag = modifiers.find(e => e === eventTypes.forceFlam) ? noteFlags.flam : noteFlags.none
 		for (const kick of kicks) {
 			const kickTypeFlag = kick.type === eventTypes.kick ? noteFlags.none : noteFlags.doubleKick
 			noteEventGroup.push({
@@ -579,8 +595,7 @@ function resolveDrumModifiers(trackEventGroups: TrackEvent[][], drumType: DrumTy
 			})
 		}
 
-		const hasOrangeAndGreen =
-			!!notes.find(e => e.type === eventTypes.fiveGreenDrum) && !!notes.find(e => e.type === eventTypes.fiveOrangeFourGreenDrum)
+		const hasOrangeAndGreen = hasOrange && hasGreen
 
 		for (const note of notes) {
 			const type = getDrumNoteTypeFromEventType(note.type, hasOrangeAndGreen)!

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -56,47 +56,32 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 
 	const normalizedVocalTracks = normalizeVocalTracks(rawChartData.vocalTracks, timedTempos, rawChartData.chartTicksPerBeat)
 	// Evaluate trackData first — normalizedVocalTracks is used below for phrase-level hasLyrics check.
-	const trackDataResult = _.chain(rawChartData.trackData)
-			.map(track => {
-				return {
-				instrument: track.instrument,
-				difficulty: track.difficulty,
-				starPowerSections: _.chain(track.starPowerSections)
-					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.thru(events => sortAndFixInvalidEventOverlaps(events))
-					.value(),
-				rejectedStarPowerSections: _.chain(track.rejectedStarPowerSections)
-					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.value(),
-				soloSections: _.chain(track.soloSections)
-					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.thru(events => sortAndFixInvalidEventOverlaps(events))
-					.value(),
-				flexLanes: _.chain(track.flexLanes)
-					.thru(events => setEventMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.thru(events => sortAndFixInvalidFlexLaneOverlaps(events))
-					.value(),
-				drumFreestyleSections: setEventMsTimes(track.drumFreestyleSections, timedTempos, rawChartData.chartTicksPerBeat),
-				textEvents: setEventMsTimes(track.textEvents, timedTempos, rawChartData.chartTicksPerBeat),
-				versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, rawChartData.chartTicksPerBeat),
-				animations: setEventMsTimes(track.animations, timedTempos, rawChartData.chartTicksPerBeat),
-				unrecognizedMidiEvents: track.unrecognizedMidiEvents,
-				noteEventGroups: _.chain(track.trackEvents)
-					.thru(events => trimSustains(events, iniChartModifiers.sustain_cutoff_threshold, rawChartData.chartTicksPerBeat, format))
-					.groupBy(note => note.tick)
-					.values()
-					.thru(eventGroups =>
-						track.instrument === 'drums' ?
-							resolveDrumModifiers(eventGroups, drumType!, format)
-						:	resolveFretModifiers(eventGroups, iniChartModifiers, rawChartData.chartTicksPerBeat, format),
-					)
-					.thru(noteGroups => snapChords(noteGroups, iniChartModifiers.chord_snap_threshold, track.instrument))
-					.tap(noteGroups => sortAndFixInvalidNoteOverlaps(noteGroups))
-					.thru(events => setEventGroupMsTimes(events, timedTempos, rawChartData.chartTicksPerBeat))
-					.value(),
-				}
-			})
-			.value()
+	const tpb = rawChartData.chartTicksPerBeat
+	const trackDataResult = rawChartData.trackData.map(track => {
+		const trimmed = trimSustains(track.trackEvents, iniChartModifiers.sustain_cutoff_threshold, tpb, format)
+		const grouped = groupByTick(trimmed)
+		const resolved = track.instrument === 'drums'
+			? resolveDrumModifiers(grouped, drumType!, format)
+			: resolveFretModifiers(grouped, iniChartModifiers, tpb, format)
+		const snapped = snapChords(resolved, iniChartModifiers.chord_snap_threshold, track.instrument)
+		sortAndFixInvalidNoteOverlaps(snapped)
+		const noteEventGroups = setEventGroupMsTimes(snapped, timedTempos, tpb)
+
+		return {
+			instrument: track.instrument,
+			difficulty: track.difficulty,
+			starPowerSections: sortAndFixInvalidEventOverlaps(setEventMsTimes(track.starPowerSections, timedTempos, tpb)),
+			rejectedStarPowerSections: setEventMsTimes(track.rejectedStarPowerSections, timedTempos, tpb),
+			soloSections: sortAndFixInvalidEventOverlaps(setEventMsTimes(track.soloSections, timedTempos, tpb)),
+			flexLanes: sortAndFixInvalidFlexLaneOverlaps(setEventMsTimes(track.flexLanes, timedTempos, tpb)),
+			drumFreestyleSections: setEventMsTimes(track.drumFreestyleSections, timedTempos, tpb),
+			textEvents: setEventMsTimes(track.textEvents, timedTempos, tpb),
+			versusPhrases: setEventMsTimes(track.versusPhrases, timedTempos, tpb),
+			animations: setEventMsTimes(track.animations, timedTempos, tpb),
+			unrecognizedMidiEvents: track.unrecognizedMidiEvents,
+			noteEventGroups,
+		}
+	})
 
 	return {
 		resolution: rawChartData.chartTicksPerBeat,
@@ -526,6 +511,22 @@ function setEventOrEventGroupMsTimes<T extends { tick: number; length?: number }
 		}
 	}
 	return events as (T & { msTime: number; msLength: number })[][] | (T & { msTime: number; msLength: number })[]
+}
+
+function groupByTick(events: TrackEvent[]): TrackEvent[][] {
+	const groups: TrackEvent[][] = []
+	let currentTick = Number.NaN
+	let currentGroup: TrackEvent[] | null = null
+	for (const e of events) {
+		if (e.tick !== currentTick) {
+			currentTick = e.tick
+			currentGroup = [e]
+			groups.push(currentGroup)
+		} else {
+			currentGroup!.push(e)
+		}
+	}
+	return groups
 }
 
 function trimSustains(

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -1039,40 +1039,36 @@ function snapChords(noteGroups: UntimedNoteEvent[][], chord_snap_threshold: numb
 }
 
 function sortAndFixInvalidFlexLaneOverlaps(events: { tick: number; length: number; isDouble: boolean; msTime: number; msLength: number }[]) {
+	if (events.length <= 1) return events
 	events.sort((a, b) => {
-		if (a.tick !== b.tick) {
-			return a.tick - b.tick
-		}
-		if (a.isDouble !== b.isDouble) {
-			return (a.isDouble ? 1 : 0) - (b.isDouble ? 1 : 0) // false first
-		}
+		if (a.tick !== b.tick) return a.tick - b.tick
+		if (a.isDouble !== b.isDouble) return (a.isDouble ? 1 : 0) - (b.isDouble ? 1 : 0) // false first
 		return b.length - a.length // length descending (longest lane is kept for duplicates)
 	})
-	let removedEvents: { tick: number; length: number; isDouble: boolean; msTime: number; msLength: number }[] | null = null
-	for (let i = 1; i < events.length; i++) {
-		if (events[i].tick === events[i - 1].tick && events[i].isDouble === events[i - 1].isDouble) {
-			;(removedEvents ??= []).push(events[i])
+	// In-place dedup on consecutive same (tick, isDouble) entries.
+	let w = 1
+	for (let r = 1; r < events.length; r++) {
+		if (!(events[r].tick === events[w - 1].tick && events[r].isDouble === events[w - 1].isDouble)) {
+			events[w++] = events[r]
 		}
 	}
-
-	if (removedEvents) {
-		_.pullAll(events, removedEvents)
-	}
-
+	events.length = w
 	return events
 }
 
 function sortAndFixInvalidEventOverlaps(events: { tick: number; length: number; msTime: number; msLength: number }[]) {
-	events.sort((a, b) => a.tick - b.tick || b.length - a.length) // Longest event is kept for duplicates
-	let removedEvents: { tick: number; length: number; msTime: number; msLength: number }[] | null = null
-	for (let i = 1; i < events.length; i++) {
-		if (events[i].tick === events[i - 1].tick) {
-			;(removedEvents ??= []).push(events[i])
+	if (events.length <= 1) {
+		// Empty or single-element arrays have no overlap to resolve.
+	} else {
+		events.sort((a, b) => a.tick - b.tick || b.length - a.length) // Longest event is kept for duplicates
+		// In-place dedup on consecutive same-tick entries.
+		let w = 1
+		for (let r = 1; r < events.length; r++) {
+			if (events[r].tick !== events[w - 1].tick) {
+				events[w++] = events[r]
+			}
 		}
-	}
-
-	if (removedEvents) {
-		_.pullAll(events, removedEvents)
+		events.length = w
 	}
 
 	let previousEvent: { tick: number; length: number; msTime: number; msLength: number } | null = null

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -458,59 +458,54 @@ function setEventGroupMsTimes<T extends { tick: number; length?: number }>(
 	events: T[][],
 	tempos: { tick: number; beatsPerMinute: number; msTime: number }[],
 	chartTicksPerBeat: number,
-) {
-	return setEventOrEventGroupMsTimes(events, tempos, chartTicksPerBeat) as (T & { msTime: number; msLength: number })[][]
+): (T & { msTime: number; msLength: number })[][] {
+	const temposLen = tempos.length
+	let lastTempoIndex = 0
+	for (const group of events) {
+		for (let i = 0; i < group.length; i++) {
+			const ev = group[i] as T & { msTime: number; msLength: number }
+			while (lastTempoIndex + 1 < temposLen && tempos[lastTempoIndex + 1].tick <= ev.tick) lastTempoIndex++
+			const lastTempo = tempos[lastTempoIndex]
+			ev.msTime = lastTempo.msTime + ((ev.tick - lastTempo.tick) * 60000) / (lastTempo.beatsPerMinute * chartTicksPerBeat)
+			const len = ev.length
+			if (len) {
+				let endTempoIndex = lastTempoIndex
+				const endTick = ev.tick + len
+				while (endTempoIndex + 1 < temposLen && tempos[endTempoIndex + 1].tick <= endTick) endTempoIndex++
+				const endTempo = tempos[endTempoIndex]
+				ev.msLength = endTempo.msTime - ev.msTime + ((endTick - endTempo.tick) * 60000) / (endTempo.beatsPerMinute * chartTicksPerBeat)
+			} else {
+				ev.msLength = 0
+			}
+		}
+	}
+	return events as (T & { msTime: number; msLength: number })[][]
 }
+
 function setEventMsTimes<T extends { tick: number; length?: number }>(
 	events: T[],
 	tempos: { tick: number; beatsPerMinute: number; msTime: number }[],
 	chartTicksPerBeat: number,
-) {
-	return setEventOrEventGroupMsTimes(events, tempos, chartTicksPerBeat) as (T & { msTime: number; msLength: number })[]
-}
-function setEventOrEventGroupMsTimes<T extends { tick: number; length?: number }>(
-	events: T[] | T[][],
-	tempos: { tick: number; beatsPerMinute: number; msTime: number }[],
-	chartTicksPerBeat: number,
-) {
+): (T & { msTime: number; msLength: number })[] {
+	const temposLen = tempos.length
 	let lastTempoIndex = 0
-
-	const processNextEvent = (event: T) => {
-		while (tempos[lastTempoIndex + 1] && tempos[lastTempoIndex + 1].tick <= event.tick) {
-			lastTempoIndex++
-		}
-
+	for (let i = 0; i < events.length; i++) {
+		const ev = events[i] as T & { msTime: number; msLength: number }
+		while (lastTempoIndex + 1 < temposLen && tempos[lastTempoIndex + 1].tick <= ev.tick) lastTempoIndex++
 		const lastTempo = tempos[lastTempoIndex]
-		const newEvent = event as T & { msTime: number; msLength: number }
-
-		newEvent.msTime = lastTempo.msTime + ((event.tick - lastTempo.tick) * 60000) / (lastTempo.beatsPerMinute * chartTicksPerBeat)
-
-		if (event.length) {
+		ev.msTime = lastTempo.msTime + ((ev.tick - lastTempo.tick) * 60000) / (lastTempo.beatsPerMinute * chartTicksPerBeat)
+		const len = ev.length
+		if (len) {
 			let endTempoIndex = lastTempoIndex
-			while (tempos[endTempoIndex + 1] && tempos[endTempoIndex + 1].tick <= event.tick + event.length) {
-				endTempoIndex++
-			}
+			const endTick = ev.tick + len
+			while (endTempoIndex + 1 < temposLen && tempos[endTempoIndex + 1].tick <= endTick) endTempoIndex++
 			const endTempo = tempos[endTempoIndex]
-			newEvent.msLength =
-				// eslint-disable-next-line max-len
-				endTempo.msTime - newEvent.msTime + ((event.tick + event.length - endTempo.tick) * 60000) / (endTempo.beatsPerMinute * chartTicksPerBeat)
+			ev.msLength = endTempo.msTime - ev.msTime + ((endTick - endTempo.tick) * 60000) / (endTempo.beatsPerMinute * chartTicksPerBeat)
 		} else {
-			newEvent.msLength = 0
+			ev.msLength = 0
 		}
 	}
-
-	if (Array.isArray(events[0])) {
-		for (const eventGroup of events as T[][]) {
-			for (const event of eventGroup) {
-				processNextEvent(event)
-			}
-		}
-	} else {
-		for (const event of events as T[]) {
-			processNextEvent(event)
-		}
-	}
-	return events as (T & { msTime: number; msLength: number })[][] | (T & { msTime: number; msLength: number })[]
+	return events as (T & { msTime: number; msLength: number })[]
 }
 
 function groupByTick(events: TrackEvent[]): TrackEvent[][] {


### PR DESCRIPTION
Autonomous perf experimentation run against \`parseChartAndIni\`. 31 commits, bottom-up in chronological order of the experiments.

## Results

Measured on 78,046 real charts (BTrack hash baseline at \`~/Desktop/scan-chart-baseline\`):

- **Wall-clock** (\`generate-baseline-hashes.mjs\`, 16 workers): 69.6s → **52.9s** (24% faster, 1.32× speedup)
- **Throughput**: 1,127 → **1,482 charts/s** (+31.5%)
- **Hash mismatches**: **0 / 78,046** — all match baseline
- Succeeded: 78,443 / 78,443 (same), Failed: 0 / 0

## \`parseChartAndIni\`-only microbench (1,800-chart corpus, single-threaded)

- **Mean**: 8.349ms → **3.40ms** (59% reduction)
- **p95**: 18.597ms → **~7.3ms** (~60% reduction)

End-to-end gain (24%) is smaller than microbench gain (59%) because \`scanChart\` also does track hashing, audio/image scanning, and chart-issue detection — none of which were touched here, so they dilute the overall speedup.

## Biggest wins

1. **\`parseChartFile\` trackData**: lodash chain pipeline → native + \`groupByTick\` helper (~19%)
2. **\`distributeInstrumentEvents\`**: native sort + inline spread replacing \`_.orderBy\` + \`_.clone\` (~12%)
3. **\`setEventMsTimes\` / \`setEventGroupMsTimes\`**: specialize each variant, remove closure + polymorphic dispatch (~12%)
4. **\`resolveDrumModifiers\`**: single partitioning pass + reuse scratch arrays (~9%)
5. **\`parseNotesFromMidi\` trackData**: imperative \`buildMidiTrackData\` replacing lodash chain/flatMap/filter (~7%)
6. **tempo/timeSignature extraction**: imperative pass instead of lodash chain (~7%)
7. **\`getTrackEvents\`**: native splice/filter replacing \`_.chain\` / \`_.pullAt\` / \`_.remove\` (~6%)
8. **midi-file patch: \`readString\` fast ASCII path + cached TextDecoder** (~6%)
9. **\`scanInstrumentTrack\`**: cache array refs, scalar versus markers, inline animation filter (~4%)
10. **\`splitMidiModifierSustains\`**: in-place filter replacing \`_.remove\` with closure (~4%)

The common pattern: replacing lodash chains with imperative loops. By the end, \`import * as _ from 'lodash'\` is removed from \`chart-parser\`, \`midi-parser\`, and \`notes-parser\`.

## midi-file patch change

Updates \`patches/midi-file+1.2.4.patch\` with two \`readString\` optimizations:
- Fast ASCII path: detects all-ASCII in one byte scan and skips \`TextDecoder\` entirely
- Cached shared \`TextDecoder\` for non-ASCII (was allocating a new one per event)
- \`readVarInt\` inline buffer access (neutral perf, cleaner)

## Correctness

Zero hash mismatches across 78,046 charts in the BTrack baseline. Verified via \`scripts/validate-hashes.mjs\`.

## Commit structure

Each of the 31 commits is a single atomic change with its measured impact documented in the title prefix (e.g. \`[~19%]\`). Percentages are approximate — per-run noise is ~1% and several commits were kept as neutral lodash-removal cleanups for simplicity / code clarity rather than measured perf.

Individual commit PRs (for easier review) are stacked at \`elicwhite:autoresearch-perf-apr19\` — see PRs #23-#58 (skipping dropped and reopened-as #63/#64/#65) for per-commit review.