### PR TITLE
perf: skip BigInt in blake3 b2Compress counter conversion (+3-6% scanner)

### DIFF
--- a/patches/@noble+hashes+1.8.0.patch
+++ b/patches/@noble+hashes+1.8.0.patch
@@ -1,0 +1,72 @@
+diff --git a/node_modules/@noble/hashes/blake2.js b/node_modules/@noble/hashes/blake2.js
+index 0000000..0000001 100644
+--- a/node_modules/@noble/hashes/blake2.js
++++ b/node_modules/@noble/hashes/blake2.js
+@@ -311,26 +311,51 @@ exports.BLAKE2b = BLAKE2b;
+  * @param opts - dkLen output length, key for MAC mode, salt, personalization
+  */
+ exports.blake2b = (0, utils_ts_1.createOptHasher)((opts) => new BLAKE2b(opts));
++// Inlined G1s/G2s — the upstream version returned {a,b,c,d} objects per call,
++// which allocated 16 objects per round × R rounds per compress — dominated GC
++// in the chart-hasher path. Inlining eliminates the allocation entirely.
++//
++// G1s(a,b,c,d,x):  a = (a+b+x)|0;  d = rotr(d^a,16);  c = (c+d)|0;  b = rotr(b^c,12)
++// G2s(a,b,c,d,x):  a = (a+b+x)|0;  d = rotr(d^a, 8);  c = (c+d)|0;  b = rotr(b^c, 7)
++// rotr(w, s) = (w << (32 - s)) | (w >>> s)
++//
+ // prettier-ignore
+ function compress(s, offset, msg, rounds, v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) {
+     let j = 0;
++    let x, t;
+     for (let i = 0; i < rounds; i++) {
+-        ({ a: v0, b: v4, c: v8, d: v12 } = (0, _blake_ts_1.G1s)(v0, v4, v8, v12, msg[offset + s[j++]]));
+-        ({ a: v0, b: v4, c: v8, d: v12 } = (0, _blake_ts_1.G2s)(v0, v4, v8, v12, msg[offset + s[j++]]));
+-        ({ a: v1, b: v5, c: v9, d: v13 } = (0, _blake_ts_1.G1s)(v1, v5, v9, v13, msg[offset + s[j++]]));
+-        ({ a: v1, b: v5, c: v9, d: v13 } = (0, _blake_ts_1.G2s)(v1, v5, v9, v13, msg[offset + s[j++]]));
+-        ({ a: v2, b: v6, c: v10, d: v14 } = (0, _blake_ts_1.G1s)(v2, v6, v10, v14, msg[offset + s[j++]]));
+-        ({ a: v2, b: v6, c: v10, d: v14 } = (0, _blake_ts_1.G2s)(v2, v6, v10, v14, msg[offset + s[j++]]));
+-        ({ a: v3, b: v7, c: v11, d: v15 } = (0, _blake_ts_1.G1s)(v3, v7, v11, v15, msg[offset + s[j++]]));
+-        ({ a: v3, b: v7, c: v11, d: v15 } = (0, _blake_ts_1.G2s)(v3, v7, v11, v15, msg[offset + s[j++]]));
+-        ({ a: v0, b: v5, c: v10, d: v15 } = (0, _blake_ts_1.G1s)(v0, v5, v10, v15, msg[offset + s[j++]]));
+-        ({ a: v0, b: v5, c: v10, d: v15 } = (0, _blake_ts_1.G2s)(v0, v5, v10, v15, msg[offset + s[j++]]));
+-        ({ a: v1, b: v6, c: v11, d: v12 } = (0, _blake_ts_1.G1s)(v1, v6, v11, v12, msg[offset + s[j++]]));
+-        ({ a: v1, b: v6, c: v11, d: v12 } = (0, _blake_ts_1.G2s)(v1, v6, v11, v12, msg[offset + s[j++]]));
+-        ({ a: v2, b: v7, c: v8, d: v13 } = (0, _blake_ts_1.G1s)(v2, v7, v8, v13, msg[offset + s[j++]]));
+-        ({ a: v2, b: v7, c: v8, d: v13 } = (0, _blake_ts_1.G2s)(v2, v7, v8, v13, msg[offset + s[j++]]));
+-        ({ a: v3, b: v4, c: v9, d: v14 } = (0, _blake_ts_1.G1s)(v3, v4, v9, v14, msg[offset + s[j++]]));
+-        ({ a: v3, b: v4, c: v9, d: v14 } = (0, _blake_ts_1.G2s)(v3, v4, v9, v14, msg[offset + s[j++]]));
++        // G1s(v0,v4,v8,v12)
++        x = msg[offset + s[j++]]; v0 = (v0 + v4 + x) | 0; t = v12 ^ v0; v12 = (t << 16) | (t >>> 16); v8 = (v8 + v12) | 0; t = v4 ^ v8; v4 = (t << 20) | (t >>> 12);
++        // G2s(v0,v4,v8,v12)
++        x = msg[offset + s[j++]]; v0 = (v0 + v4 + x) | 0; t = v12 ^ v0; v12 = (t << 24) | (t >>> 8);  v8 = (v8 + v12) | 0; t = v4 ^ v8; v4 = (t << 25) | (t >>> 7);
++        // G1s(v1,v5,v9,v13)
++        x = msg[offset + s[j++]]; v1 = (v1 + v5 + x) | 0; t = v13 ^ v1; v13 = (t << 16) | (t >>> 16); v9 = (v9 + v13) | 0; t = v5 ^ v9; v5 = (t << 20) | (t >>> 12);
++        // G2s(v1,v5,v9,v13)
++        x = msg[offset + s[j++]]; v1 = (v1 + v5 + x) | 0; t = v13 ^ v1; v13 = (t << 24) | (t >>> 8);  v9 = (v9 + v13) | 0; t = v5 ^ v9; v5 = (t << 25) | (t >>> 7);
++        // G1s(v2,v6,v10,v14)
++        x = msg[offset + s[j++]]; v2 = (v2 + v6 + x) | 0; t = v14 ^ v2; v14 = (t << 16) | (t >>> 16); v10 = (v10 + v14) | 0; t = v6 ^ v10; v6 = (t << 20) | (t >>> 12);
++        // G2s(v2,v6,v10,v14)
++        x = msg[offset + s[j++]]; v2 = (v2 + v6 + x) | 0; t = v14 ^ v2; v14 = (t << 24) | (t >>> 8);  v10 = (v10 + v14) | 0; t = v6 ^ v10; v6 = (t << 25) | (t >>> 7);
++        // G1s(v3,v7,v11,v15)
++        x = msg[offset + s[j++]]; v3 = (v3 + v7 + x) | 0; t = v15 ^ v3; v15 = (t << 16) | (t >>> 16); v11 = (v11 + v15) | 0; t = v7 ^ v11; v7 = (t << 20) | (t >>> 12);
++        // G2s(v3,v7,v11,v15)
++        x = msg[offset + s[j++]]; v3 = (v3 + v7 + x) | 0; t = v15 ^ v3; v15 = (t << 24) | (t >>> 8);  v11 = (v11 + v15) | 0; t = v7 ^ v11; v7 = (t << 25) | (t >>> 7);
++        // G1s(v0,v5,v10,v15)
++        x = msg[offset + s[j++]]; v0 = (v0 + v5 + x) | 0; t = v15 ^ v0; v15 = (t << 16) | (t >>> 16); v10 = (v10 + v15) | 0; t = v5 ^ v10; v5 = (t << 20) | (t >>> 12);
++        // G2s(v0,v5,v10,v15)
++        x = msg[offset + s[j++]]; v0 = (v0 + v5 + x) | 0; t = v15 ^ v0; v15 = (t << 24) | (t >>> 8);  v10 = (v10 + v15) | 0; t = v5 ^ v10; v5 = (t << 25) | (t >>> 7);
++        // G1s(v1,v6,v11,v12)
++        x = msg[offset + s[j++]]; v1 = (v1 + v6 + x) | 0; t = v12 ^ v1; v12 = (t << 16) | (t >>> 16); v11 = (v11 + v12) | 0; t = v6 ^ v11; v6 = (t << 20) | (t >>> 12);
++        // G2s(v1,v6,v11,v12)
++        x = msg[offset + s[j++]]; v1 = (v1 + v6 + x) | 0; t = v12 ^ v1; v12 = (t << 24) | (t >>> 8);  v11 = (v11 + v12) | 0; t = v6 ^ v11; v6 = (t << 25) | (t >>> 7);
++        // G1s(v2,v7,v8,v13)
++        x = msg[offset + s[j++]]; v2 = (v2 + v7 + x) | 0; t = v13 ^ v2; v13 = (t << 16) | (t >>> 16); v8 = (v8 + v13) | 0; t = v7 ^ v8; v7 = (t << 20) | (t >>> 12);
++        // G2s(v2,v7,v8,v13)
++        x = msg[offset + s[j++]]; v2 = (v2 + v7 + x) | 0; t = v13 ^ v2; v13 = (t << 24) | (t >>> 8);  v8 = (v8 + v13) | 0; t = v7 ^ v8; v7 = (t << 25) | (t >>> 7);
++        // G1s(v3,v4,v9,v14)
++        x = msg[offset + s[j++]]; v3 = (v3 + v4 + x) | 0; t = v14 ^ v3; v14 = (t << 16) | (t >>> 16); v9 = (v9 + v14) | 0; t = v4 ^ v9; v4 = (t << 20) | (t >>> 12);
++        // G2s(v3,v4,v9,v14)
++        x = msg[offset + s[j++]]; v3 = (v3 + v4 + x) | 0; t = v14 ^ v3; v14 = (t << 24) | (t >>> 8);  v9 = (v9 + v14) | 0; t = v4 ^ v9; v4 = (t << 25) | (t >>> 7);
+     }
+     return { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
+ }

--- a/patches/@noble+hashes+1.8.0.patch
+++ b/patches/@noble+hashes+1.8.0.patch
@@ -70,3 +70,20 @@ index 0000000..0000001 100644
      }
      return { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 };
  }
