### PR TITLE
Preserve unknown [Song] keys and [SyncTrack] events for .chart round-trip

### DIFF
--- a/src/__tests__/chart-round-trip-extras.test.ts
+++ b/src/__tests__/chart-round-trip-extras.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for round-trip preservation fields that catch `.chart` data which
+ * doesn't map to a typed ParsedChart field:
+ *
+ *   - `metadata.extraChartSongFields` — unknown `[Song]` keys (Moonscraper /
+ *     GHTCP deprecated fields, audio-stream filenames, `Player2`, `HoPo`,
+ *     `PreviewEnd`, `MediaType`, …)
+ *   - `unknownSyncTrackEvents` — `[SyncTrack]` lines that aren't tempo (`B`)
+ *     or time signature (`TS`); today this is primarily tempo anchors (`A`),
+ *     but the bucket is type-agnostic so future SyncTrack event types survive.
+ *
+ * `.mid` populates neither field — both are a `.chart`-only round-trip aid.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { writeMidi, MidiData } from '@geomitron/midi-file'
+import { parseNotesFromChart } from '../chart/chart-parser'
+import { parseNotesFromMidi } from '../chart/midi-parser'
+import { defaultIniChartModifiers } from '../chart/note-parsing-interfaces'
+
+function buildChart(sections: Record<string, string[]>): Uint8Array {
+	const lines: string[] = []
+	for (const [name, content] of Object.entries(sections)) {
+		lines.push(`[${name}]`)
+		lines.push('{')
+		for (const line of content) lines.push(`  ${line}`)
+		lines.push('}')
+	}
+	return new TextEncoder().encode(lines.join('\r\n'))
+}
+
+function tempoTrack(): MidiData['tracks'][number] {
+	return [
+		{ deltaTime: 0, type: 'trackName', text: '' },
+		{ deltaTime: 0, type: 'setTempo', microsecondsPerBeat: 500000 },
+		{ deltaTime: 0, type: 'timeSignature', numerator: 4, denominator: 4, metronome: 24, thirtyseconds: 8 },
+		{ deltaTime: 0, type: 'endOfTrack' },
+	]
+}
+
+function buildMidi(ticksPerBeat: number, tracks: MidiData['tracks']): Uint8Array {
+	return new Uint8Array(writeMidi({ header: { format: 1, numTracks: tracks.length, ticksPerBeat }, tracks }))
+}
+
+// ---------------------------------------------------------------------------
+// metadata.extraChartSongFields
+// ---------------------------------------------------------------------------
+
+describe('.chart [Song] unknown-key preservation (metadata.extraChartSongFields)', () => {
+	it('captures Moonscraper / GHTCP legacy fields verbatim', () => {
+		const chart = buildChart({
+			Song: [
+				'Resolution = 192',
+				'Name = "Test"',
+				'Artist = "Me"',
+				'Player2 = bass',
+				'PreviewEnd = 0',
+				'MediaType = "cd"',
+				'MusicStream = "song.ogg"',
+				'GuitarStream = "guitar.ogg"',
+				'HoPo = 0',
+			],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		// Known typed fields still populate.
+		expect(r.metadata.name).toBe('Test')
+		expect(r.metadata.artist).toBe('Me')
+		// Everything else lands in the preservation bag, values unchanged.
+		expect(r.metadata.extraChartSongFields).toEqual({
+			Player2: 'bass',
+			PreviewEnd: '0',
+			MediaType: 'cd',
+			MusicStream: 'song.ogg',
+			GuitarStream: 'guitar.ogg',
+			HoPo: '0',
+		})
+	})
+
+	it('is omitted when [Song] has no unknown keys', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192', 'Name = "Test"'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.metadata.extraChartSongFields).toBeUndefined()
+	})
+
+	it('preserves keys from authoring tools that scan-chart has never heard of', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192', 'Name = "Test"', 'FutureField = "future-value"', 'Boss = "1"'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.metadata.extraChartSongFields).toEqual({ FutureField: 'future-value', Boss: '1' })
+	})
+
+	it('does not consume claimed keys (Resolution / Name / Artist / etc.)', () => {
+		const chart = buildChart({
+			Song: [
+				'Resolution = 192',
+				'Name = "Test"',
+				'Artist = "A"',
+				'Album = "Al"',
+				'Genre = "G"',
+				'Year = ", 2020"',
+				'Charter = "C"',
+				'Difficulty = 3',
+				'Offset = 0',
+				'PreviewStart = 10',
+			],
+			SyncTrack: ['0 = B 120000', '0 = TS 4'],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.metadata.extraChartSongFields).toBeUndefined()
+	})
+
+	it('.mid does not populate extraChartSongFields (field is .chart-only)', () => {
+		const midi = buildMidi(480, [tempoTrack()])
+		const r = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(r.metadata.extraChartSongFields).toBeUndefined()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// unknownSyncTrackEvents
+// ---------------------------------------------------------------------------
+
+describe('.chart [SyncTrack] unknown-event preservation (unknownSyncTrackEvents)', () => {
+	it('preserves tempo anchors (A) verbatim', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192', 'Name = "T"'],
+			SyncTrack: [
+				'0 = B 120000',
+				'0 = A 0',
+				'0 = TS 4',
+				'3840 = A 8805460',
+				'3840 = B 122000',
+			],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.unknownSyncTrackEvents).toEqual([
+			{ tick: 0, text: 'A 0' },
+			{ tick: 3840, text: 'A 8805460' },
+		])
+		// Tempos and time sigs still populated normally.
+		expect(r.tempos.length).toBe(2)
+		expect(r.timeSignatures.length).toBe(1)
+	})
+
+	it('preserves future / unrecognized SyncTrack event types verbatim', () => {
+		// Forward-compat: an event type scan-chart doesn't know about today
+		// should still come out unchanged on write.
+		const chart = buildChart({
+			Song: ['Resolution = 192', 'Name = "T"'],
+			SyncTrack: [
+				'0 = B 120000',
+				'0 = TS 4',
+				'1920 = FUTURE 12 34 56',
+			],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.unknownSyncTrackEvents).toEqual([{ tick: 1920, text: 'FUTURE 12 34 56' }])
+	})
+
+	it('is empty when [SyncTrack] only has tempos and time signatures', () => {
+		const chart = buildChart({
+			Song: ['Resolution = 192', 'Name = "T"'],
+			SyncTrack: ['0 = B 120000', '0 = TS 4', '1920 = B 130000'],
+			Events: [],
+		})
+		const r = parseNotesFromChart(chart)
+		expect(r.unknownSyncTrackEvents).toEqual([])
+	})
+
+	it('.mid does not populate unknownSyncTrackEvents (field is .chart-only)', () => {
+		const midi = buildMidi(480, [tempoTrack()])
+		const r = parseNotesFromMidi(midi, defaultIniChartModifiers)
+		expect(r.unknownSyncTrackEvents).toEqual([])
+	})
+})

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -61,6 +61,19 @@ const trackNameMap = {
 const discoFlipDifficultyMap = ['easy', 'medium', 'hard', 'expert'] as const
 
 /**
+ * `[Song]` keys that a typed metadata field claims. Anything outside this set
+ * is preserved on `metadata.extraChartSongFields` so it round-trips verbatim
+ * (deprecated Moonscraper / GHTCP fields, audio stream filenames, `Player2`,
+ * `HoPo`, `PreviewEnd`, etc.). `Resolution` is not a metadata field but is
+ * claimed here because it's emitted separately from the chart's tick-rate.
+ */
+const CLAIMED_SONG_KEYS = new Set<string>([
+	'Resolution',
+	'Name', 'Artist', 'Album', 'Genre', 'Year', 'Charter',
+	'Difficulty', 'Offset', 'PreviewStart',
+])
+
+/**
  * Parses `buffer` as a chart in the .chart format. Returns all the note data in `RawChartData`, but any
  * chart format rules that apply to both .chart and .mid have not been applied. This is a partial result
  * that can be produced by both the .chart and .mid formats so that the remaining chart rules can be parsed
@@ -99,6 +112,15 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		throw 'Invalid .chart file: resolution not found.'
 	}
 
+	// Collect any [Song] keys not claimed by a typed metadata field into
+	// `extraChartSongFields` so they round-trip verbatim. Parallel to how
+	// `extraIniFields` preserves unknown song.ini keys.
+	const extraChartSongFields: { [key: string]: string } = {}
+	for (const [key, value] of Object.entries(metadata)) {
+		if (CLAIMED_SONG_KEYS.has(key)) continue
+		extraChartSongFields[key] = value
+	}
+
 	// Classify each line of the [Events] section into one of:
 	// sections, endEvents, codaEvents, or unrecognizedTextEvents (the remainder).
 	const eventsScan = scanEventsSection(fileSections['Events'] ?? [])
@@ -121,6 +143,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 			// it never collides with the ini-origin `delay` on merge.
 			chart_offset: Number(metadata['Offset']) ? Number(metadata['Offset']) * 1000 : undefined,
 			preview_start_time: Number(metadata['PreviewStart']) ? Number(metadata['PreviewStart']) * 1000 : undefined,
+			...(Object.keys(extraChartSongFields).length > 0 ? { extraChartSongFields } : {}),
 		},
 		vocalTracks: {
 			vocals: {
@@ -137,6 +160,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		},
 		tempos: parseChartTempos(fileSections['SyncTrack']),
 		timeSignatures: parseChartTimeSignatures(fileSections['SyncTrack']),
+		unknownSyncTrackEvents: parseChartUnknownSyncTrackEvents(fileSections['SyncTrack'] ?? []),
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEventsTrackTextEvents: eventsScan.unrecognizedTextEvents,
@@ -322,6 +346,7 @@ const chartLineNS = /^(\d+) = ([NS]) (\w+)( \d+)?$/
 const chartLineDiscoFlipE = /^\s*\[?mix[ _]([0-3])[ _]drums([0-5])(d|dnoflip|easy|easynokick|)\]?\s*$/
 const chartSyncTempo = /^(\d+) = B (\d+)$/
 const chartSyncTS = /^(\d+) = TS (\d+)(?: (\d+))?$/
+const chartSyncUnknown = /^(\d+) = (.+)$/
 const chartSongMetaRegex = /^(.+?) = "?(.*?)"?$/
 
 function parseChartTempos(lines: string[]): { tick: number; beatsPerMinute: number }[] {
@@ -367,6 +392,25 @@ function parseChartTimeSignatures(lines: string[]): { tick: number; numerator: n
 		result.unshift({ tick: 0, numerator: 4, denominator: 4 })
 	}
 	return result
+}
+
+/**
+ * Collect `[SyncTrack]` lines that aren't tempos (`B`) or time signatures
+ * (`TS`) into a raw-preserved bucket so they round-trip verbatim. Today this
+ * mostly catches tempo anchors (`A <microseconds>`); the bucket is
+ * intentionally type-agnostic so any future `[SyncTrack]` event type survives
+ * a parse → write loop without parser updates.
+ */
+function parseChartUnknownSyncTrackEvents(lines: string[]): { tick: number; text: string }[] {
+	const out: { tick: number; text: string }[] = []
+	for (const line of lines) {
+		if (chartSyncTempo.test(line)) continue
+		if (chartSyncTS.test(line)) continue
+		const m = chartSyncUnknown.exec(line)
+		if (!m) continue
+		out.push({ tick: Number(m[1]), text: m[2] })
+	}
+	return out
 }
 
 /**

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -207,6 +207,8 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		vocalTracks,
 		tempos: extractTempos(midiFile.tracks[0]),
 		timeSignatures: extractTimeSignatures(midiFile.tracks[0]),
+		unknownSyncTrackEvents: [], // .chart-only
+
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEventsTrackTextEvents: eventsScan.unrecognizedTextEvents,

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -56,6 +56,20 @@ export interface RawChartData {
 		/** Unknown song.ini key/value pairs, preserved for round-trip writing. */
 		extraIniFields?: { [key: string]: string }
 		/**
+		 * Unknown `[Song]`-section key/value pairs from a `.chart` file,
+		 * preserved verbatim for round-trip writing. Counterpart to
+		 * `extraIniFields` for the chart file's metadata block. Covers
+		 * deprecated/legacy fields that games don't read but chart editors
+		 * like Moonscraper expect to see round-tripped — `Player2`, `HoPo`,
+		 * `PreviewEnd`, `MediaType`, `ArtistText`, audio-stream filenames
+		 * (`MusicStream`, `GuitarStream`, …), etc. Consumers should not
+		 * treat these as authoritative (e.g. audio filenames here should be
+		 * ignored in favor of folder scans), and writers should not
+		 * synthesize or update these values — only persist what the source
+		 * carried. `.mid` files do not populate this field.
+		 */
+		extraChartSongFields?: { [key: string]: string }
+		/**
 		 * `[Song].Offset` from the .chart file body, in milliseconds. Distinct
 		 * from the ini-origin `delay` field — games recognize `Offset` only in
 		 * [Song], and `delay` only in song.ini. Kept as a separate key so the
@@ -82,6 +96,20 @@ export interface RawChartData {
 		tick: number
 		numerator: number
 		denominator: number
+	}[]
+	/**
+	 * `[SyncTrack]` lines from a `.chart` file that are neither tempo (`B`)
+	 * nor time signature (`TS`). Preserved verbatim for round-trip so tempo
+	 * anchors (`A <microseconds>`) and any future SyncTrack event types
+	 * survive parse → write. `text` is the line content after `TICK = ` —
+	 * e.g. `"A 0"` for an anchor at time-position 0. Anchors are editor-time
+	 * audio-sync metadata and are not competitively relevant, but Moonscraper
+	 * and other editors make use of them. `.mid` files do not populate this
+	 * field.
+	 */
+	unknownSyncTrackEvents: {
+		tick: number
+		text: string
 	}[]
 	sections: {
 		tick: number

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -94,6 +94,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		unrecognizedChartSections: rawChartData.unrecognizedChartSections,
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
+		unknownSyncTrackEvents: rawChartData.unknownSyncTrackEvents,
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
 		trackData: trackDataResult,
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,10 +103,11 @@ export function scanChart(
 
 	if (parseResult.parsedChart) {
 		// Apply the merged metadata (ini overlays [Song], defaults fill gaps when ini is present).
-		// `chart_offset` is [Song]-only and `extraIniFields` is a round-trip
-		// preservation bag — neither belongs on the top-level ScannedChart
-		// surface, so strip them before assigning.
-		_.assign(chart, _.omit(parseResult.parsedChart.metadata, 'extraIniFields', 'chart_offset'))
+		// `chart_offset` is [Song]-only. `extraIniFields` and
+		// `extraChartSongFields` are round-trip preservation bags — none of the
+		// three belong on the top-level ScannedChart surface, so strip them
+		// before assigning.
+		_.assign(chart, _.omit(parseResult.parsedChart.metadata, 'extraIniFields', 'extraChartSongFields', 'chart_offset'))
 		chart.chart_offset = parseResult.parsedChart.metadata.chart_offset ?? 0
 	} else {
 		chart.playable = false


### PR DESCRIPTION
## Summary

Two new `.chart`-only round-trip buckets on `ParsedChart`, both empty for `.mid`:

- **`metadata.extraChartSongFields: { [key: string]: string }`** — catches every `[Song]` key outside the typed-metadata set (Name/Artist/Album/Genre/Year/Charter/Difficulty/Resolution/Offset/PreviewStart). Parallel to the existing `metadata.extraIniFields` for unknown `song.ini` keys. Covers Moonscraper / GHTCP legacy fields like `Player2`, `HoPo`, `PreviewEnd`, `MediaType`, `ArtistText`, audio-stream filenames (`MusicStream`, `GuitarStream`, `DrumStream`, …), etc.

- **`unrecognizedSyncTrackEvents: { tick: number; text: string }[]`** — `[SyncTrack]` lines that are neither tempo (`B`) nor time signature (`TS`). Today this primarily captures tempo anchors (`A <microseconds>`), but the bucket is type-agnostic so any future `[SyncTrack]` event type survives parse → write without a parser change. `text` is the line content after \`TICK = \`, e.g. `"A 0"`. Naming follows the existing `unrecognized*` convention (`unrecognizedEventsTrackTextEvents`, `unrecognizedMidiTracks`, `unrecognizedChartSections`, etc.).

## Why

I ran a coverage audit across **62 697 real `.chart` charts** (Enchor mirror + extended corpus) and classified every non-empty line as consumed / raw-preserved / structural / dropped. The findings were:

- **Tempo anchors `A` in `[SyncTrack]`** — 49 541 lines across 2 076 charts (3.3%); 1 959 charts (3.1%) have non-trivial anchors. Parser docstring already called this out as \"ignored for now.\"
- **\`[Song]\` legacy metadata** — `Player2` (~100% of corpus), `PreviewEnd` (62k), `MediaType` (62k), audio streams (~68k occurrences across 11 field names), `HoPo` / `ArtistText` / etc. (171 charts).
- **Everything else** in the audit was either author-error (malformed lines, unknown N/S codes in instrument tracks), or already captured by existing `unrecognizedChartSections` / `unrecognizedEvents` / `textEvents` / `versusPhrases` buckets.

On the project Discord, @Geomitron confirmed the direction: preserve tempo anchors via a generic catch-all bucket that also catches future `[SyncTrack]` additions, and round-trip unknown `[Song]` keys the same way `extraIniFields` round-trips unknown ini keys. Audio-stream filenames are persisted verbatim as part of the `[Song]` bag — consumers should discover audio via folder scan and writers should never synthesize or update these values, they're strictly a Moonscraper-compat round-trip aid.

## Test plan

- [x] 9 new tests in `src/__tests__/chart-round-trip-extras.test.ts` cover: typed fields still populate, unknown `[Song]` keys land in the bag, bag omitted when no unknowns, forward-compat for unrecognized `[SyncTrack]` event types, empty fields on `.mid`.
- [x] All 305 tests pass (296 existing + 9 new).
- [x] No new \`tsc --noEmit\` errors introduced (identical error count on upstream/master vs. this branch).

## Notes

- `src/index.ts` strips `extraChartSongFields` when projecting merged metadata onto the legacy `ScannedChart` surface, matching the existing treatment of `extraIniFields` / `chart_offset`.
- No writer changes here — writer support is coming in the existing writeChartFile PRs already in flight; when those land, they'll emit both new fields when present.