### PR TITLE
Rename unknownSyncTrackEvents → unrecognizedSyncTrackEvents

### DIFF
--- a/src/__tests__/chart-round-trip-extras.test.ts
+++ b/src/__tests__/chart-round-trip-extras.test.ts
@@ -5,7 +5,7 @@
  *   - `metadata.extraChartSongFields` — unknown `[Song]` keys (Moonscraper /
  *     GHTCP deprecated fields, audio-stream filenames, `Player2`, `HoPo`,
  *     `PreviewEnd`, `MediaType`, …)
- *   - `unknownSyncTrackEvents` — `[SyncTrack]` lines that aren't tempo (`B`)
+ *   - `unrecognizedSyncTrackEvents` — `[SyncTrack]` lines that aren't tempo (`B`)
  *     or time signature (`TS`); today this is primarily tempo anchors (`A`),
  *     but the bucket is type-agnostic so future SyncTrack event types survive.
  *
@@ -127,10 +127,10 @@ describe('.chart [Song] unknown-key preservation (metadata.extraChartSongFields)
 })
 
 // ---------------------------------------------------------------------------
-// unknownSyncTrackEvents
+// unrecognizedSyncTrackEvents
 // ---------------------------------------------------------------------------
 
-describe('.chart [SyncTrack] unknown-event preservation (unknownSyncTrackEvents)', () => {
+describe('.chart [SyncTrack] unknown-event preservation (unrecognizedSyncTrackEvents)', () => {
 	it('preserves tempo anchors (A) verbatim', () => {
 		const chart = buildChart({
 			Song: ['Resolution = 192', 'Name = "T"'],
@@ -144,7 +144,7 @@ describe('.chart [SyncTrack] unknown-event preservation (unknownSyncTrackEvents)
 			Events: [],
 		})
 		const r = parseNotesFromChart(chart)
-		expect(r.unknownSyncTrackEvents).toEqual([
+		expect(r.unrecognizedSyncTrackEvents).toEqual([
 			{ tick: 0, text: 'A 0' },
 			{ tick: 3840, text: 'A 8805460' },
 		])
@@ -166,7 +166,7 @@ describe('.chart [SyncTrack] unknown-event preservation (unknownSyncTrackEvents)
 			Events: [],
 		})
 		const r = parseNotesFromChart(chart)
-		expect(r.unknownSyncTrackEvents).toEqual([{ tick: 1920, text: 'FUTURE 12 34 56' }])
+		expect(r.unrecognizedSyncTrackEvents).toEqual([{ tick: 1920, text: 'FUTURE 12 34 56' }])
 	})
 
 	it('is empty when [SyncTrack] only has tempos and time signatures', () => {
@@ -176,12 +176,12 @@ describe('.chart [SyncTrack] unknown-event preservation (unknownSyncTrackEvents)
 			Events: [],
 		})
 		const r = parseNotesFromChart(chart)
-		expect(r.unknownSyncTrackEvents).toEqual([])
+		expect(r.unrecognizedSyncTrackEvents).toEqual([])
 	})
 
-	it('.mid does not populate unknownSyncTrackEvents (field is .chart-only)', () => {
+	it('.mid does not populate unrecognizedSyncTrackEvents (field is .chart-only)', () => {
 		const midi = buildMidi(480, [tempoTrack()])
 		const r = parseNotesFromMidi(midi, defaultIniChartModifiers)
-		expect(r.unknownSyncTrackEvents).toEqual([])
+		expect(r.unrecognizedSyncTrackEvents).toEqual([])
 	})
 })

--- a/src/chart/chart-parser.ts
+++ b/src/chart/chart-parser.ts
@@ -160,7 +160,7 @@ export function parseNotesFromChart(data: Uint8Array): RawChartData {
 		},
 		tempos: parseChartTempos(fileSections['SyncTrack']),
 		timeSignatures: parseChartTimeSignatures(fileSections['SyncTrack']),
-		unknownSyncTrackEvents: parseChartUnknownSyncTrackEvents(fileSections['SyncTrack'] ?? []),
+		unrecognizedSyncTrackEvents: parseChartUnrecognizedSyncTrackEvents(fileSections['SyncTrack'] ?? []),
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,
 		unrecognizedEventsTrackTextEvents: eventsScan.unrecognizedTextEvents,
@@ -401,7 +401,7 @@ function parseChartTimeSignatures(lines: string[]): { tick: number; numerator: n
  * intentionally type-agnostic so any future `[SyncTrack]` event type survives
  * a parse → write loop without parser updates.
  */
-function parseChartUnknownSyncTrackEvents(lines: string[]): { tick: number; text: string }[] {
+function parseChartUnrecognizedSyncTrackEvents(lines: string[]): { tick: number; text: string }[] {
 	const out: { tick: number; text: string }[] = []
 	for (const line of lines) {
 		if (chartSyncTempo.test(line)) continue

--- a/src/chart/midi-parser.ts
+++ b/src/chart/midi-parser.ts
@@ -207,7 +207,7 @@ export function parseNotesFromMidi(data: Uint8Array, iniChartModifiers: IniChart
 		vocalTracks,
 		tempos: extractTempos(midiFile.tracks[0]),
 		timeSignatures: extractTimeSignatures(midiFile.tracks[0]),
-		unknownSyncTrackEvents: [], // .chart-only
+		unrecognizedSyncTrackEvents: [], // .chart-only
 
 		sections: eventsScan.sections,
 		endEvents: eventsScan.endEvents,

--- a/src/chart/note-parsing-interfaces.ts
+++ b/src/chart/note-parsing-interfaces.ts
@@ -107,7 +107,7 @@ export interface RawChartData {
 	 * and other editors make use of them. `.mid` files do not populate this
 	 * field.
 	 */
-	unknownSyncTrackEvents: {
+	unrecognizedSyncTrackEvents: {
 		tick: number
 		text: string
 	}[]

--- a/src/chart/notes-parser.ts
+++ b/src/chart/notes-parser.ts
@@ -94,7 +94,7 @@ export function parseChartFile(data: Uint8Array, format: 'chart' | 'mid', partia
 		unrecognizedChartSections: rawChartData.unrecognizedChartSections,
 		tempos: timedTempos,
 		timeSignatures: setEventMsTimes(rawChartData.timeSignatures, timedTempos, rawChartData.chartTicksPerBeat),
-		unknownSyncTrackEvents: rawChartData.unknownSyncTrackEvents,
+		unrecognizedSyncTrackEvents: rawChartData.unrecognizedSyncTrackEvents,
 		sections: setEventMsTimes(rawChartData.sections, timedTempos, rawChartData.chartTicksPerBeat),
 		trackData: trackDataResult,
 	}


### PR DESCRIPTION
Follow-up to #120. The rest of the parser uses the \`unrecognized*\` prefix for round-trip preservation buckets:

- \`unrecognizedEventsTrackTextEvents\`
- \`unrecognizedEventsTrackMidiEvents\`
- \`unrecognizedMidiTracks\`
- \`unrecognizedChartSections\`
- \`unrecognizedEvents\` (the older `.chart` [Events] bag)

The new `[SyncTrack]` catch-all slipped in under the \`unknown*\` prefix — renaming for consistency. Pure rename, no behavior change.

### Test plan

- [x] All 305 tests pass.
- [x] `grep -rn "unknownSyncTrack" src/` → no hits.