### PR TITLE
perf: swap @noble/hashes/blake3 for @awasm/noble (WASM) — 3.18× faster scan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "8.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@noble/hashes": "^1.4.0",
+				"@awasm/noble": "^0.1.1",
 				"bottleneck": "^2.19.5",
 				"exifreader": "^4.23.2",
 				"fluent-ffmpeg": "^2.1.2",
@@ -317,6 +317,18 @@
 			"peer": true,
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@awasm/noble": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@awasm/noble/-/noble-0.1.1.tgz",
+			"integrity": "sha512-WTAFJq3ShNt/ABL++b1PgnmR8W4rgQ6O49FGI5vUNlFehatf0M4yloEEosqgnvYkZPNyRMz6wCPyRI2JMU3kmQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 22.22.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@babel/runtime": {
@@ -1571,18 +1583,6 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@noble/hashes": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	},
 	"homepage": "https://github.com/Geomitron/scan-chart#readme",
 	"dependencies": {
-		"@noble/hashes": "^1.4.0",
+		"@awasm/noble": "^0.1.1",
 		"bottleneck": "^2.19.5",
 		"exifreader": "^4.23.2",
 		"fluent-ffmpeg": "^2.1.2",

--- a/src/chart/chart-scanner.ts
+++ b/src/chart/chart-scanner.ts
@@ -1,4 +1,4 @@
-import { blake3 } from '@noble/hashes/blake3'
+import { blake3 } from '@awasm/noble'
 
 import { md5 } from 'js-md5'
 import * as _ from 'lodash'

--- a/src/chart/track-hasher.ts
+++ b/src/chart/track-hasher.ts
@@ -1,4 +1,4 @@
-import { blake3 } from '@noble/hashes/blake3'
+import { blake3 } from '@awasm/noble'
 
 import * as _ from 'lodash'
 import { base64url } from 'rfc4648'


### PR DESCRIPTION
## Summary

Swap `@noble/hashes/blake3` (JS) for `@awasm/noble@0.1.1` (WASM) — same blake3, same output bytes, ~3× faster end-to-end scan.

`blake3` is the only noble hash scan-chart uses (per-track hashes in `track-hasher.ts` + the chartHash in `chart-scanner.ts`), and in the scanner path hashing was the dominant cost.

## Numbers

End-to-end `scanChart()` time across 1800 real charts × 3 runs, 8 workers:

| variant | mean | p50 | p95 | p99 |
|---|---|---|---|---|
| `@noble/hashes@1.8.0` (stock) | 6.03 ms | 5.24 ms | 13.41 ms | 19.56 ms |
| `@awasm/noble@0.1.1` (this PR) | **1.90 ms** | **1.42 ms** | **5.23 ms** | **9.11 ms** |

**3.18× faster. 0 hash mismatches** across all 1800 charts × 3 runs — every per-track + chart hash byte-identical to the `@noble/hashes` output.

## Where the time was going

Single-threaded CPU profile breakdown:

| | total | hash | GC | hash+GC |
|---|---|---|---|---|
| stock noble | 42.2 s | 22.0 s (52%) | 10.3 s (24%) | **76.6%** |
| @awasm/noble | 16.8 s | 1.3 s (8%) | 5.3 s (31%) | 39.4% |

`blake2.compress` was 52% of scanner CPU, plus another 24% GC almost entirely driven by the `{a,b,c,d}` object allocations inside `G1s`/`G2s` (16 calls × 7 rounds per compress). The WASM path removes both.

## Why this package

[`@awasm/noble`](https://github.com/paulmillr/awasm-noble) is the WASM companion to `@noble/hashes` — same maintainer ([paulmillr](https://github.com/paulmillr)), same cryptographic implementation, byte-for-byte identical output. It's the recommended WASM acceleration path; see [noble-hashes#137](https://github.com/paulmillr/noble-hashes/pull/137) for context on the author's recommendation.

Note: `0.1.0` had a SIMD bug at 4 KiB-aligned input sizes that caused hash mismatches in the scanner bench ([paulmillr/awasm-noble#2](https://github.com/paulmillr/awasm-noble/pull/2), now fixed). `0.1.1` is clean — zero mismatches across the 1800-chart corpus confirms that.

## Changes

- `package.json`: `@noble/hashes` → `@awasm/noble@^0.1.1`
- `src/chart/track-hasher.ts`: one import line
- `src/chart/chart-scanner.ts`: one import line

No API changes. The `blake3(uint8Array)` signature is identical.

## Test plan

- [x] `npx vitest run` — 281/283 pass (2 pre-existing `lyric-parser.test.ts` Latin-1 failures unrelated to this change; verified by running same test on `master`)
- [x] autoresearch-scan bench — 1800 charts × 3 runs, 0 hash mismatches
- [x] dist builds clean (`npx tsup src/index.ts --format cjs,esm --dts`)