### PR TITLE
Add shared `File` type in interfaces.ts

### DIFF
--- a/src/__tests__/derived-flags.test.ts
+++ b/src/__tests__/derived-flags.test.ts
@@ -17,8 +17,9 @@ import { parseChartFile } from '../chart/notes-parser'
 import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
 import { scanChart } from '..'
 import { parseChartAndIni } from '../chart/parse-chart-and-ini'
+import { File } from '../interfaces'
 
-function buildChart(body: string): { fileName: string; data: Uint8Array }[] {
+function buildChart(body: string): File[] {
 	return [{ fileName: 'notes.chart', data: new TextEncoder().encode(body) }]
 }
 

--- a/src/__tests__/ini-scanner.test.ts
+++ b/src/__tests__/ini-scanner.test.ts
@@ -3,9 +3,10 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { File } from '../interfaces'
 import { scanIni } from '../ini/ini-scanner'
 
-function buildIni(lines: string[]): { fileName: string; data: Uint8Array }[] {
+function buildIni(lines: string[]): File[] {
 	const text = lines.join('\r\n')
 	return [{ fileName: 'song.ini', data: new TextEncoder().encode(text) }]
 }

--- a/src/audio/audio-scanner.ts
+++ b/src/audio/audio-scanner.ts
@@ -1,11 +1,11 @@
 import * as _ from 'lodash'
 
-import { FolderIssueType } from '../interfaces'
+import { File, FolderIssueType } from '../interfaces'
 import { getBasename, hasAudioExtension, hasAudioName } from '../utils'
 
 // TODO: use _max_threads
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function scanAudio(files: { fileName: string; data: Uint8Array }[]) {
+export function scanAudio(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 
 	const findAudioDataResult = findAudioData(files)
@@ -31,7 +31,7 @@ export function scanAudio(files: { fileName: string; data: Uint8Array }[]) {
 /**
  * @returns the audio file(s) in this chart, or `[]` if none were found.
  */
-function findAudioData(files: { fileName: string; data: Uint8Array }[]) {
+function findAudioData(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 	const audioData: Uint8Array[] = []
 	const stemNames: string[] = []

--- a/src/chart/parse-chart-and-ini.ts
+++ b/src/chart/parse-chart-and-ini.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash'
 
 import { scanIni } from '../ini'
-import { FolderIssueType, MetadataIssueType } from '../interfaces'
+import { File, FolderIssueType, MetadataIssueType } from '../interfaces'
 import { getExtension, hasChartExtension, hasChartName } from '../utils'
 import { defaultIniChartModifiers, IniChartModifiers } from './note-parsing-interfaces'
 import { parseChartFile } from './notes-parser'
@@ -63,7 +63,7 @@ export interface ParseChartAndIniResult {
  * `ParsedChart`, with no hashing or audio/image scanning. Pair with
  * `scanChart` if you need hashes, chart issues, or asset scanning.
  */
-export function parseChartAndIni(files: { fileName: string; data: Uint8Array }[]): ParseChartAndIniResult {
+export function parseChartAndIni(files: File[]): ParseChartAndIniResult {
 	const iniData = scanIni(files)
 	const iniChartModifiers: IniChartModifiers = iniData.metadata
 		? { ...defaultIniChartModifiers, ...iniData.metadata }
@@ -112,7 +112,7 @@ export function parseChartAndIni(files: { fileName: string; data: Uint8Array }[]
 	}
 }
 
-function findChartData(files: { fileName: string; data: Uint8Array }[]) {
+function findChartData(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 
 	const chartFiles = _.chain(files)

--- a/src/image/image-scanner.ts
+++ b/src/image/image-scanner.ts
@@ -1,9 +1,9 @@
 import { load } from 'exifreader'
 
-import { FolderIssueType } from '../interfaces'
+import { File, FolderIssueType } from '../interfaces'
 import { hasAlbumName } from '../utils'
 
-export function scanImage(files: { fileName: string; data: Uint8Array }[]) {
+export function scanImage(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 
 	const findAlbumDataResult = findAlbumData(files)
@@ -21,7 +21,7 @@ export function scanImage(files: { fileName: string; data: Uint8Array }[]) {
 /**
  * @returns the album art file data in this chart, or `null` if one wasn't found.
  */
-function findAlbumData(files: { fileName: string; data: Uint8Array }[]) {
+function findAlbumData(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 	let albumCount = 0
 	let lastAlbumData: Uint8Array | null = null

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { scanAudio } from './audio'
 import { parseChartAndIni, ParseChartAndIniResult, scanParsedChart } from './chart'
 import { scanImage } from './image'
 import { defaultMetadata } from './ini'
-import { Instrument, ScanChartFolderConfig, ScannedChart } from './interfaces'
+import { File, Instrument, ScanChartFolderConfig, ScannedChart } from './interfaces'
 import { RequireMatchingProps, Subset } from './utils'
 import { scanVideo } from './video'
 
@@ -21,7 +21,7 @@ export { calculateTrackHash } from './chart/track-hasher'
  * Validate, hash, and asset-scan a parsed chart folder. Pair with `parseChartAndIni()` to get the input.
  */
 export function scanChart(
-	files: { fileName: string; data: Uint8Array }[],
+	files: File[],
 	parseResult: ParseChartAndIniResult,
 	config?: ScanChartFolderConfig,
 ): ScannedChart {
@@ -141,11 +141,11 @@ export function scanChart(
  * @deprecated Call `parseChartAndIni()` + `scanChart()` directly. Preserved
  * as a back-compat shim for existing callers.
  */
-export function scanChartFolder(files: { fileName: string; data: Uint8Array }[], config?: ScanChartFolderConfig): ScannedChart {
+export function scanChartFolder(files: File[], config?: ScanChartFolderConfig): ScannedChart {
 	return scanChart(files, parseChartAndIni(files), config)
 }
 
-function getChartMD5(files: { fileName: string; data: Uint8Array }[]) {
+function getChartMD5(files: File[]) {
 	const hash = md5.create()
 	for (const file of _.orderBy(files, f => f.fileName)) {
 		hash.update(file.fileName)

--- a/src/ini/ini-scanner.ts
+++ b/src/ini/ini-scanner.ts
@@ -1,4 +1,4 @@
-import { FolderIssueType, MetadataIssueType } from '../interfaces'
+import { File, FolderIssueType, MetadataIssueType } from '../interfaces'
 import { hasIniExtension, hasIniName, removeStyleTags } from '../utils'
 import { parseIni } from './ini-parser'
 
@@ -87,7 +87,7 @@ const integerProperties: MetaNumberKey[] = [
 ]
 const requiredProperties: MetaStringKey[] = ['name', 'artist', 'album', 'genre', 'year', 'charter']
 
-export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
+export function scanIni(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 
 	const findIniDataResult = findIniData(files)
@@ -112,7 +112,7 @@ export function scanIni(files: { fileName: string; data: Uint8Array }[]) {
 /**
  * @returns the .ini file data in this chart, or `null` if one wasn't found.
  */
-function findIniData(files: { fileName: string; data: Uint8Array }[]): {
+function findIniData(files: File[]): {
 	iniData: Uint8Array | null
 	folderIssues: { folderIssue: FolderIssueType; description: string }[]
 } {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,15 @@
 import { ObjectValues } from './utils'
 
+/**
+ * A single file from a chart folder: the (case-preserved) file name and the
+ * raw bytes. Every scan-chart API that takes "a chart folder" takes a
+ * `File[]` of this shape.
+ */
+export interface File {
+	fileName: string
+	data: Uint8Array
+}
+
 export interface ScanChartFolderConfig {
 	/**
 	 * Set this to false to skip calculating `ScannedChart.md5`. It will be set to 'md5 calculation skipped' instead.

--- a/src/video/video-scanner.ts
+++ b/src/video/video-scanner.ts
@@ -1,7 +1,7 @@
-import { FolderIssueType } from '../interfaces'
+import { File, FolderIssueType } from '../interfaces'
 import { hasBadVideoName, hasVideoName } from '../utils'
 
-export function scanVideo(files: { fileName: string; data: Uint8Array }[]) {
+export function scanVideo(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 
 	const findVideoDataResult = findVideoData(files)
@@ -10,7 +10,7 @@ export function scanVideo(files: { fileName: string; data: Uint8Array }[]) {
 	return { hasVideoBackground: !!findVideoDataResult.videoData, folderIssues }
 }
 
-function findVideoData(files: { fileName: string; data: Uint8Array }[]) {
+function findVideoData(files: File[]) {
 	const folderIssues: { folderIssue: FolderIssueType; description: string }[] = []
 	let videoCount = 0
 	let bestVideoData: Uint8Array | null = null


### PR DESCRIPTION
## Summary

Extract the `{ fileName: string; data: Uint8Array }` shape that's inlined in every scan-chart folder-taking API into a named `File` type in `interfaces.ts`. No runtime change; purely a rename.

Callsites updated:
- `scanChart`, `scanChartFolder`, `getChartMD5` (`src/index.ts`)
- `parseChartAndIni`, `findChartData` (`src/chart/parse-chart-and-ini.ts`)
- `scanIni`, `findIniData` (`src/ini/ini-scanner.ts`)
- `scanAudio`, `findAudioData` (`src/audio/audio-scanner.ts`)
- `scanImage`, `findAlbumData` (`src/image/image-scanner.ts`)
- `scanVideo`, `findVideoData` (`src/video/video-scanner.ts`)
- Test helpers in `ini-scanner.test.ts` and `derived-flags.test.ts`

## Context

This lives at the bottom of the writer stack so that the downstream `ChartDocument` PR can replace its bespoke `ChartAsset` type with a reference to `File`. Addresses review feedback on #109 asking for a shared type before landing that PR.

## Test plan

- [x] `npx vitest run` — 586/586 pass (no semantic change)
- [x] Public API surface unchanged except for the new `File` export