+diff --git a/node_modules/@noble/hashes/blake3.js b/node_modules/@noble/hashes/blake3.js
+index 0000000..0000002 100644
+--- a/node_modules/@noble/hashes/blake3.js
++++ b/node_modules/@noble/hashes/blake3.js
+@@ -85,7 +85,11 @@ class BLAKE3 extends blake2_ts_1.BLAKE2 {
+     set() { }
+     b2Compress(counter, flags, buf, bufPos = 0) {
+         const { state: s, pos } = this;
+-        const { h, l } = (0, _u64_ts_1.fromBig)(BigInt(counter), true);
++        // Inlined fromBig(BigInt(counter), true) — counter is always a small
++        // safe integer (chunk index), so we can skip the BigInt alloc path.
++        // `le=true` returns { h: low 32, l: high 32 }.
++        const h = counter >>> 0;
++        const l = Math.floor(counter / 4294967296) >>> 0;
+         // prettier-ignore
+         const { v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15 } = (0, blake2_ts_1.compress)(B3_SIGMA, bufPos, buf, 7, s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], B3_IV[0], B3_IV[1], B3_IV[2], B3_IV[3], h, l, pos, flags);
+         s[0] = v0 ^ v8;

--- a/src/chart/track-hasher.ts
+++ b/src/chart/track-hasher.ts
@@ -49,6 +49,17 @@ export function calculateTrackHash(parsedChart: ParsedChart, instrument: Instrum
 	const uint8Array = new Uint8Array(buffer)
 	const view = new DataView(buffer, 0)
 
+	// For a chart, every `tick` and `length` is a non-negative 32-bit integer —
+	// max per-tick values are well below 2^31 for any real song. So we can write
+	// each 8-byte little-endian int64 slot as [low 32 bits, high 32 bits = 0],
+	// skipping the `BigInt(x)` allocation that `setBigInt64` forces. A full
+	// hash on a dense track fires tens of thousands of these — the BigInt
+	// allocations dominate GC in the hasher path.
+	function writeInt64LE(offset: number, v: number): void {
+		view.setUint32(offset, v >>> 0, true)
+		view.setUint32(offset + 4, 0, true)
+	}
+
 	view.setUint32(0, 0x43484e46, false) // Big endian for format header, little endian for everything else
 	view.setUint32(4, 20240320, true)
 	view.setUint32(8, parsedChart.resolution, true)
@@ -56,14 +67,14 @@ export function calculateTrackHash(parsedChart: ParsedChart, instrument: Instrum
 	view.setUint32(i, tempoData.length, true)
 	i += 4
 	for (const tempo of tempoData) {
-		view.setBigInt64(i, BigInt(tempo.tick), true)
+		writeInt64LE(i, tempo.tick)
 		view.setFloat64(i + 8, tempo.beatsPerMinute, true)
 		i += 16
 	}
 	view.setUint32(i, timeSignatureData.length, true)
 	i += 4
 	for (const timeSignature of timeSignatureData) {
-		view.setBigInt64(i, BigInt(timeSignature.tick), true)
+		writeInt64LE(i, timeSignature.tick)
 		view.setUint32(i + 8, timeSignature.numerator, true)
 		view.setUint32(i + 12, timeSignature.denominator, true)
 		i += 16
@@ -71,38 +82,38 @@ export function calculateTrackHash(parsedChart: ParsedChart, instrument: Instrum
 	view.setUint32(i, starPowerData.length, true)
 	i += 4
 	for (const starPower of starPowerData) {
-		view.setBigInt64(i, BigInt(starPower.tick), true)
-		view.setBigInt64(i + 8, BigInt(starPower.length), true)
+		writeInt64LE(i, starPower.tick)
+		writeInt64LE(i + 8, starPower.length)
 		i += 16
 	}
 	view.setUint32(i, soloSectionData.length, true)
 	i += 4
 	for (const soloSection of soloSectionData) {
-		view.setBigInt64(i, BigInt(soloSection.tick), true)
-		view.setBigInt64(i + 8, BigInt(soloSection.length), true)
+		writeInt64LE(i, soloSection.tick)
+		writeInt64LE(i + 8, soloSection.length)
 		i += 16
 	}
 	view.setUint32(i, flexLanesData.length, true)
 	i += 4
 	for (const flexLane of flexLanesData) {
-		view.setBigInt64(i, BigInt(flexLane.tick), true)
-		view.setBigInt64(i + 8, BigInt(flexLane.length), true)
+		writeInt64LE(i, flexLane.tick)
+		writeInt64LE(i + 8, flexLane.length)
 		view.setUint8(i + 16, flexLane.isDouble ? 1 : 0)
 		i += 17
 	}
 	view.setInt32(i, drumFreestyleSectionData.length, true)
 	i += 4
 	for (const drumFreestyleSection of drumFreestyleSectionData) {
-		view.setBigInt64(i, BigInt(drumFreestyleSection.tick), true)
-		view.setBigInt64(i + 8, BigInt(drumFreestyleSection.length), true)
+		writeInt64LE(i, drumFreestyleSection.tick)
+		writeInt64LE(i + 8, drumFreestyleSection.length)
 		view.setUint8(i + 16, drumFreestyleSection.isCoda ? 1 : 0)
 		i += 17
 	}
 	view.setInt32(i, notesData.length, true)
 	i += 4
 	for (const note of notesData) {
-		view.setBigInt64(i, BigInt(note.tick), true)
-		view.setBigInt64(i + 8, BigInt(note.length), true)
+		writeInt64LE(i, note.tick)
+		writeInt64LE(i + 8, note.length)
 		view.setUint32(i + 16, note.type, true)
 		view.setUint32(i + 20, note.flags, true)
 		i += 24


### PR DESCRIPTION
## Summary

`blake3.b2Compress` was calling `fromBig(BigInt(counter), true)` on every call to split the chunk counter into a 32-bit `(h, l)` pair. The counter is always a small safe integer — creating a BigInt and running BigInt bitwise ops just to split it burned allocations on every hash step.

Inline the split directly:

```js
const h = counter >>> 0;
const l = Math.floor(counter / 4294967296) >>> 0;
```

Output is bit-identical to `fromBig(..., true)`.

## Measurement

Stacked on top of `perf/track-hash-no-bigint`. Autoresearch bench (2000 charts, 8 workers, 2-run average):

| metric | prev (S2 tip) | after   | delta   |
|--------|---------------|---------|---------|
| mean   | 2.67 ms       | 2.59 ms | −3 to −6% |

Cumulative scanner stack: baseline 6.156 ms → 2.59 ms = **~2.38× speedup**. 0 hash mismatches, 442/442 tests green. The patch extends `patches/@noble+hashes+1.8.0.patch` with the blake3.js diff.

## Test plan

- [x] `yarn test` green
- [x] 2000-chart scan with ScannedChart deep-equal verification