### PR TITLE
Consolidate song metadata onto parsedChart.metadata

### DIFF
--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -114,8 +114,12 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 			year: metadata['Year']?.slice(2) || undefined, // Thank you GHTCP, very cool
 			charter: metadata['Charter'] || undefined,
 			diff_guitar: Number(metadata['Difficulty']) || undefined,
-			// "Offset" and "PreviewStart" are in units of seconds
-			delay: Number(metadata['Offset']) ? Number(metadata['Offset']) * 1000 : undefined,
+			// "Offset" and "PreviewStart" are in units of seconds.
+			// NOTE: [Song].Offset is a .chart-only property — distinct from
+			// song.ini's `delay`, which games recognize in .ini (but NOT in
+			// [Song]). We expose [Song].Offset under the `chart_offset` key so
+			// it never collides with the ini-origin `delay` on merge.
+			chart_offset: Number(metadata['Offset']) ? Number(metadata['Offset']) * 1000 : undefined,
 			preview_start_time: Number(metadata['PreviewStart']) ? Number(metadata['PreviewStart']) * 1000 : undefined,
 		},
 		vocalTracks: {

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -1,4 +1,5 @@
 import type { MidiEvent } from 'midi-file'
+import { defaultMetadata } from 'src/ini'
 import { Difficulty, Instrument, NotesData } from 'src/interfaces'
 import { ObjectValues } from 'src/utils'
 
@@ -13,15 +14,24 @@ export interface IniChartModifiers {
 	pro_drums: boolean
 }
 
-export const defaultIniChartModifiers = {
-	song_length: 0,
-	hopo_frequency: 0,
-	eighthnote_hopo: false,
-	multiplier_note: 0,
-	sustain_cutoff_threshold: -1,
-	chord_snap_threshold: 0,
-	five_lane_drums: false,
-	pro_drums: false,
+/**
+ * Projection of the 8 `song.ini` fields that influence chart parsing, with
+ * defaults derived from {@link defaultMetadata}. Exported so consumers who
+ * call `parseChartFile` directly can construct a `Partial<IniChartModifiers>`
+ * on top of known defaults without having to duplicate the values here.
+ *
+ * Kept as a projection (rather than a standalone literal) so these 8 defaults
+ * can never drift from the 40-field source of truth in {@link defaultMetadata}.
+ */
+export const defaultIniChartModifiers: IniChartModifiers = {
+	song_length: defaultMetadata.song_length,
+	hopo_frequency: defaultMetadata.hopo_frequency,
+	eighthnote_hopo: defaultMetadata.eighthnote_hopo,
+	multiplier_note: defaultMetadata.multiplier_note,
+	sustain_cutoff_threshold: defaultMetadata.sustain_cutoff_threshold,
+	chord_snap_threshold: defaultMetadata.chord_snap_threshold,
+	five_lane_drums: defaultMetadata.five_lane_drums,
+	pro_drums: defaultMetadata.pro_drums,
 }
 
 /**
@@ -36,16 +46,22 @@ export const defaultIniChartModifiers = {
  */
 export interface RawChartData {
 	chartTicksPerBeat: number
-	metadata: {
-		name?: string
-		artist?: string
-		album?: string
-		genre?: string
-		year?: string
-		charter?: string
-		diff_guitar?: number
-		delay?: number
-		preview_start_time?: number
+	/**
+	 * Song metadata. Parsers populate only what the source file carries
+	 * (the [Song] section for .chart; nothing for .mid). `parseChartAndIni`
+	 * overlays `song.ini` values on top of this, with ini winning where both
+	 * are present, and populates `extraIniFields` from unknown ini keys.
+	 */
+	metadata: Partial<typeof defaultMetadata> & {
+		/** Unknown song.ini key/value pairs, preserved for round-trip writing. */
+		extraIniFields?: { [key: string]: string }
+		/**
+		 * `[Song].Offset` from the .chart file body, in milliseconds. Distinct
+		 * from the ini-origin `delay` field — games recognize `Offset` only in
+		 * [Song], and `delay` only in song.ini. Kept as a separate key so the
+		 * two never collide on the ini-wins merge in `parseChartAndIni`.
+		 */
+		chart_offset?: number
 	}
 	/**
 	 * Vocal track data keyed by part name.

--- a/src/chart/parse-chart-and-ini.ts
+++ b/src/chart/parse-chart-and-ini.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 
-import { defaultMetadata, scanIni } from '../ini'
+import { scanIni } from '../ini'
 import { FolderIssueType, MetadataIssueType } from '../interfaces'
 import { getExtension, hasChartExtension, hasChartName } from '../utils'
 import { defaultIniChartModifiers, IniChartModifiers } from './note-parsing-interfaces'
@@ -29,15 +29,26 @@ export interface ParseChartAndIniResult {
 	/**
 	 * The parsed chart, or `null` if a chart file could not be found or could
 	 * not be parsed. Inspect `chartFolderIssues` for the reason.
+	 *
+	 * `parsedChart.metadata` holds the normalized metadata: values from
+	 * `song.ini` take precedence over the chart file's `[Song]` section, and
+	 * unknown ini key/value pairs are preserved in `metadata.extraIniFields`
+	 * for round-trip writing.
 	 */
 	parsedChart: ParsedChart | null
+	/**
+	 * `true` if the folder contains a parseable `song.ini` (i.e. a file was
+	 * present AND it had a readable `[Song]` section). Useful for downstream
+	 * checks that only make sense when ini-derived metadata is available —
+	 * e.g. "ini is missing a diff_X value" issues don't apply at all when the
+	 * ini file doesn't exist.
+	 */
+	hasIni: boolean
 	/**
 	 * Folder-level issues from chart file discovery and parsing
 	 * (`noChart`, `invalidChart`, `multipleChart`, `badChart`).
 	 */
 	chartFolderIssues: { folderIssue: FolderIssueType; description: string }[]
-	/** The metadata parsed from `song.ini`, or `null` if no ini was present. */
-	iniMetadata: typeof defaultMetadata | null
 	/**
 	 * Folder-level issues from ini scanning (`noMetadata`, `invalidIni`,
 	 * `invalidMetadata`, `badIniLine`, `multipleIniFiles`).
@@ -45,8 +56,6 @@ export interface ParseChartAndIniResult {
 	iniFolderIssues: { folderIssue: FolderIssueType; description: string }[]
 	/** Validation issues with ini values. */
 	iniMetadataIssues: { metadataIssue: MetadataIssueType; description: string }[]
-	/** ini key/value pairs not in scan-chart's known list. */
-	iniUnknownValues: { [key: string]: string }
 }
 
 /**
@@ -66,7 +75,22 @@ export function parseChartAndIni(files: { fileName: string; data: Uint8Array }[]
 	if (chartData) {
 		try {
 			const inner = parseChartFile(chartData, format!, iniChartModifiers)
+
+			// Merge [Song]-section metadata with song.ini metadata onto a single
+			// `parsedChart.metadata`. song.ini wins where both provide a value —
+			// the ini file is authoritative and the chart file's [Song] block is
+			// a legacy overlap. Unknown ini keys are preserved in `extraIniFields`
+			// for round-trip writing.
+			const mergedMetadata: ParsedChart['metadata'] = {
+				...inner.metadata,
+				...(iniData.metadata ?? {}),
+			}
+			if (Object.keys(iniData.unknownIniValues).length > 0) {
+				mergedMetadata.extraIniFields = { ...iniData.unknownIniValues }
+			}
+
 			parsedChart = Object.assign({}, inner, {
+				metadata: mergedMetadata,
 				chartBytes: chartData,
 				format: format!,
 				iniChartModifiers,
@@ -81,11 +105,10 @@ export function parseChartAndIni(files: { fileName: string; data: Uint8Array }[]
 
 	return {
 		parsedChart,
+		hasIni: iniData.metadata !== null,
 		chartFolderIssues,
-		iniMetadata: iniData.metadata,
 		iniFolderIssues: iniData.folderIssues,
 		iniMetadataIssues: iniData.metadataIssues,
-		iniUnknownValues: iniData.unknownIniValues,
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,15 @@ export function scanChart(
 		chart.chartHash = chartData.chartHash
 		chart.notesData = chartData.notesData
 		const instruments = chartData.notesData.instruments
-		if (parseResult.iniMetadata) {
+		// Missing/extra diff_* issues are ini-centric — they're about whether
+		// the song.ini file declares an appropriate difficulty rating for each
+		// charted instrument. Skip the checks entirely when no ini was parsed:
+		// "ini is missing X" isn't a meaningful complaint if there's no ini at
+		// all (the folder-level `noMetadata` issue already flags that).
+		if (parseResult.hasIni) {
+			const metadata = parseResult.parsedChart.metadata
 			const checkMissingDifficulty = (instrument: Instrument, diffKey: keyof typeof defaultMetadata) => {
-				if (instruments.includes(instrument) && parseResult.iniMetadata![diffKey] === defaultMetadata[diffKey]) {
+				if (instruments.includes(instrument) && metadata[diffKey] === defaultMetadata[diffKey]) {
 					chart.metadataIssues.push({ metadataIssue: 'missingValue', description: `Metadata is missing a "${diffKey}" value.` })
 				}
 			}
@@ -64,12 +70,12 @@ export function scanChart(
 			checkMissingDifficulty('guitarcoopghl', 'diff_guitar_coop_ghl')
 			checkMissingDifficulty('rhythmghl', 'diff_rhythm_ghl')
 			checkMissingDifficulty('bassghl', 'diff_bassghl')
-			if (chartData.notesData.hasVocals && parseResult.iniMetadata.diff_vocals === defaultMetadata.diff_vocals) {
+			if (chartData.notesData.hasVocals && metadata.diff_vocals === defaultMetadata.diff_vocals) {
 				chart.metadataIssues.push({ metadataIssue: 'missingValue', description: 'Metadata is missing a "diff_vocals" value.' })
 			}
 
 			const checkExtraDifficulty = (instrument: Instrument, diffKey: keyof typeof defaultMetadata) => {
-				if (parseResult.iniMetadata![diffKey] !== defaultMetadata[diffKey] && !instruments.includes(instrument)) {
+				if (metadata[diffKey] !== defaultMetadata[diffKey] && !instruments.includes(instrument)) {
 					chart.metadataIssues.push({
 						metadataIssue: 'extraValue',
 						description: `Metadata contains "${diffKey}", but ${instrument} is not charted.`,
@@ -86,7 +92,7 @@ export function scanChart(
 			checkExtraDifficulty('guitarcoopghl', 'diff_guitar_coop_ghl')
 			checkExtraDifficulty('rhythmghl', 'diff_rhythm_ghl')
 			checkExtraDifficulty('bassghl', 'diff_bassghl')
-			if (parseResult.iniMetadata.diff_vocals !== defaultMetadata.diff_vocals && !chartData.notesData.hasVocals) {
+			if (metadata.diff_vocals !== defaultMetadata.diff_vocals && !chartData.notesData.hasVocals) {
 				chart.metadataIssues.push({
 					metadataIssue: 'extraValue',
 					description: 'Metadata contains "diff_vocals", but vocals are not charted.',
@@ -95,17 +101,16 @@ export function scanChart(
 		}
 	}
 
-	if (parseResult.iniMetadata) {
-		// Use metadata from .ini file if it exists (filled in with defaults for properties that are not included)
-		_.assign(chart, parseResult.iniMetadata)
-	} else if (parseResult.parsedChart?.metadata) {
-		// Use metadata from .chart file if it exists
-		_.assign(chart, parseResult.parsedChart.metadata)
+	if (parseResult.parsedChart) {
+		// Apply the merged metadata (ini overlays [Song], defaults fill gaps when ini is present).
+		// `chart_offset` is [Song]-only and `extraIniFields` is a round-trip
+		// preservation bag — neither belongs on the top-level ScannedChart
+		// surface, so strip them before assigning.
+		_.assign(chart, _.omit(parseResult.parsedChart.metadata, 'extraIniFields', 'chart_offset'))
+		chart.chart_offset = parseResult.parsedChart.metadata.chart_offset ?? 0
 	} else {
-		// No metadata available
 		chart.playable = false
 	}
-	chart.chart_offset = parseResult.parsedChart?.metadata?.delay ?? 0
 
 	const imageData = scanImage(files)
 	chart.folderIssues.push(...imageData.folderIssues)


### PR DESCRIPTION
## Context

While scoping out writing support downstream (chart-edit in spotify-clonehero-next), ran into an asymmetry in scan-chart's metadata surface that you confirmed is worth flattening:

- `ParsedChart.metadata` — 9 fields from the `[Song]` section inside `notes.chart`/`notes.mid`
- `ParseChartAndIniResult.iniMetadata` — 40 fields from `song.ini`
- `IniChartModifiers` — an 8-field subset of song.ini that `parseChartFile` consumes

Your guidance (paraphrased): *song.ini is authoritative, the `[Song]` values are a legacy overlap, writers should emit the "official" merged version back to both places*. This PR is the parse-side half of that — converging the two metadata sources onto a single normalized field on `ParsedChart`. Writers will land in a follow-up stack.

Submitting this as a standalone checkpoint so we can confirm the shape before I build on it.

## Changes

### 1. `ParsedChart.metadata` becomes the merged surface

Widened from a 9-field literal to:

```ts
metadata: Partial<typeof defaultMetadata> & {
  extraIniFields?: { [key: string]: string }
}
```

`parseChartFile` still populates only what the chart body carries (`[Song]` values for `.chart`, nothing for `.mid`) — those are a valid subset of the widened type.

`parseChartAndIni` now overlays `iniData.metadata` on top of `parsedChart.metadata` (ini wins) and moves `iniData.unknownIniValues` into `parsedChart.metadata.extraIniFields`.

### 2. `ParseChartAndIniResult` drops `iniMetadata` and `iniUnknownValues`

Same data is now reachable via `result.parsedChart.metadata`. `iniFolderIssues` and `iniMetadataIssues` stay — they're diagnostics, not duplicate data.

This is a breaking change to `ParseChartAndIniResult`'s shape. If you'd rather deprecate-then-remove instead of removing outright, happy to rework — just let me know.

### 3. `scanChart` reads the merged metadata

The diff-against-default checks in `scanChart` (missing/extra instrument difficulties) now read from `parseResult.parsedChart.metadata` and treat "set" as *present AND not equal to the default*.

**Incidental fix:** the previous code assigned ini metadata onto the scan result but then re-read `chart.chart_offset` from `parseResult.parsedChart?.metadata?.delay` — so `chart.delay` came from ini while `chart.chart_offset` came from `[Song]`. After consolidation both come from the merged metadata (ini wins), which is the behavior the rest of the code assumed. Flagging in case you want that preserved.

### 4. `defaultIniChartModifiers` becomes a projection of `defaultMetadata`

The 8 modifier defaults were duplicated as a literal alongside the 40-field `defaultMetadata`. Rewritten as a projection so the two can't drift.

## Validation

- 283 scan-chart tests pass
- Downstream typecheck (spotify-clonehero-next) passes — chart-edit consumes `scanIni` + `parseChartFile` directly, neither of which changed shape
- 848 downstream Jest tests pass
- 78K-chart same-format round-trip corpus validation in progress, will update if it surfaces anything

## Open questions

A few things worth calling out that aren't in this PR but are in the same design space — separate follow-ups, flagging here for visibility:

1. **Is `parseChartFile` intended as a peer public API, or an implementation detail?** `scanChartFolder` is already `@deprecated` pointing at `parseChartAndIni`. If `parseChartFile` is also intended as internal, `defaultIniChartModifiers` and `IniChartModifiers` could stop being public too — currently they exist only to help consumers of `parseChartFile` construct modifier objects, but `parseChartAndIni` handles that internally. No action needed here, just want to understand the direction.

2. **Should `parsedChart.metadata` be truly partial (only set fields) or fully populated (with defaults filled)?** This PR keeps "ini present → all 40 fields filled with defaults, ini absent → `[Song]`-only partial", matching previous `iniMetadata` semantics. If you'd prefer consistently-partial, I can filter ini values equal to their defaults before merging.